### PR TITLE
Refactor HTTP handler

### DIFF
--- a/http_handler.go
+++ b/http_handler.go
@@ -25,49 +25,60 @@ import (
 	"net/http"
 )
 
-// payload struct defines the format of the request payload received
-type payload struct {
-	Level string `json:"level"`
+type httpPayload struct {
+	Level *Level `json:"level"`
 }
 
-// NewHTTPHandler takes a logger instance and provides methods to enable
-// runtime changes to the logger level via http.handler interface.
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+type levelHandler struct {
+	logger Logger
+}
+
+// NewHTTPHandler returns an HTTP handler that can change the logging level at
+// runtime.
+//
+// GET requests return a JSON description of the current logging level. PUT
+// requests change the logging level and expect a payload like
+//   {"level":"info"}
 func NewHTTPHandler(logger Logger) http.Handler {
-	fn := func(w http.ResponseWriter, r *http.Request) {
-		var currentLevel string
+	return &levelHandler{logger: logger}
+}
 
-		switch r.Method {
-		case "GET":
-			currentLevel = logger.Level().String()
-		case "PUT":
-			decoder := json.NewDecoder(r.Body)
-			var p payload
-
-			err := decoder.Decode(&p)
-			if err != nil {
-				// received data in wrong format
-				http.Error(w, "Bad Request", 400)
-				return
-			}
-
-			var loggerLevel Level
-			err = loggerLevel.UnmarshalText([]byte(p.Level))
-			if err != nil {
-				// unrecognized level provided by the request
-				http.Error(w, "Unrecognized Level", 400)
-				return
-			}
-
-			logger.SetLevel(loggerLevel)
-			currentLevel = loggerLevel.String()
-		default:
-			http.Error(w, "Method Not Allowed", 405)
-			return
-		}
-
-		res := payload{currentLevel}
-		json.NewEncoder(w).Encode(res)
+func (h *levelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getLevel(w, r)
+	case http.MethodPut:
+		h.putLevel(w, r)
+	default:
+		h.error(w, "Only GET and PUT are supported.", http.StatusMethodNotAllowed)
 	}
+}
 
-	return http.HandlerFunc(fn)
+func (h *levelHandler) getLevel(w http.ResponseWriter, r *http.Request) {
+	current := h.logger.Level()
+	json.NewEncoder(w).Encode(httpPayload{Level: &current})
+}
+
+func (h *levelHandler) putLevel(w http.ResponseWriter, r *http.Request) {
+	var p httpPayload
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&p); err != nil {
+		h.error(w, "Request body must be well-formed JSON.", http.StatusBadRequest)
+		return
+	}
+	if p.Level == nil {
+		h.error(w, "Must specify a logging level.", http.StatusBadRequest)
+		return
+	}
+	h.logger.SetLevel(*p.Level)
+	json.NewEncoder(w).Encode(p)
+}
+
+func (h *levelHandler) error(w http.ResponseWriter, msg string, status int) {
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(errorResponse{Error: msg})
 }

--- a/http_handler.go
+++ b/http_handler.go
@@ -22,6 +22,7 @@ package zap
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -67,7 +68,11 @@ func (h *levelHandler) putLevel(w http.ResponseWriter, r *http.Request) {
 	var p httpPayload
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&p); err != nil {
-		h.error(w, "Request body must be well-formed JSON.", http.StatusBadRequest)
+		h.error(
+			w,
+			fmt.Sprintf("Request body must be well-formed JSON: %v", err),
+			http.StatusBadRequest,
+		)
 		return
 	}
 	if p.Level == nil {

--- a/http_handler.go
+++ b/http_handler.go
@@ -49,9 +49,9 @@ func NewHTTPHandler(logger Logger) http.Handler {
 
 func (h *levelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
-	case http.MethodGet:
+	case "GET":
 		h.getLevel(w, r)
-	case http.MethodPut:
+	case "PUT":
 		h.putLevel(w, r)
 	default:
 		h.error(w, "Only GET and PUT are supported.", http.StatusMethodNotAllowed)

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -75,8 +75,7 @@ func makeRequest(t testing.TB, method string, handler http.Handler, reader io.Re
 	req, err := http.NewRequest(method, ts.URL, reader)
 	require.NoError(t, err, "Error constructing %s request.", method)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := http.DefaultClient.Do(req)
 	require.NoError(t, err, "Error making %s request.", method)
 	defer res.Body.Close()
 


### PR DESCRIPTION
Refactor @pravj's HTTP handler a little - the core of the code is the same, but I rearranged things a bit.

- Create a struct for the handler, which makes it easier to separate the get and put logic.
- Return JSON even for non-200 responses.
- Leverage the `Level` type's `UnmarshalText` method.
- Use the spy logger instead of a JSON logger in these tests.

