### PR TITLE
Handle NaN and +/- Inf

### DIFF
--- a/json_encoder.go
+++ b/json_encoder.go
@@ -105,19 +105,16 @@ func (enc *jsonEncoder) AddInt64(key string, val int64) {
 // grade-school notation otherwise).
 func (enc *jsonEncoder) AddFloat64(key string, val float64) {
 	enc.addKey(key)
-	if math.IsNaN(val) {
+	switch {
+	case math.IsNaN(val):
 		enc.bytes = append(enc.bytes, `"NaN"`...)
-		return
-	}
-	if math.IsInf(val, 1) {
+	case math.IsInf(val, 1):
 		enc.bytes = append(enc.bytes, `"+Inf"`...)
-		return
-	}
-	if math.IsInf(val, -1) {
+	case math.IsInf(val, -1):
 		enc.bytes = append(enc.bytes, `"-Inf"`...)
-		return
+	default:
+		enc.bytes = strconv.AppendFloat(enc.bytes, val, 'g', -1, 64)
 	}
-	enc.bytes = strconv.AppendFloat(enc.bytes, val, 'g', -1, 64)
 }
 
 // Nest allows the caller to populate a nested object under the provided key.

--- a/json_encoder.go
+++ b/json_encoder.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 	"sync"
 	"time"
@@ -104,6 +105,18 @@ func (enc *jsonEncoder) AddInt64(key string, val int64) {
 // grade-school notation otherwise).
 func (enc *jsonEncoder) AddFloat64(key string, val float64) {
 	enc.addKey(key)
+	if math.IsNaN(val) {
+		enc.bytes = append(enc.bytes, `"NaN"`...)
+		return
+	}
+	if math.IsInf(val, 1) {
+		enc.bytes = append(enc.bytes, `"+Inf"`...)
+		return
+	}
+	if math.IsInf(val, -1) {
+		enc.bytes = append(enc.bytes, `"-Inf"`...)
+		return
+	}
 	enc.bytes = strconv.AppendFloat(enc.bytes, val, 'g', -1, 64)
 }
 

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -23,6 +23,7 @@ package zap
 import (
 	"bytes"
 	"io"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -101,6 +102,19 @@ func TestJSONAddFloat64(t *testing.T) {
 		enc.truncate()
 		enc.AddFloat64(`foo\`, 1.0)
 		assertJSON(t, `"foo\\":1`, enc)
+
+		// Test floats that can't be represented in JSON.
+		enc.truncate()
+		enc.AddFloat64(`foo`, math.NaN())
+		assertJSON(t, `"foo":"NaN"`, enc)
+
+		enc.truncate()
+		enc.AddFloat64(`foo`, math.Inf(1))
+		assertJSON(t, `"foo":"+Inf"`, enc)
+
+		enc.truncate()
+		enc.AddFloat64(`foo`, math.Inf(-1))
+		assertJSON(t, `"foo":"-Inf"`, enc)
 	})
 }
 


### PR DESCRIPTION
The type system won't protect us from this, so we should handle these cases explicitly.
