### PR TITLE
Fix the 'Bool' method output by checking the field value

### DIFF
--- a/field.go
+++ b/field.go
@@ -52,7 +52,7 @@ type Field struct {
 
 // Bool constructs a Field with the given key and value.
 func Bool(key string, val bool) Field {
-	var ival int64 = 0
+	var ival int64
 	if val {
 		ival = 1
 	}

--- a/field.go
+++ b/field.go
@@ -52,7 +52,12 @@ type Field struct {
 
 // Bool constructs a Field with the given key and value.
 func Bool(key string, val bool) Field {
-	return Field{key: key, fieldType: boolType, ival: 1}
+	var ival int64 = 0
+	if val {
+		ival = 1
+	}
+
+	return Field{key: key, fieldType: boolType, ival: ival}
 }
 
 // Float64 constructs a Field with the given key and value. The floating-point

--- a/field_test.go
+++ b/field_test.go
@@ -51,6 +51,15 @@ func assertFieldJSON(t testing.TB, expected string, field Field) {
 		"Unexpected JSON output after applying field %+v.", field)
 }
 
+func assertNotEqualFieldJSON(t testing.TB, expected string, field Field) {
+	enc := newJSONEncoder()
+	defer enc.Free()
+
+	field.addTo(enc)
+	assert.NotEqual(t, expected, string(enc.bytes),
+		"Unexpected JSON output after applying field %+v.", field)
+}
+
 func assertCanBeReused(t testing.TB, field Field) {
 	var wg sync.WaitGroup
 
@@ -72,9 +81,19 @@ func assertCanBeReused(t testing.TB, field Field) {
 	wg.Wait()
 }
 
-func TestBoolField(t *testing.T) {
+func TestTrueBoolField(t *testing.T) {
 	assertFieldJSON(t, `"foo":true`, Bool("foo", true))
 	assertCanBeReused(t, Bool("foo", true))
+}
+
+func TestFalseBoolField(t *testing.T) {
+	assertFieldJSON(t, `"bar":false`, Bool("bar", false))
+	assertCanBeReused(t, Bool("bar", false))
+}
+
+func TestUnlikeBoolField(t *testing.T) {
+	assertNotEqualFieldJSON(t, `"foo":true`, Bool("foo", false))
+	assertNotEqualFieldJSON(t, `"bar":false`, Bool("bar", true))
 }
 
 func TestFloat64Field(t *testing.T) {


### PR DESCRIPTION
According to the issue #52, the logger was always reporting a boolean key-value pair as 'true'.

It was happening because of the hardcoded field value as 1, in the file ['field.go'](https://github.com/uber-go/zap/blob/master/field.go#L55).

Test cases were unable to detect it probably because the test case is giving input [only as](https://github.com/uber-go/zap/blob/master/field_test.go#L75-L78) 'true' type.