### PR TITLE
Export field.AddTo to support wrappers

### DIFF
--- a/field.go
+++ b/field.go
@@ -148,7 +148,8 @@ func Nest(key string, fields ...Field) Field {
 	return Field{key: key, fieldType: marshalerType, obj: multiFields(fields)}
 }
 
-func (f Field) addTo(kv KeyValue) error {
+// AddTo exports a field through the KeyValue interface.
+func (f Field) AddTo(kv KeyValue) error {
 	switch f.fieldType {
 	case boolType:
 		kv.AddBool(f.key, f.ival == 1)
@@ -181,7 +182,7 @@ func (fs multiFields) MarshalLog(kv KeyValue) error {
 func addFields(kv KeyValue, fields []Field) error {
 	var errs multiError
 	for _, f := range fields {
-		if err := f.addTo(kv); err != nil {
+		if err := f.AddTo(kv); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/field_test.go
+++ b/field_test.go
@@ -46,7 +46,7 @@ func assertFieldJSON(t testing.TB, expected string, field Field) {
 	enc := newJSONEncoder()
 	defer enc.Free()
 
-	field.addTo(enc)
+	field.AddTo(enc)
 	assert.Equal(t, expected, string(enc.bytes),
 		"Unexpected JSON output after applying field %+v.", field)
 }
@@ -55,7 +55,7 @@ func assertNotEqualFieldJSON(t testing.TB, expected string, field Field) {
 	enc := newJSONEncoder()
 	defer enc.Free()
 
-	field.addTo(enc)
+	field.AddTo(enc)
 	assert.NotEqual(t, expected, string(enc.bytes),
 		"Unexpected JSON output after applying field %+v.", field)
 }
@@ -73,7 +73,7 @@ func assertCanBeReused(t testing.TB, field Field) {
 		go func() {
 			defer wg.Done()
 			assert.NotPanics(t, func() {
-				field.addTo(enc)
+				field.AddTo(enc)
 			}, "Reusing a field should not cause issues")
 		}()
 	}
@@ -167,7 +167,7 @@ func TestStackField(t *testing.T) {
 	enc := newJSONEncoder()
 	defer enc.Free()
 
-	Stack().addTo(enc)
+	Stack().AddTo(enc)
 	output := string(enc.bytes)
 
 	require.True(t, strings.HasPrefix(output, `"stacktrace":`), "Stacktrace added under an unexpected key.")
@@ -180,6 +180,6 @@ func TestUnknownField(t *testing.T) {
 
 	for _, ft := range []fieldType{unknownType, -42} {
 		field := Field{fieldType: ft}
-		assert.Panics(t, func() { field.addTo(enc) }, "Expected panic when using a field of unknown type.")
+		assert.Panics(t, func() { field.AddTo(enc) }, "Expected panic when using a field of unknown type.")
 	}
 }

--- a/hook.go
+++ b/hook.go
@@ -72,7 +72,7 @@ func AddCaller() Option {
 func AddStacks(lvl Level) Option {
 	return hook(func(msgLevel Level, msg string, kv KeyValue) (string, error) {
 		if msgLevel >= lvl {
-			Stack().addTo(kv)
+			Stack().AddTo(kv)
 		}
 		return msg, nil
 	})


### PR DESCRIPTION
Export `Field.addTo` so it can be used by external wrapper libraries.

(This is step 1 towards addressing #57.)