### PR TITLE
Add KeyValueMap, a KeyValue implemented backed by a map

### DIFF
--- a/zwrap/kvmap.go
+++ b/zwrap/kvmap.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zwrap
+
+import "github.com/uber-go/zap"
+
+// KeyValueMap implements zap.KeyValue backed by a map.
+type KeyValueMap map[string]interface{}
+
+// AddBool adds the value under the specified key to the map.
+func (m KeyValueMap) AddBool(k string, v bool) { m[k] = v }
+
+// AddFloat64 adds the value under the specified key to the map.
+func (m KeyValueMap) AddFloat64(k string, v float64) { m[k] = v }
+
+// AddInt adds the value under the specified key to the map.
+func (m KeyValueMap) AddInt(k string, v int) { m[k] = v }
+
+// AddInt64 adds the value under the specified key to the map.
+func (m KeyValueMap) AddInt64(k string, v int64) { m[k] = v }
+
+// AddObject adds the value under the specified key to the map.
+func (m KeyValueMap) AddObject(k string, v interface{}) { m[k] = v }
+
+// AddString adds the value under the specified key to the map.
+func (m KeyValueMap) AddString(k string, v string) { m[k] = v }
+
+// AddMarshaler adds the value under the specified key to the map.
+func (m KeyValueMap) AddMarshaler(k string, v zap.LogMarshaler) error {
+	return m.Nest(k, v.MarshalLog)
+}
+
+// Nest builds a object and adds the value under the specified key to the map.
+func (m KeyValueMap) Nest(k string, f func(zap.KeyValue) error) error {
+	newMap := make(KeyValueMap)
+	m[k] = newMap
+	return f(newMap)
+}

--- a/zwrap/kvmap_test.go
+++ b/zwrap/kvmap_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zwrap
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/zap"
+)
+
+type unloggable struct{}
+
+func (unloggable) MarshalLog(kv zap.KeyValue) error {
+	return errors.New("not loggable")
+}
+
+type loggable struct{}
+
+func (l loggable) MarshalLog(kv zap.KeyValue) error {
+	kv.AddString("loggable", "yes")
+	return nil
+}
+
+func TestKeyValueMapAdd(t *testing.T) {
+	arbitraryObj := map[string]interface{}{
+		"foo": "bar",
+		"baz": 5,
+	}
+
+	kv := KeyValueMap{}
+	kv.AddBool("b", true)
+	kv.AddFloat64("f64", 1.56)
+	kv.AddInt("int", 5)
+	kv.AddInt64("i64", math.MaxInt64)
+	kv.AddString("s", "string")
+	kv.AddObject("obj", arbitraryObj)
+
+	assert.NoError(t, kv.AddMarshaler("m1", loggable{}), "AddMarshaler failed")
+	assert.NoError(t, kv.Nest("m2", loggable{}.MarshalLog), "Nest failed")
+
+	want := KeyValueMap{
+		"b":   true,
+		"f64": 1.56,
+		"int": 5,
+		"i64": int64(math.MaxInt64),
+		"s":   "string",
+		"obj": arbitraryObj,
+		"m1": KeyValueMap{
+			"loggable": "yes",
+		},
+		"m2": KeyValueMap{
+			"loggable": "yes",
+		},
+	}
+	assert.Equal(t, want, kv, "Unexpected result")
+}
+
+func TestKeyValueMapAddFails(t *testing.T) {
+	kv := KeyValueMap{}
+
+	assert.Error(t, kv.AddMarshaler("m1", unloggable{}), "AddMarshaler should fail")
+	assert.Error(t, kv.Nest("m2", unloggable{}.MarshalLog), "Nest should fail")
+	assert.Equal(t, KeyValueMap{
+		"m1": KeyValueMap{},
+		"m2": KeyValueMap{},
+	}, kv, "Empty values on errors")
+}


### PR DESCRIPTION
This is a useful utility when testing custom MarhsalLog implementations

cc @billf: Can you make sure that this works for you to use in #85 