### PR TITLE
Update Makefile to lint selectively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export GO15VENDOREXPERIMENT=1
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 PKGS ?= $(shell glide novendor)
 # Many Go tools take file globs or directories as arguments instead of packages.
-PKG_DIRS ?= *.go
+PKG_FILES ?= *.go
 
 # The linting tools evolve with each Go version, so run them only on the latest
 # stable release.
@@ -37,11 +37,11 @@ endif
 lint:
 	@rm -rf lint.log
 	@echo "Checking formatting..."
-	@gofmt -d -s $(PKG_DIRS) 2>&1 | tee lint.log
+	@gofmt -d -s $(PKG_FILES) 2>&1 | tee lint.log
 	@echo "Checking vet..."
-	@$(foreach dir,$(PKG_DIRS),go tool vet $(dir) 2>&1 | tee -a lint.log;)
+	@$(foreach dir,$(PKG_FILES),go tool vet $(dir) 2>&1 | tee -a lint.log;)
 	@echo "Checking lint..."
-	@$(foreach dir,$(PKG_DIRS),golint $(dir) 2>&1 | tee -a lint.log;)
+	@$(foreach dir,$(PKG_FILES),golint $(dir) 2>&1 | tee -a lint.log;)
 	@echo "Checking for unresolved FIXMEs..."
 	@git grep -i fixme | grep -v -e vendor -e Makefile | tee -a lint.log
 	@[ ! -s lint.log ]


### PR DESCRIPTION
Update the Makefile to
- Lint only on the latest stable Go, since the fmt/lint/vet rules change over time, and
- Assume only a single package.

This is a precursor to a larger refactoring and complete POC.
