### PR TITLE
Rename levels and Err field constructor

### DIFF
--- a/benchmarks/logrus_bench_test.go
+++ b/benchmarks/logrus_bench_test.go
@@ -63,7 +63,7 @@ func BenchmarkLogrusAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapBarkifyAddingFields(b *testing.B) {
-	logger := zbark.Barkify(zap.NewJSON(zap.All, zap.Output(zap.Discard)))
+	logger := zbark.Barkify(zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard)))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -106,7 +106,7 @@ func BenchmarkLogrusWithAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapBarkifyWithAccumulatedContext(b *testing.B) {
-	baseLogger := zbark.Barkify(zap.NewJSON(zap.All, zap.Output(zap.Discard)))
+	baseLogger := zbark.Barkify(zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard)))
 	logger := baseLogger.WithFields(bark.Fields{
 		"int":               1,
 		"int64":             int64(1),

--- a/benchmarks/stdlib_bench_test.go
+++ b/benchmarks/stdlib_bench_test.go
@@ -41,8 +41,8 @@ func BenchmarkStandardLibraryWithoutFields(b *testing.B) {
 
 func BenchmarkZapStandardizeWithoutFields(b *testing.B) {
 	logger, err := zwrap.Standardize(
-		zap.NewJSON(zap.All, zap.Output(zap.Discard)),
-		zap.Info,
+		zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard)),
+		zap.InfoLevel,
 	)
 	if err != nil {
 		panic("Failed to Standardize a zap.Logger.")

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -59,7 +59,7 @@ func fakeFields() []zap.Field {
 		zap.String("string", "four!"),
 		zap.Bool("bool", true),
 		zap.Time("time", time.Unix(0, 0)),
-		zap.Err(errExample),
+		zap.Error(errExample),
 		zap.Duration("duration", time.Second),
 		zap.Marshaler("user-defined type", _jane),
 		zap.String("another string", "done!"),
@@ -75,7 +75,7 @@ func fakeMessages(n int) []string {
 }
 
 func BenchmarkZapDisabledLevelsWithoutFields(b *testing.B) {
-	logger := zap.NewJSON(zap.Error, zap.Output(zap.Discard))
+	logger := zap.NewJSON(zap.ErrorLevel, zap.Output(zap.Discard))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -86,7 +86,7 @@ func BenchmarkZapDisabledLevelsWithoutFields(b *testing.B) {
 
 func BenchmarkZapDisabledLevelsAccumulatedContext(b *testing.B) {
 	context := fakeFields()
-	logger := zap.NewJSON(zap.Error, zap.Output(zap.Discard), zap.Fields(context...))
+	logger := zap.NewJSON(zap.ErrorLevel, zap.Output(zap.Discard), zap.Fields(context...))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -96,7 +96,7 @@ func BenchmarkZapDisabledLevelsAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapDisabledLevelsAddingFields(b *testing.B) {
-	logger := zap.NewJSON(zap.Error, zap.Output(zap.Discard))
+	logger := zap.NewJSON(zap.ErrorLevel, zap.Output(zap.Discard))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -106,11 +106,11 @@ func BenchmarkZapDisabledLevelsAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapDisabledLevelsCheckAddingFields(b *testing.B) {
-	logger := zap.NewJSON(zap.Error, zap.Output(zap.Discard))
+	logger := zap.NewJSON(zap.ErrorLevel, zap.Output(zap.Discard))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			if m := logger.Check(zap.Info, "Should be discarded."); m.OK() {
+			if m := logger.Check(zap.InfoLevel, "Should be discarded."); m.OK() {
 				m.Write(fakeFields()...)
 			}
 		}
@@ -118,7 +118,7 @@ func BenchmarkZapDisabledLevelsCheckAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapAddingFields(b *testing.B) {
-	logger := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -129,7 +129,7 @@ func BenchmarkZapAddingFields(b *testing.B) {
 
 func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 	context := fakeFields()
-	logger := zap.NewJSON(zap.All, zap.Output(zap.Discard), zap.Fields(context...))
+	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard), zap.Fields(context...))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -139,7 +139,7 @@ func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapWithoutFields(b *testing.B) {
-	logger := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -150,7 +150,7 @@ func BenchmarkZapWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleWithoutFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	base := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -164,7 +164,7 @@ func BenchmarkZapSampleWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleAddingFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	base := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -178,14 +178,14 @@ func BenchmarkZapSampleAddingFields(b *testing.B) {
 
 func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	base := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
 		for pb.Next() {
 			i++
-			if cm := logger.Check(zap.Info, messages[i%1000]); cm.OK() {
+			if cm := logger.Check(zap.InfoLevel, messages[i%1000]); cm.OK() {
 				cm.Write()
 			}
 		}
@@ -194,14 +194,14 @@ func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleCheckAddingFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	base := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
 		for pb.Next() {
 			i++
-			if m := logger.Check(zap.Info, messages[i%1000]); m.OK() {
+			if m := logger.Check(zap.InfoLevel, messages[i%1000]); m.OK() {
 				m.Write(fakeFields()...)
 			}
 		}

--- a/checked_message_test.go
+++ b/checked_message_test.go
@@ -28,10 +28,10 @@ import (
 )
 
 func TestJSONLoggerCheck(t *testing.T) {
-	withJSONLogger(t, opts(Info), func(jl *jsonLogger, output func() []string) {
-		assert.False(t, jl.Check(Debug, "Debug.").OK(), "Expected CheckedMessage to be not OK at disabled levels.")
+	withJSONLogger(t, opts(InfoLevel), func(jl *jsonLogger, output func() []string) {
+		assert.False(t, jl.Check(DebugLevel, "Debug.").OK(), "Expected CheckedMessage to be not OK at disabled levels.")
 
-		cm := jl.Check(Info, "Info.")
+		cm := jl.Check(InfoLevel, "Info.")
 		require.True(t, cm.OK(), "Expected CheckedMessage to be OK at enabled levels.")
 		cm.Write(Int("magic", 42))
 		assert.Equal(
@@ -49,7 +49,7 @@ func TestCheckedMessageIsSingleUse(t *testing.T) {
 		`{"msg":"Shouldn't re-use a CheckedMessage.","level":"error","ts":0,"fields":{"original":"Single-use."}}`,
 	}
 	withJSONLogger(t, nil, func(jl *jsonLogger, output func() []string) {
-		cm := jl.Check(Info, "Single-use.")
+		cm := jl.Check(InfoLevel, "Single-use.")
 		cm.Write() // ok
 		cm.Write() // first re-use logs error
 		cm.Write() // second re-use is silently ignored

--- a/example_test.go
+++ b/example_test.go
@@ -84,7 +84,7 @@ func ExampleNewJSON_options() {
 	// We can pass multiple options to the NewJSON method to configure
 	// the logging level, output location, or even the initial context.
 	logger := zap.NewJSON(
-		zap.Debug,
+		zap.DebugLevel,
 		zap.Fields(zap.Int("count", 1)),
 	)
 	// Stub the current time in tests.
@@ -107,12 +107,12 @@ func ExampleCheckedMessage() {
 	// logger.Debug will still allocate a slice to hold any passed fields.
 	// Particularly performance-sensitive applications can avoid paying this
 	// penalty by using checked messages.
-	if cm := logger.Check(zap.Debug, "This is a debug log."); cm.OK() {
+	if cm := logger.Check(zap.DebugLevel, "This is a debug log."); cm.OK() {
 		// Debug-level logging is disabled, so we won't get here.
 		cm.Write(zap.Int("foo", 42), zap.Stack())
 	}
 
-	if cm := logger.Check(zap.Info, "This is an info log."); cm.OK() {
+	if cm := logger.Check(zap.InfoLevel, "This is an info log."); cm.OK() {
 		// Since info-level logging is enabled, we expect to write out this message.
 		cm.Write()
 	}

--- a/field.go
+++ b/field.go
@@ -95,10 +95,10 @@ func Time(key string, val time.Time) Field {
 	return Int64(key, val.UnixNano())
 }
 
-// Err constructs a Field that stores err.Error() under the key "error". This is
+// Error constructs a Field that stores err.Error() under the key "error". This is
 // just a convenient shortcut for a common pattern - apart from saving a few
 // keystrokes, it's no different from using zap.String.
-func Err(err error) Field {
+func Error(err error) Field {
 	return String("error", err.Error())
 }
 

--- a/field_test.go
+++ b/field_test.go
@@ -128,8 +128,8 @@ func TestTimeField(t *testing.T) {
 }
 
 func TestErrField(t *testing.T) {
-	assertFieldJSON(t, `"error":"fail"`, Err(errors.New("fail")))
-	assertCanBeReused(t, Err(errors.New("fail")))
+	assertFieldJSON(t, `"error":"fail"`, Error(errors.New("fail")))
+	assertCanBeReused(t, Error(errors.New("fail")))
 }
 
 func TestDurationField(t *testing.T) {

--- a/flag_test.go
+++ b/flag_test.go
@@ -36,7 +36,7 @@ func TestLevelFlag(t *testing.T) {
 	}{
 		{
 			args:      nil,
-			wantLevel: Info,
+			wantLevel: InfoLevel,
 		},
 		{
 			args:    []string{"--level", "unknown"},
@@ -44,7 +44,7 @@ func TestLevelFlag(t *testing.T) {
 		},
 		{
 			args:      []string{"--level", "error"},
-			wantLevel: Error,
+			wantLevel: ErrorLevel,
 		},
 	}
 
@@ -54,7 +54,7 @@ func TestLevelFlag(t *testing.T) {
 	for _, tt := range tests {
 		flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
 		flag.CommandLine.SetOutput(ioutil.Discard)
-		level := LevelFlag("level", Info, "")
+		level := LevelFlag("level", InfoLevel, "")
 
 		err := flag.CommandLine.Parse(tt.args)
 		if tt.wantErr {

--- a/hook_test.go
+++ b/hook_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestHookAddCaller(t *testing.T) {
 	buf := newTestBuffer()
-	logger := NewJSON(All, Output(buf), AddCaller())
+	logger := NewJSON(AllLevel, Output(buf), AddCaller())
 	logger.Info("Callers.")
 
 	re := regexp.MustCompile(`"msg":"hook_test.go:[\d]+: Callers\."`)
@@ -45,7 +45,7 @@ func TestHookAddCallerFail(t *testing.T) {
 	_callerSkip = 1e3
 	defer func() { _callerSkip = originalSkip }()
 
-	logger := NewJSON(All, Output(buf), ErrorOutput(errBuf), AddCaller())
+	logger := NewJSON(AllLevel, Output(buf), ErrorOutput(errBuf), AddCaller())
 	logger.Info("Failure.")
 	assert.Equal(t, "failed to get caller\n", errBuf.String(), "Didn't find expected failure message.")
 	assert.Contains(t, buf.String(), `"msg":"Failure."`, "Expected original message to survive failures in runtime.Caller.")
@@ -53,7 +53,7 @@ func TestHookAddCallerFail(t *testing.T) {
 
 func TestHookAddStacks(t *testing.T) {
 	buf := newTestBuffer()
-	logger := NewJSON(All, Output(buf), AddStacks(Info))
+	logger := NewJSON(AllLevel, Output(buf), AddStacks(InfoLevel))
 
 	logger.Info("Stacks.")
 	output := buf.String()

--- a/level.go
+++ b/level.go
@@ -35,45 +35,46 @@ var errMarshalNilLevel = errors.New("can't marshal a nil *Level to text")
 type Level int32
 
 const (
-	// Debug logs are typically voluminous, and are usually disabled in
+	// DebugLevel logs are typically voluminous, and are usually disabled in
 	// production.
-	Debug Level = iota - 1
-	// Info is the default logging priority.
-	Info
-	// Warn logs are more important than Info, but don't need individual human review.
-	Warn
-	// Error logs are high-priority. If an application is running smoothly, it
-	// shouldn't generate any error-level logs.
-	Error
-	// Panic logs a message, then panics.
-	Panic
-	// Fatal logs a message, then calls os.Exit(1).
-	Fatal
+	DebugLevel Level = iota - 1
+	// InfoLevel is the default logging priority.
+	InfoLevel
+	// WarnLevel logs are more important than Info, but don't need individual
+	// human review.
+	WarnLevel
+	// ErrorLevel logs are high-priority. If an application is running smoothly,
+	// it shouldn't generate any error-level logs.
+	ErrorLevel
+	// PanicLevel logs a message, then panics.
+	PanicLevel
+	// FatalLevel logs a message, then calls os.Exit(1).
+	FatalLevel
 
-	// All logs everything.
-	All Level = math.MinInt32
-	// None silences logging completely.
-	None Level = math.MaxInt32
+	// AllLevel logs everything.
+	AllLevel Level = math.MinInt32
+	// NoneLevel silences logging completely.
+	NoneLevel Level = math.MaxInt32
 )
 
 // String returns a lower-case ASCII representation of the log level.
 func (l Level) String() string {
 	switch l {
-	case All:
+	case AllLevel:
 		return "all"
-	case Debug:
+	case DebugLevel:
 		return "debug"
-	case Info:
+	case InfoLevel:
 		return "info"
-	case Warn:
+	case WarnLevel:
 		return "warn"
-	case Error:
+	case ErrorLevel:
 		return "error"
-	case Panic:
+	case PanicLevel:
 		return "panic"
-	case Fatal:
+	case FatalLevel:
 		return "fatal"
-	case None:
+	case NoneLevel:
 		return "none"
 	default:
 		return fmt.Sprintf("Level(%d)", l)
@@ -95,21 +96,21 @@ func (l *Level) MarshalText() ([]byte, error) {
 func (l *Level) UnmarshalText(text []byte) error {
 	switch string(text) {
 	case "all":
-		*l = All
+		*l = AllLevel
 	case "debug":
-		*l = Debug
+		*l = DebugLevel
 	case "info":
-		*l = Info
+		*l = InfoLevel
 	case "warn":
-		*l = Warn
+		*l = WarnLevel
 	case "error":
-		*l = Error
+		*l = ErrorLevel
 	case "panic":
-		*l = Panic
+		*l = PanicLevel
 	case "fatal":
-		*l = Fatal
+		*l = FatalLevel
 	case "none":
-		*l = None
+		*l = NoneLevel
 	default:
 		return fmt.Errorf("unrecognized level: %v", string(text))
 	}

--- a/level_test.go
+++ b/level_test.go
@@ -28,14 +28,14 @@ import (
 
 func TestLevelString(t *testing.T) {
 	tests := map[Level]string{
-		All:        "all",
-		Debug:      "debug",
-		Info:       "info",
-		Warn:       "warn",
-		Error:      "error",
-		Panic:      "panic",
-		Fatal:      "fatal",
-		None:       "none",
+		AllLevel:   "all",
+		DebugLevel: "debug",
+		InfoLevel:  "info",
+		WarnLevel:  "warn",
+		ErrorLevel: "error",
+		PanicLevel: "panic",
+		FatalLevel: "fatal",
+		NoneLevel:  "none",
 		Level(-42): "Level(-42)",
 	}
 
@@ -49,14 +49,14 @@ func TestLevelText(t *testing.T) {
 		text  string
 		level Level
 	}{
-		{"all", All},
-		{"debug", Debug},
-		{"info", Info},
-		{"warn", Warn},
-		{"error", Error},
-		{"panic", Panic},
-		{"fatal", Fatal},
-		{"none", None},
+		{"all", AllLevel},
+		{"debug", DebugLevel},
+		{"info", InfoLevel},
+		{"warn", WarnLevel},
+		{"error", ErrorLevel},
+		{"panic", PanicLevel},
+		{"fatal", FatalLevel},
+		{"none", NoneLevel},
 	}
 	for _, tt := range tests {
 		lvl := tt.level

--- a/logger.go
+++ b/logger.go
@@ -92,7 +92,7 @@ type jsonLogger struct {
 // Options can change the log level, the output location, or the initial
 // fields that should be added as context.
 func NewJSON(options ...Option) Logger {
-	defaultLevel := atomic.NewInt32(int32(Info))
+	defaultLevel := atomic.NewInt32(int32(InfoLevel))
 	jl := &jsonLogger{
 		enc:   newJSONEncoder(),
 		level: defaultLevel,
@@ -150,9 +150,9 @@ func (jl *jsonLogger) Check(lvl Level, msg string) *CheckedMessage {
 
 func (jl *jsonLogger) Log(lvl Level, msg string, fields ...Field) {
 	switch lvl {
-	case Panic:
+	case PanicLevel:
 		jl.Panic(msg, fields...)
-	case Fatal:
+	case FatalLevel:
 		jl.Fatal(msg, fields...)
 	default:
 		jl.log(lvl, msg, fields)
@@ -160,28 +160,28 @@ func (jl *jsonLogger) Log(lvl Level, msg string, fields ...Field) {
 }
 
 func (jl *jsonLogger) Debug(msg string, fields ...Field) {
-	jl.log(Debug, msg, fields)
+	jl.log(DebugLevel, msg, fields)
 }
 
 func (jl *jsonLogger) Info(msg string, fields ...Field) {
-	jl.log(Info, msg, fields)
+	jl.log(InfoLevel, msg, fields)
 }
 
 func (jl *jsonLogger) Warn(msg string, fields ...Field) {
-	jl.log(Warn, msg, fields)
+	jl.log(WarnLevel, msg, fields)
 }
 
 func (jl *jsonLogger) Error(msg string, fields ...Field) {
-	jl.log(Error, msg, fields)
+	jl.log(ErrorLevel, msg, fields)
 }
 
 func (jl *jsonLogger) Panic(msg string, fields ...Field) {
-	jl.log(Panic, msg, fields)
+	jl.log(PanicLevel, msg, fields)
 	panic(msg)
 }
 
 func (jl *jsonLogger) Fatal(msg string, fields ...Field) {
-	jl.log(Fatal, msg, fields)
+	jl.log(FatalLevel, msg, fields)
 	_exit(1)
 }
 
@@ -219,7 +219,7 @@ func (jl *jsonLogger) log(lvl Level, msg string, fields []Field) {
 	}
 	temp.Free()
 
-	if lvl > Error {
+	if lvl > ErrorLevel {
 		// Sync on Panic and Fatal, since they may crash the program.
 		jl.w.Sync()
 	}

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -48,7 +48,7 @@ var _jane = user{
 }
 
 func withBenchedLogger(b *testing.B, f func(zap.Logger)) {
-	logger := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -95,7 +95,7 @@ func BenchmarkStringField(b *testing.B) {
 
 func BenchmarkStringerField(b *testing.B) {
 	withBenchedLogger(b, func(log zap.Logger) {
-		log.Info("Level.", zap.Stringer("foo", zap.Info))
+		log.Info("Level.", zap.Stringer("foo", zap.InfoLevel))
 	})
 }
 
@@ -115,7 +115,7 @@ func BenchmarkDurationField(b *testing.B) {
 func BenchmarkErrorField(b *testing.B) {
 	err := errors.New("egad!")
 	withBenchedLogger(b, func(log zap.Logger) {
-		log.Info("Error.", zap.Err(err))
+		log.Info("Error.", zap.Error(err))
 	})
 }
 
@@ -171,7 +171,7 @@ func Benchmark10Fields(b *testing.B) {
 
 func Benchmark100Fields(b *testing.B) {
 	const batchSize = 50
-	logger := zap.NewJSON(zap.All, zap.Output(zap.Discard))
+	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
 
 	// Don't include allocating these helper slices in the benchmark. Since
 	// access to them isn't synchronized, we can't run the benchmark in

--- a/spy/logger.go
+++ b/spy/logger.go
@@ -137,38 +137,38 @@ func (l *Logger) Log(lvl zap.Level, msg string, fields ...zap.Field) {
 
 // Debug logs at the Debug level.
 func (l *Logger) Debug(msg string, fields ...zap.Field) {
-	l.sink.WriteLog(zap.Debug, msg, l.allFields(fields))
+	l.sink.WriteLog(zap.DebugLevel, msg, l.allFields(fields))
 }
 
 // Info logs at the Info level.
 func (l *Logger) Info(msg string, fields ...zap.Field) {
-	l.sink.WriteLog(zap.Info, msg, l.allFields(fields))
+	l.sink.WriteLog(zap.InfoLevel, msg, l.allFields(fields))
 
 }
 
 // Warn logs at the Warn level.
 func (l *Logger) Warn(msg string, fields ...zap.Field) {
-	l.sink.WriteLog(zap.Warn, msg, l.allFields(fields))
+	l.sink.WriteLog(zap.WarnLevel, msg, l.allFields(fields))
 
 }
 
 // Error logs at the Error level.
 func (l *Logger) Error(msg string, fields ...zap.Field) {
-	l.sink.WriteLog(zap.Error, msg, l.allFields(fields))
+	l.sink.WriteLog(zap.ErrorLevel, msg, l.allFields(fields))
 
 }
 
 // Panic logs at the Panic level. Note that the spy Logger doesn't actually
 // panic.
 func (l *Logger) Panic(msg string, fields ...zap.Field) {
-	l.sink.WriteLog(zap.Panic, msg, l.allFields(fields))
+	l.sink.WriteLog(zap.PanicLevel, msg, l.allFields(fields))
 
 }
 
 // Fatal logs at the Fatal level. Note that the spy logger doesn't actuall call
 // os.Exit.
 func (l *Logger) Fatal(msg string, fields ...zap.Field) {
-	l.sink.WriteLog(zap.Fatal, msg, l.allFields(fields))
+	l.sink.WriteLog(zap.FatalLevel, msg, l.allFields(fields))
 
 }
 
@@ -176,9 +176,9 @@ func (l *Logger) Fatal(msg string, fields ...zap.Field) {
 // level otherwise.
 func (l *Logger) DFatal(msg string, fields ...zap.Field) {
 	if l.development {
-		l.sink.WriteLog(zap.Fatal, msg, l.allFields(fields))
+		l.sink.WriteLog(zap.FatalLevel, msg, l.allFields(fields))
 	} else {
-		l.sink.WriteLog(zap.Error, msg, l.allFields(fields))
+		l.sink.WriteLog(zap.ErrorLevel, msg, l.allFields(fields))
 	}
 }
 

--- a/zbark/bark_test.go
+++ b/zbark/bark_test.go
@@ -59,7 +59,7 @@ func (l loggable) MarshalLog(kv zap.KeyValue) error {
 
 func newBark() (bark.Logger, *bytes.Buffer) {
 	buf := &bytes.Buffer{}
-	logger := zap.NewJSON(zap.All, zap.Output(zap.AddSync(buf)))
+	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.AddSync(buf)))
 	return Barkify(logger), buf
 }
 

--- a/zwrap/example_test.go
+++ b/zwrap/example_test.go
@@ -35,7 +35,7 @@ func Example_standardize() {
 	// Wrap our structured logger to mimic the standard library's log.Logger.
 	// We also specify that we want all calls to the standard logger's Print
 	// family of methods to log at zap's Warn level.
-	stdLogger, err := zwrap.Standardize(zapLogger, zap.Warn)
+	stdLogger, err := zwrap.Standardize(zapLogger, zap.WarnLevel)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -111,43 +111,43 @@ func (s *sampler) Log(lvl zap.Level, msg string, fields ...zap.Field) {
 }
 
 func (s *sampler) Debug(msg string, fields ...zap.Field) {
-	if s.check(zap.Debug, msg) {
+	if s.check(zap.DebugLevel, msg) {
 		s.Logger.Debug(msg, fields...)
 	}
 }
 
 func (s *sampler) Info(msg string, fields ...zap.Field) {
-	if s.check(zap.Info, msg) {
+	if s.check(zap.InfoLevel, msg) {
 		s.Logger.Info(msg, fields...)
 	}
 }
 
 func (s *sampler) Warn(msg string, fields ...zap.Field) {
-	if s.check(zap.Warn, msg) {
+	if s.check(zap.WarnLevel, msg) {
 		s.Logger.Warn(msg, fields...)
 	}
 }
 
 func (s *sampler) Error(msg string, fields ...zap.Field) {
-	if s.check(zap.Error, msg) {
+	if s.check(zap.ErrorLevel, msg) {
 		s.Logger.Error(msg, fields...)
 	}
 }
 
 func (s *sampler) Panic(msg string, fields ...zap.Field) {
-	if s.check(zap.Panic, msg) {
+	if s.check(zap.PanicLevel, msg) {
 		s.Logger.Panic(msg, fields...)
 	}
 }
 
 func (s *sampler) Fatal(msg string, fields ...zap.Field) {
-	if s.check(zap.Fatal, msg) {
+	if s.check(zap.FatalLevel, msg) {
 		s.Logger.Fatal(msg, fields...)
 	}
 }
 
 func (s *sampler) DFatal(msg string, fields ...zap.Field) {
-	if s.check(zap.Error, msg) {
+	if s.check(zap.ErrorLevel, msg) {
 		s.Logger.DFatal(msg, fields...)
 	}
 }

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -38,7 +38,7 @@ func WithIter(l zap.Logger, n int) zap.Logger {
 
 func fakeSampler(tick time.Duration, first, thereafter int, development bool) (zap.Logger, *spy.Sink) {
 	base, sink := spy.New()
-	base.SetLevel(zap.All)
+	base.SetLevel(zap.AllLevel)
 	base.SetDevelopment(development)
 	sampler := Sample(base, tick, first, thereafter)
 	return sampler, sink
@@ -63,41 +63,41 @@ func TestSampler(t *testing.T) {
 		development bool
 	}{
 		{
-			level:   zap.Debug,
+			level:   zap.DebugLevel,
 			logFunc: func(sampler zap.Logger, n int) { WithIter(sampler, n).Debug("sample") },
 		},
 		{
-			level:   zap.Info,
+			level:   zap.InfoLevel,
 			logFunc: func(sampler zap.Logger, n int) { WithIter(sampler, n).Info("sample") },
 		},
 		{
-			level:   zap.Warn,
+			level:   zap.WarnLevel,
 			logFunc: func(sampler zap.Logger, n int) { WithIter(sampler, n).Warn("sample") },
 		},
 		{
-			level:   zap.Error,
+			level:   zap.ErrorLevel,
 			logFunc: func(sampler zap.Logger, n int) { WithIter(sampler, n).Error("sample") },
 		},
 		{
-			level:   zap.Panic,
+			level:   zap.PanicLevel,
 			logFunc: func(sampler zap.Logger, n int) { WithIter(sampler, n).Panic("sample") },
 		},
 		{
-			level:   zap.Fatal,
+			level:   zap.FatalLevel,
 			logFunc: func(sampler zap.Logger, n int) { WithIter(sampler, n).Fatal("sample") },
 		},
 		{
-			level:   zap.Error,
+			level:   zap.ErrorLevel,
 			logFunc: func(sampler zap.Logger, n int) { WithIter(sampler, n).DFatal("sample") },
 		},
 		{
-			level:       zap.Fatal,
+			level:       zap.FatalLevel,
 			logFunc:     func(sampler zap.Logger, n int) { WithIter(sampler, n).DFatal("sample") },
 			development: true,
 		},
 		{
-			level:   zap.Error,
-			logFunc: func(sampler zap.Logger, n int) { WithIter(sampler, n).Log(zap.Error, "sample") },
+			level:   zap.ErrorLevel,
+			logFunc: func(sampler zap.Logger, n int) { WithIter(sampler, n).Log(zap.ErrorLevel, "sample") },
 		},
 	}
 
@@ -113,12 +113,12 @@ func TestSampler(t *testing.T) {
 
 func TestSampledDisabledLevels(t *testing.T) {
 	sampler, sink := fakeSampler(time.Minute, 1, 100, false)
-	sampler.SetLevel(zap.Info)
+	sampler.SetLevel(zap.InfoLevel)
 
 	// Shouldn't be counted, because debug logging isn't enabled.
 	WithIter(sampler, 1).Debug("sample")
 	WithIter(sampler, 2).Info("sample")
-	expected := buildExpectation(zap.Info, 2)
+	expected := buildExpectation(zap.InfoLevel, 2)
 	assert.Equal(t, expected, sink.Logs(), "Expected to disregard disabled log levels.")
 }
 
@@ -127,7 +127,7 @@ func TestSamplerWithSharesCounters(t *testing.T) {
 
 	expected := []spy.Log{
 		{
-			Level:  zap.Info,
+			Level:  zap.InfoLevel,
 			Msg:    "sample",
 			Fields: []zap.Field{zap.String("child", "first"), zap.Int("iter", 1)},
 		},
@@ -161,23 +161,23 @@ func TestSamplerTicks(t *testing.T) {
 		WithIter(sampler, i).Info("sample")
 	}
 
-	expected := buildExpectation(zap.Info, 1, 3)
+	expected := buildExpectation(zap.InfoLevel, 1, 3)
 	assert.Equal(t, expected, sink.Logs(), "Expected sleeping for a tick to reset sampler.")
 }
 
 func TestSamplerCheck(t *testing.T) {
 	sampler, sink := fakeSampler(time.Millisecond, 1, 10, false)
-	sampler.SetLevel(zap.Info)
+	sampler.SetLevel(zap.InfoLevel)
 
-	assert.Nil(t, sampler.Check(zap.Debug, "foo"), "Expected a nil CheckedMessage at disabled log levels.")
+	assert.Nil(t, sampler.Check(zap.DebugLevel, "foo"), "Expected a nil CheckedMessage at disabled log levels.")
 
 	for i := 1; i < 12; i++ {
-		if cm := sampler.Check(zap.Info, "sample"); cm.OK() {
+		if cm := sampler.Check(zap.InfoLevel, "sample"); cm.OK() {
 			cm.Write(zap.Int("iter", i))
 		}
 	}
 
-	expected := buildExpectation(zap.Info, 1, 11)
+	expected := buildExpectation(zap.InfoLevel, 1, 11)
 	assert.Equal(t, expected, sink.Logs(), "Unexpected output when sampling with Check.")
 }
 

--- a/zwrap/standard.go
+++ b/zwrap/standard.go
@@ -56,13 +56,13 @@ func Standardize(l zap.Logger, printAt zap.Level) (StandardLogger, error) {
 		fatal: l.Fatal,
 	}
 	switch printAt {
-	case zap.Debug:
+	case zap.DebugLevel:
 		s.write = l.Debug
-	case zap.Info:
+	case zap.InfoLevel:
 		s.write = l.Info
-	case zap.Warn:
+	case zap.WarnLevel:
 		s.write = l.Warn
-	case zap.Error:
+	case zap.ErrorLevel:
 		s.write = l.Error
 	default:
 		return nil, ErrInvalidLevel

--- a/zwrap/standard_test.go
+++ b/zwrap/standard_test.go
@@ -33,20 +33,20 @@ import (
 
 func newStd(lvl zap.Level) (StandardLogger, *bytes.Buffer, error) {
 	buf := &bytes.Buffer{}
-	logger := zap.NewJSON(zap.All, zap.Output(zap.AddSync(buf)))
+	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.AddSync(buf)))
 	std, err := Standardize(logger, lvl)
 	return std, buf, err
 }
 
 func TestStandardizeInvalidLevels(t *testing.T) {
-	for _, level := range []zap.Level{zap.All, zap.Panic, zap.Fatal, zap.None, zap.Level(42)} {
+	for _, level := range []zap.Level{zap.AllLevel, zap.PanicLevel, zap.FatalLevel, zap.NoneLevel, zap.Level(42)} {
 		_, _, err := newStd(level)
 		assert.Equal(t, ErrInvalidLevel, err, "Expected ErrInvalidLevel when passing an invalid level to Standardize.")
 	}
 }
 
 func TestStandardizeValidLevels(t *testing.T) {
-	for _, level := range []zap.Level{zap.Debug, zap.Info, zap.Warn, zap.Error} {
+	for _, level := range []zap.Level{zap.DebugLevel, zap.InfoLevel, zap.WarnLevel, zap.ErrorLevel} {
 		std, buf, err := newStd(level)
 		require.NoError(t, err, "Unexpected error calling Standardize with a valid level.")
 		std.Print("foo")
@@ -57,7 +57,7 @@ func TestStandardizeValidLevels(t *testing.T) {
 }
 
 func TestStandardLoggerPrint(t *testing.T) {
-	std, buf, err := newStd(zap.Info)
+	std, buf, err := newStd(zap.InfoLevel)
 	require.NoError(t, err, "Unexpected error standardizing a Logger.")
 
 	verify := func() {
@@ -76,7 +76,7 @@ func TestStandardLoggerPrint(t *testing.T) {
 }
 
 func TestStandardLoggerPanic(t *testing.T) {
-	std, buf, err := newStd(zap.Info)
+	std, buf, err := newStd(zap.InfoLevel)
 	require.NoError(t, err, "Unexpected error standardizing a Logger.")
 
 	verify := func(f func()) {
@@ -99,7 +99,7 @@ func TestStandardLoggerPanic(t *testing.T) {
 }
 
 func TestStandardLoggerFatal(t *testing.T) {
-	std, buf, err := newStd(zap.Info)
+	std, buf, err := newStd(zap.InfoLevel)
 	require.NoError(t, err, "Unexpected error standardizing a Logger.")
 
 	// Don't actually call os.Exit.


### PR DESCRIPTION
Rename all the `Level` constants from `Foo` to `FooLevel`, which allows
us to rename the `Err` field constructor to `Error`. This is a large bag
of changes, but they were all created with `gorename`.

Fixes #47.