### PR TITLE
Add apex/log benchmark

### DIFF
--- a/benchmarks/apex_log_bench_test.go
+++ b/benchmarks/apex_log_bench_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmarks
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/apex/log/handlers/json"
+)
+
+func newApexLog() *log.Logger {
+	return &log.Logger{
+		Handler: json.New(ioutil.Discard),
+		Level:   log.DebugLevel,
+	}
+}
+
+func BenchmarkApexLogAddingFields(b *testing.B) {
+	logger := newApexLog()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.WithFields(log.Fields{
+				"int":               1,
+				"int64":             int64(1),
+				"float":             3.0,
+				"string":            "four!",
+				"bool":              true,
+				"time":              time.Unix(0, 0),
+				"error":             errExample.Error(),
+				"duration":          time.Second,
+				"user-defined type": _jane,
+				"another string":    "done!",
+			}).Info("Go fast.")
+		}
+	})
+}
+
+func BenchmarkApexLogWithAccumulatedContext(b *testing.B) {
+	baseLogger := newApexLog()
+	logger := baseLogger.WithFields(log.Fields{
+		"int":               1,
+		"int64":             int64(1),
+		"float":             3.0,
+		"string":            "four!",
+		"bool":              true,
+		"time":              time.Unix(0, 0),
+		"error":             errExample.Error(),
+		"duration":          time.Second,
+		"user-defined type": _jane,
+		"another string":    "done!",
+	})
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go really fast.")
+		}
+	})
+}
+
+func BenchmarkApexLogWithoutFields(b *testing.B) {
+	logger := newApexLog()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go fast.")
+		}
+	})
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,10 @@
-hash: adb82d82c3f4e076845f514da0ffeb104ce1f79825bc67132999c976cd961ea2
-updated: 2016-04-18T08:54:46.580456609-07:00
+hash: 86ba3defb276434bb1c6dd1e222e67e081d4ac2b85507acc025b6fd0492053ad
+updated: 2016-05-26T16:19:43.051804352+09:00
 imports:
+- name: github.com/apex/log
+  version: a999c1b29c986b1972ec53b15092b63a8051ec83
+  subpackages:
+  - handler/json
 - name: github.com/axw/gocov
   version: f5b2b5cf8644b8b432436eaee1c8a73d2f4cf86e
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,3 +24,6 @@ import:
   - golint
 - package: github.com/mattn/go-colorable
 - package: github.com/uber-common/bark
+- package: github.com/apex/log
+  subpackages:
+  - handler/json


### PR DESCRIPTION
Add [apex/log](https://github.com/apex/log) benchmark.

```
BenchmarkApexLogAddingFields-8                    100000             16614 ns/op            3609 B/op         63 allocs/op
BenchmarkApexLogWithAccumulatedContext-8          100000             14201 ns/op            2385 B/op         48 allocs/op
BenchmarkApexLogWithoutFields-8                   500000              3048 ns/op             584 B/op         11 allocs/op
```