### PR TITLE
Migrate non-code scaffolding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+go:
+  - 1.6
+  - tip
+cache:
+  directories:
+    - vendor
+install:
+  - make dependencies
+script:
+  - make coveralls
+  - make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: go
 go:
+  - 1.5
   - 1.6
   - tip
+env:
+  global:
+    - GO15VENDOREXPERIMENT=1
 cache:
   directories:
     - vendor

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2016 Uber Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,3 @@
-# Copyright (c) 2016 Uber Technologies, Inc.
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
 
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 PACKAGES ?= $(shell glide novendor)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+# Copyright (c) 2016 Uber Technologies, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
+PACKAGES ?= $(shell glide novendor)
+
+.PHONY: all
+all: lint test
+
+.PHONY: dependencies
+dependencies:
+	glide --version || go get -u -f github.com/Masterminds/glide
+	glide install
+	go install ./vendor/github.com/golang/lint/golint
+	go install ./vendor/github.com/axw/gocov/gocov
+	go install ./vendor/github.com/mattn/goveralls
+
+.PHONY: lint
+lint:
+	rm -rf lint.log
+	@echo "Checking formatting..."
+	gofmt -d -s *.go benchmarks 2>&1 | tee lint.log
+	@echo "Checking vet..."
+	go tool vet *.go 2>&1 | tee -a lint.log
+	go tool vet benchmarks 2>&1 | tee -a lint.log
+	@echo "Checking lint..."
+	golint . 2>&1 | tee -a lint.log
+	golint benchmarks 2>&1 | tee -a lint.log
+	@[ ! -s lint.log ]
+
+.PHONY: test
+test:
+	go test -race $(PACKAGES)
+
+.PHONY: coveralls
+coveralls:
+	goveralls -service=travis-ci $(PACKAGES)
+
+.PHONY: bench
+BENCH ?= .
+bench:
+	go test -bench=$(BENCH) $(BENCH_FLAGS) ./benchmarks

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+export GO15VENDOREXPERIMENT=1
 
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 PACKAGES ?= $(shell glide novendor)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# :zap: zap [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+
+Fast, structured, leveled logging in Go.
+
+## Structure
+
+Zap takes an opinionated stance on logging and doesn't provide any
+`printf`-style helpers. Rather than `logger.Printf("Error %v writing logs to
+%v, lost %v messages.", err, f, m)`, flog encourages the more structured
+
+```
+Logger.
+  WithError(err).
+  With("msgCount", m).
+  With("fileName", f).
+  Info("Error writing logs.")
+```
+
+This a bit more verbose, but it enables powerful ad-hoc analysis, flexible
+dashboarding, and accurate message bucketing. In short, it helps you get the
+most out of tools like ELK, Splunk, and Sentry. All log messages are
+JSON-serialized.
+
+## Performance
+
+For applications that log in the hot path, reflection-based serialization and
+string formatting are prohibitively expensive &mdash; they're CPU-intensive and
+make many small allocations. Put differently, using `encoding/json` to log tons
+of `interface{}`s makes your application slow.
+
+Zap's API offers a variety of type-safe ways to annotate a logger's context
+without incurring tons of overhead. It also offers a suite of conditional
+annotations, so collecting rich debugging context doesn't impact normal
+operations.
+
+As measured by its own benchmarking suite, not only is zap more performant
+than comparable structured logging libraries &mdash; it's also faster than the
+standard library. Like all benchmarks, take these with a grain of salt.
+
+Add 5 fields to the logging context, one at a time:
+
+| Library | Time | Bytes Allocated | Objects Allocated |
+| :--- | :---: | :---: | ---: |
+| zap | 3340 ns/op | 5713 B/op | 16 allocs/op |
+| logrus | 66776 ns/op | 52646 B/op | 254 allocs/op |
+
+Add 5 fields to the logging context as a single map:
+
+| Library | Time | Bytes Allocated | Objects Allocated |
+| :--- | :---: | :---: | ---: |
+| zap | 1615 ns/op | 1504 B/op | 6 allocs/op |
+| logrus | 36592 ns/op | 21409 B/op | 209 allocs/op |
+
+Log static strings, without any context or `printf`-style formatting:
+
+| Library | Time | Bytes Allocated | Objects Allocated |
+| :--- | :---: | :---: | ---: |
+| zap | 328 ns/op | 32 B/op | 1 allocs/op |
+| standard library | 840 ns/op | 592 B/op | 2 allocs/op |
+
+## Development Status: Alpha
+
+Breaking changes are certain.
+
+<hr>
+Released under the [MIT License](LICENSE.txt).
+
+[doc-img]: https://godoc.org/github.com/uber-common/zap?status.svg
+[doc]: https://godoc.org/github.com/uber-common/zap
+[ci-img]: https://travis-ci.org/uber-common/zap.svg?branch=master
+[ci]: https://travis-ci.org/uber-common/zap
+[cov-img]: https://coveralls.io/repos/github/uber-common/zap/badge.svg?branch=master
+[cov]: https://coveralls.io/github/uber-common/zap?branch=master

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,51 @@
+hash: 62c3a1f1604ecfb5c9b447b5c4f7c91a44e8cde18155f2b25925b662cd3c27b4
+updated: 2016-02-15T16:07:45.743891128-08:00
+imports:
+- name: github.com/axw/gocov
+  version: ac431cdb392ef21dc2aa61f4f4470ada6b70fced
+  subpackages:
+  - gocov
+- name: github.com/davecgh/go-spew
+  version: 2df174808ee097f90d259e432cc04442cf60be21
+  subpackages:
+  - spew
+- name: github.com/go-kit/kit
+  version: 724fee9497e9788bf00911ea5b2f4cfaf726bf3f
+  subpackages:
+  - log
+- name: github.com/golang/glog
+  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+- name: github.com/golang/lint
+  version: 32a87160691b3c96046c0c678fe57c5bef761456
+  subpackages:
+  - golint
+- name: github.com/mattn/goveralls
+  version: 025ace5d02b8e6df403c2d63fec4f7f86f7cc619
+- name: github.com/pborman/uuid
+  version: cd53251766d76cf1969596428dc09c7b97956eeb
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/Sirupsen/logrus
+  version: 3455d89ac9652295c85db2a98ea32f1d61c380bc
+- name: github.com/stretchr/objx
+  version: cbeaeb16a013161a98496fad62933b1d21786672
+- name: github.com/stretchr/testify
+  version: 9f9027faeb0dad515336ed2f28317f9f8f527ab4
+  subpackages:
+  - assert
+  - require
+  - http
+  - mock
+- name: golang.org/x/tools
+  version: cadb821a95df0e7ef6343c3d16d13d53e8f9a9d6
+  subpackages:
+  - go/gcimporter
+  - go/types
+  - go/exact
+- name: gopkg.in/logfmt.v0
+  version: c50dc9aa845e681529d8e49d3dc11ec0195aacac
+- name: gopkg.in/stack.v1
+  version: 0585967eab0016c8e4e2d55ac20585b469574cec
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,20 @@
+package: github.com/akshayjshah/flog
+import:
+- package: github.com/stretchr/testify
+  subpackages:
+  - assert
+  - require
+- package: github.com/golang/lint
+  subpackages:
+  - golint
+- package: github.com/mattn/goveralls
+- package: github.com/Sirupsen/logrus
+- package: github.com/axw/gocov
+  subpackages:
+  - gocov
+- package: github.com/golang/glog
+- package: github.com/go-kit/kit
+  subpackages:
+  - log
+- package: gopkg.in/logfmt.v0
+- package: gopkg.in/stack.v1


### PR DESCRIPTION
Migrate everything except the actual logging code: readme, license, Travis config, Glide manifests, Makefile, etc.

/cc @prashantv @jwolski 
