### PR TITLE
Make benchmarks more realistic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,4 @@ coveralls:
 .PHONY: bench
 BENCH ?= .
 bench:
-	go test -bench=$(BENCH) $(BENCH_FLAGS) .
+	go test -bench=$(BENCH) -run="^$$" $(BENCH_FLAGS) .


### PR DESCRIPTION
Structure the benchmarks so that all allocations happen inside the
benchmark.

Cherry-picked @akshayjshah's commit from #10.
