### PR TITLE
Reduce allocations for disabled/sampled logs

### DIFF
--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -110,7 +110,7 @@ func BenchmarkZapDisabledLevelsCheckAddingFields(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			if m := logger.Check(zap.Info, "Should be discarded."); m != nil {
+			if m := logger.Check(zap.Info, "Should be discarded."); m.OK() {
 				m.Write(fakeFields()...)
 			}
 		}
@@ -185,7 +185,7 @@ func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
 		i := 0
 		for pb.Next() {
 			i++
-			if cm := logger.Check(zap.Info, messages[i%1000]); cm != nil {
+			if cm := logger.Check(zap.Info, messages[i%1000]); cm.OK() {
 				cm.Write()
 			}
 		}
@@ -201,7 +201,7 @@ func BenchmarkZapSampleCheckAddingFields(b *testing.B) {
 		i := 0
 		for pb.Next() {
 			i++
-			if m := logger.Check(zap.Info, messages[i%1000]); m != nil {
+			if m := logger.Check(zap.Info, messages[i%1000]); m.OK() {
 				m.Write(fakeFields()...)
 			}
 		}

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -66,6 +66,14 @@ func fakeFields() []zap.Field {
 	}
 }
 
+func fakeMessages(n int) []string {
+	messages := make([]string, n)
+	for i := range messages {
+		messages[i] = fmt.Sprintf("Test logging, but use a somewhat realistic message length. (#%v)", i)
+	}
+	return messages
+}
+
 func BenchmarkZapDisabledLevelsWithoutFields(b *testing.B) {
 	logger := zap.NewJSON(zap.Error, zap.Output(zap.Discard))
 	b.ResetTimer()
@@ -96,6 +104,19 @@ func BenchmarkZapDisabledLevelsAddingFields(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkZapDisabledLevelsCheckAddingFields(b *testing.B) {
+	logger := zap.NewJSON(zap.Error, zap.Output(zap.Discard))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if m := logger.Check(zap.Info, "Should be discarded."); m != nil {
+				m.Write(fakeFields()...)
+			}
+		}
+	})
+}
+
 func BenchmarkZapAddingFields(b *testing.B) {
 	logger := zap.NewJSON(zap.All, zap.Output(zap.Discard))
 	b.ResetTimer()
@@ -128,18 +149,61 @@ func BenchmarkZapWithoutFields(b *testing.B) {
 }
 
 func BenchmarkZapSampleWithoutFields(b *testing.B) {
-	messages := make([]string, 1000)
-	for i := range messages {
-		messages[i] = fmt.Sprintf("Sample the logs, but use a somewhat realistic message length. (#%v)", i)
-	}
+	messages := fakeMessages(1000)
 	base := zap.NewJSON(zap.All, zap.Output(zap.Discard))
-	logger := zwrap.Sample(base, time.Second, 10, 100)
+	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
 		for pb.Next() {
 			i++
 			logger.Info(messages[i%1000])
+		}
+	})
+}
+
+func BenchmarkZapSampleAddingFields(b *testing.B) {
+	messages := fakeMessages(1000)
+	base := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	logger := zwrap.Sample(base, time.Second, 10, 10000)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			i++
+			logger.Info(messages[i%1000], fakeFields()...)
+		}
+	})
+}
+
+func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
+	messages := fakeMessages(1000)
+	base := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	logger := zwrap.Sample(base, time.Second, 10, 10000)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			i++
+			if cm := logger.Check(zap.Info, messages[i%1000]); cm != nil {
+				cm.Write()
+			}
+		}
+	})
+}
+
+func BenchmarkZapSampleCheckAddingFields(b *testing.B) {
+	messages := fakeMessages(1000)
+	base := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	logger := zwrap.Sample(base, time.Second, 10, 10000)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			i++
+			if m := logger.Check(zap.Info, messages[i%1000]); m != nil {
+				m.Write(fakeFields()...)
+			}
 		}
 	})
 }

--- a/checked_message.go
+++ b/checked_message.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import "sync/atomic"
+
+// A CheckedMessage is the result of a call to Logger.Check, which allows
+// especially performance-sensitive applications to avoid allocations for disabled
+// or heavily sampled log levels.
+type CheckedMessage struct {
+	logger Logger
+	used   uint32
+	lvl    Level
+	msg    string
+}
+
+// NewCheckedMessage constructs a CheckedMessage. It's only intended for use by
+// wrapper libraries, and shouldn't be necessary in application code.
+func NewCheckedMessage(logger Logger, lvl Level, msg string) *CheckedMessage {
+	return &CheckedMessage{
+		logger: logger,
+		lvl:    lvl,
+		msg:    msg,
+	}
+}
+
+// Write logs the pre-checked message with the supplied fields. It should only
+// be used once; if a CheckedMessage is re-used, it also logs an error message
+// with the underlying logger's DFatal method.
+func (m *CheckedMessage) Write(fields ...Field) {
+	if n := atomic.AddUint32(&m.used, 1); n > 1 {
+		m.logger.DFatal("Shouldn't re-use a CheckedMessage.")
+	}
+	m.logger.Log(m.lvl, m.msg, fields...)
+}
+
+// OK checks whether it's safe to call Write.
+func (m *CheckedMessage) OK() bool {
+	return m != nil
+}

--- a/checked_message_test.go
+++ b/checked_message_test.go
@@ -46,13 +46,13 @@ func TestJSONLoggerCheck(t *testing.T) {
 func TestCheckedMessageIsSingleUse(t *testing.T) {
 	expected := []string{
 		`{"msg":"Single-use.","level":"info","ts":0,"fields":{}}`,
-		`{"msg":"Shouldn't re-use a CheckedMessage.","level":"error","ts":0,"fields":{}}`,
-		`{"msg":"Single-use.","level":"info","ts":0,"fields":{}}`,
+		`{"msg":"Shouldn't re-use a CheckedMessage.","level":"error","ts":0,"fields":{"original":"Single-use."}}`,
 	}
 	withJSONLogger(t, nil, func(jl *jsonLogger, output func() []string) {
 		cm := jl.Check(Info, "Single-use.")
-		cm.Write()
-		cm.Write()
+		cm.Write() // ok
+		cm.Write() // first re-use logs error
+		cm.Write() // second re-use is silently ignored
 		assert.Equal(t, expected, output(), "Expected re-using a CheckedMessage to log an error.")
 	})
 }

--- a/checked_message_test.go
+++ b/checked_message_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONLoggerCheck(t *testing.T) {
+	withJSONLogger(t, opts(Info), func(jl *jsonLogger, output func() []string) {
+		assert.False(t, jl.Check(Debug, "Debug.").OK(), "Expected CheckedMessage to be not OK at disabled levels.")
+
+		cm := jl.Check(Info, "Info.")
+		require.True(t, cm.OK(), "Expected CheckedMessage to be OK at enabled levels.")
+		cm.Write(Int("magic", 42))
+		assert.Equal(
+			t,
+			`{"msg":"Info.","level":"info","ts":0,"fields":{"magic":42}}`,
+			output()[0],
+			"Unexpected output after writing a CheckedMessage.",
+		)
+	})
+}
+
+func TestCheckedMessageIsSingleUse(t *testing.T) {
+	expected := []string{
+		`{"msg":"Single-use.","level":"info","ts":0,"fields":{}}`,
+		`{"msg":"Shouldn't re-use a CheckedMessage.","level":"error","ts":0,"fields":{}}`,
+		`{"msg":"Single-use.","level":"info","ts":0,"fields":{}}`,
+	}
+	withJSONLogger(t, nil, func(jl *jsonLogger, output func() []string) {
+		cm := jl.Check(Info, "Single-use.")
+		cm.Write()
+		cm.Write()
+		assert.Equal(t, expected, output(), "Expected re-using a CheckedMessage to log an error.")
+	})
+}

--- a/example_test.go
+++ b/example_test.go
@@ -107,13 +107,12 @@ func ExampleCheckedMessage() {
 	// logger.Debug will still allocate a slice to hold any passed fields.
 	// Particularly performance-sensitive applications can avoid paying this
 	// penalty by using checked messages.
-	if cm := logger.Check(zap.Debug, "This is a debug log."); cm != nil {
-		// We'll only get here if debug-level logging is enabled.
+	if cm := logger.Check(zap.Debug, "This is a debug log."); cm.OK() {
+		// Debug-level logging is disabled, so we won't get here.
 		cm.Write(zap.Int("foo", 42), zap.Stack())
-		// CheckedMessages are only good for one use! Calling Write again will panic.
 	}
 
-	if cm := logger.Check(zap.Info, "This is an info log."); cm != nil {
+	if cm := logger.Check(zap.Info, "This is an info log."); cm.OK() {
 		// Since info-level logging is enabled, we expect to write out this message.
 		cm.Write()
 	}

--- a/logger.go
+++ b/logger.go
@@ -27,37 +27,6 @@ import (
 	"time"
 )
 
-// A CheckedMessage is the result of a call to Logger.Check, which allows
-// especially performance-sensitive applications to avoid allocations for disabled
-// or heavily sampled log levels.
-type CheckedMessage struct {
-	logger Logger
-	used   uint32
-	lvl    Level
-	msg    string
-}
-
-// NewCheckedMessage constructs a CheckedMessage. It's only intended for use by
-// wrapper libraries, and shouldn't be necessary in application code.
-func NewCheckedMessage(logger Logger, lvl Level, msg string) *CheckedMessage {
-	return &CheckedMessage{
-		logger: logger,
-		lvl:    lvl,
-		msg:    msg,
-	}
-}
-
-// Write logs the pre-checked message with the supplied fields. It panics if
-// called more than once.
-func (m *CheckedMessage) Write(fields ...Field) {
-	if n := atomic.AddUint32(&m.used, 1); n > 1 {
-		// We could call logger.Log at a (possibly large) performance cost, but it's
-		// better to make this an obvious user error.
-		panic("Can't use a CheckedMessage more than once.")
-	}
-	m.logger.Log(m.lvl, m.msg, fields...)
-}
-
 // A Logger enables leveled, structured logging. All methods are safe for
 // concurrent use.
 type Logger interface {

--- a/spy/logger.go
+++ b/spy/logger.go
@@ -124,6 +124,14 @@ func (l *Logger) With(fields ...zap.Field) zap.Logger {
 	}
 }
 
+// Check returns a CheckedMessage if logging a particular message would succeed.
+func (l *Logger) Check(lvl zap.Level, msg string) *zap.CheckedMessage {
+	if !l.Enabled(lvl) {
+		return nil
+	}
+	return zap.NewCheckedMessage(l, lvl, msg)
+}
+
 // Log writes a message at the specified level.
 func (l *Logger) Log(lvl zap.Level, msg string, fields ...zap.Field) {
 	l.sink.WriteLog(lvl, msg, l.allFields(fields))

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -97,6 +97,13 @@ func (s *sampler) With(fields ...zap.Field) zap.Logger {
 	}
 }
 
+func (s *sampler) Check(lvl zap.Level, msg string) *zap.CheckedMessage {
+	if !s.check(lvl, msg) {
+		return nil
+	}
+	return zap.NewCheckedMessage(s.Logger, lvl, msg)
+}
+
 func (s *sampler) Log(lvl zap.Level, msg string, fields ...zap.Field) {
 	if s.check(lvl, msg) {
 		s.Logger.Log(lvl, msg, fields...)

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -164,6 +164,22 @@ func TestSamplerTicks(t *testing.T) {
 	assert.Equal(t, expected, sink.Logs(), "Expected sleeping for a tick to reset sampler.")
 }
 
+func TestSamplerCheck(t *testing.T) {
+	sampler, sink := fakeSampler(time.Millisecond, 1, 10, false)
+	sampler.SetLevel(zap.Info)
+
+	assert.Nil(t, sampler.Check(zap.Debug, "foo"), "Expected a nil CheckedMessage at disabled log levels.")
+
+	for i := 1; i < 12; i++ {
+		if cm := sampler.Check(zap.Info, "sample"); cm != nil {
+			cm.Write(zap.Int("iter", i))
+		}
+	}
+
+	expected := buildExpectation(zap.Info, 1, 11)
+	assert.Equal(t, expected, sink.Logs(), "Unexpected output when sampling with Check.")
+}
+
 func TestSamplerRaces(t *testing.T) {
 	sampler, _ := fakeSampler(time.Minute, 1, 1000, false)
 

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -171,7 +171,7 @@ func TestSamplerCheck(t *testing.T) {
 	assert.Nil(t, sampler.Check(zap.Debug, "foo"), "Expected a nil CheckedMessage at disabled log levels.")
 
 	for i := 1; i < 12; i++ {
-		if cm := sampler.Check(zap.Info, "sample"); cm != nil {
+		if cm := sampler.Check(zap.Info, "sample"); cm.OK() {
 			cm.Write(zap.Int("iter", i))
 		}
 	}


### PR DESCRIPTION
Even when a log level is disabled or heavily sampled, calling `logger.Error(msg, someField, someOtherField)` will make at least one allocation to hold the fields. Since we're going to discard the message anyways, this is wasted work. This PR introduces the `logger.Check` API, which allows particularly performance-sensitive applications to avoid these allocations by using a slightly wordier call pattern.

Using `Check` makes it virtually free to pass fields to a sampled logger or collect lots of debug logs:

```
BenchmarkZapDisabledLevelsAddingFields-4         3000000        439 ns/op             704 B/op          2 allocs/op
BenchmarkZapDisabledLevelsCheckAddingFields-4   200000000         5.74 ns/op            0 B/op          0 allocs/op

BenchmarkZapSampleWithoutFields-4       20000000                60.9 ns/op             0 B/op          0 allocs/op
BenchmarkZapSampleCheckWithoutFields-4  20000000                61.4 ns/op             0 B/op          0 allocs/op

BenchmarkZapSampleAddingFields-4         2000000               575 ns/op             704 B/op          2 allocs/op
BenchmarkZapSampleCheckAddingFields-4   20000000                65.2 ns/op             0 B/op          0 allocs/op
```

This fixes #56.