### PR TITLE
Remove AllLevel and NoneLevel

### DIFF
--- a/benchmarks/logrus_bench_test.go
+++ b/benchmarks/logrus_bench_test.go
@@ -63,7 +63,7 @@ func BenchmarkLogrusAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapBarkifyAddingFields(b *testing.B) {
-	logger := zbark.Barkify(zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard)))
+	logger := zbark.Barkify(zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard)))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -106,7 +106,7 @@ func BenchmarkLogrusWithAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapBarkifyWithAccumulatedContext(b *testing.B) {
-	baseLogger := zbark.Barkify(zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard)))
+	baseLogger := zbark.Barkify(zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard)))
 	logger := baseLogger.WithFields(bark.Fields{
 		"int":               1,
 		"int64":             int64(1),

--- a/benchmarks/stdlib_bench_test.go
+++ b/benchmarks/stdlib_bench_test.go
@@ -41,7 +41,7 @@ func BenchmarkStandardLibraryWithoutFields(b *testing.B) {
 
 func BenchmarkZapStandardizeWithoutFields(b *testing.B) {
 	logger, err := zwrap.Standardize(
-		zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard)),
+		zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard)),
 		zap.InfoLevel,
 	)
 	if err != nil {

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -118,7 +118,7 @@ func BenchmarkZapDisabledLevelsCheckAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapAddingFields(b *testing.B) {
-	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
+	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -129,7 +129,7 @@ func BenchmarkZapAddingFields(b *testing.B) {
 
 func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 	context := fakeFields()
-	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard), zap.Fields(context...))
+	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard), zap.Fields(context...))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -139,7 +139,7 @@ func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapWithoutFields(b *testing.B) {
-	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
+	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -150,7 +150,7 @@ func BenchmarkZapWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleWithoutFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
+	base := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -164,7 +164,7 @@ func BenchmarkZapSampleWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleAddingFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
+	base := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -178,7 +178,7 @@ func BenchmarkZapSampleAddingFields(b *testing.B) {
 
 func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
+	base := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -194,7 +194,7 @@ func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleCheckAddingFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
+	base := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/hook_test.go
+++ b/hook_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestHookAddCaller(t *testing.T) {
 	buf := newTestBuffer()
-	logger := NewJSON(AllLevel, Output(buf), AddCaller())
+	logger := NewJSON(DebugLevel, Output(buf), AddCaller())
 	logger.Info("Callers.")
 
 	re := regexp.MustCompile(`"msg":"hook_test.go:[\d]+: Callers\."`)
@@ -45,7 +45,7 @@ func TestHookAddCallerFail(t *testing.T) {
 	_callerSkip = 1e3
 	defer func() { _callerSkip = originalSkip }()
 
-	logger := NewJSON(AllLevel, Output(buf), ErrorOutput(errBuf), AddCaller())
+	logger := NewJSON(DebugLevel, Output(buf), ErrorOutput(errBuf), AddCaller())
 	logger.Info("Failure.")
 	assert.Equal(t, "failed to get caller\n", errBuf.String(), "Didn't find expected failure message.")
 	assert.Contains(t, buf.String(), `"msg":"Failure."`, "Expected original message to survive failures in runtime.Caller.")
@@ -53,7 +53,7 @@ func TestHookAddCallerFail(t *testing.T) {
 
 func TestHookAddStacks(t *testing.T) {
 	buf := newTestBuffer()
-	logger := NewJSON(AllLevel, Output(buf), AddStacks(InfoLevel))
+	logger := NewJSON(DebugLevel, Output(buf), AddStacks(InfoLevel))
 
 	logger.Info("Stacks.")
 	output := buf.String()

--- a/level.go
+++ b/level.go
@@ -23,7 +23,6 @@ package zap
 import (
 	"errors"
 	"fmt"
-	"math"
 )
 
 var errMarshalNilLevel = errors.New("can't marshal a nil *Level to text")
@@ -50,11 +49,6 @@ const (
 	PanicLevel
 	// FatalLevel logs a message, then calls os.Exit(1).
 	FatalLevel
-
-	// allLevel logs everything.
-	allLevel Level = math.MinInt32
-	// noneLevel silences logging completely.
-	noneLevel Level = math.MaxInt32
 )
 
 // String returns a lower-case ASCII representation of the log level.

--- a/level.go
+++ b/level.go
@@ -51,17 +51,15 @@ const (
 	// FatalLevel logs a message, then calls os.Exit(1).
 	FatalLevel
 
-	// AllLevel logs everything.
-	AllLevel Level = math.MinInt32
-	// NoneLevel silences logging completely.
-	NoneLevel Level = math.MaxInt32
+	// allLevel logs everything.
+	allLevel Level = math.MinInt32
+	// noneLevel silences logging completely.
+	noneLevel Level = math.MaxInt32
 )
 
 // String returns a lower-case ASCII representation of the log level.
 func (l Level) String() string {
 	switch l {
-	case AllLevel:
-		return "all"
 	case DebugLevel:
 		return "debug"
 	case InfoLevel:
@@ -74,8 +72,6 @@ func (l Level) String() string {
 		return "panic"
 	case FatalLevel:
 		return "fatal"
-	case NoneLevel:
-		return "none"
 	default:
 		return fmt.Sprintf("Level(%d)", l)
 	}
@@ -98,8 +94,6 @@ func (l *Level) MarshalText() ([]byte, error) {
 // TOML, or JSON files.
 func (l *Level) UnmarshalText(text []byte) error {
 	switch string(text) {
-	case "all":
-		*l = AllLevel
 	case "debug":
 		*l = DebugLevel
 	case "info":
@@ -112,8 +106,6 @@ func (l *Level) UnmarshalText(text []byte) error {
 		*l = PanicLevel
 	case "fatal":
 		*l = FatalLevel
-	case "none":
-		*l = NoneLevel
 	default:
 		return fmt.Errorf("unrecognized level: %v", string(text))
 	}

--- a/level_test.go
+++ b/level_test.go
@@ -21,8 +21,6 @@
 package zap
 
 import (
-	"fmt"
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,8 +34,6 @@ func TestLevelString(t *testing.T) {
 		ErrorLevel: "error",
 		PanicLevel: "panic",
 		FatalLevel: "fatal",
-		allLevel:   fmt.Sprintf("Level(%d)", math.MinInt32),
-		noneLevel:  fmt.Sprintf("Level(%d)", math.MaxInt32),
 		Level(-42): "Level(-42)",
 	}
 

--- a/level_test.go
+++ b/level_test.go
@@ -21,6 +21,8 @@
 package zap
 
 import (
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,14 +30,14 @@ import (
 
 func TestLevelString(t *testing.T) {
 	tests := map[Level]string{
-		AllLevel:   "all",
 		DebugLevel: "debug",
 		InfoLevel:  "info",
 		WarnLevel:  "warn",
 		ErrorLevel: "error",
 		PanicLevel: "panic",
 		FatalLevel: "fatal",
-		NoneLevel:  "none",
+		allLevel:   fmt.Sprintf("Level(%d)", math.MinInt32),
+		noneLevel:  fmt.Sprintf("Level(%d)", math.MaxInt32),
 		Level(-42): "Level(-42)",
 	}
 
@@ -49,14 +51,12 @@ func TestLevelText(t *testing.T) {
 		text  string
 		level Level
 	}{
-		{"all", AllLevel},
 		{"debug", DebugLevel},
 		{"info", InfoLevel},
 		{"warn", WarnLevel},
 		{"error", ErrorLevel},
 		{"panic", PanicLevel},
 		{"fatal", FatalLevel},
-		{"none", NoneLevel},
 	}
 	for _, tt := range tests {
 		lvl := tt.level

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -48,7 +48,7 @@ var _jane = &user{
 }
 
 func withBenchedLogger(b *testing.B, f func(zap.Logger)) {
-	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
+	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -169,7 +169,7 @@ func Benchmark10Fields(b *testing.B) {
 
 func Benchmark100Fields(b *testing.B) {
 	const batchSize = 50
-	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.Discard))
+	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
 
 	// Don't include allocating these helper slices in the benchmark. Since
 	// access to them isn't synchronized, we can't run the benchmark in

--- a/logger_test.go
+++ b/logger_test.go
@@ -66,7 +66,7 @@ func withJSONLogger(t testing.TB, opts []Option, f func(*jsonLogger, func() []st
 	errSink := newTestBuffer()
 
 	allOpts := make([]Option, 0, 3+len(opts))
-	allOpts = append(allOpts, AllLevel, Output(sink), ErrorOutput(errSink))
+	allOpts = append(allOpts, DebugLevel, Output(sink), ErrorOutput(errSink))
 	allOpts = append(allOpts, opts...)
 	jl := NewJSON(allOpts...)
 	jl.StubTime()
@@ -94,7 +94,7 @@ func assertFields(t testing.TB, jl Logger, getOutput func() []string, expectedFi
 
 func TestJSONLoggerSetLevel(t *testing.T) {
 	withJSONLogger(t, nil, func(jl *jsonLogger, _ func() []string) {
-		assert.Equal(t, AllLevel, jl.Level(), "Unexpected initial level.")
+		assert.Equal(t, DebugLevel, jl.Level(), "Unexpected initial level.")
 		jl.SetLevel(DebugLevel)
 		assert.Equal(t, DebugLevel, jl.Level(), "Unexpected level after SetLevel.")
 	})
@@ -239,7 +239,7 @@ func TestJSONLoggerInternalErrorHandling(t *testing.T) {
 	buf := newTestBuffer()
 	errBuf := newTestBuffer()
 
-	jl := NewJSON(AllLevel, Output(buf), ErrorOutput(errBuf), Fields(Marshaler("user", fakeUser{"fail"})))
+	jl := NewJSON(DebugLevel, Output(buf), ErrorOutput(errBuf), Fields(Marshaler("user", fakeUser{"fail"})))
 	jl.StubTime()
 	output := func() []string { return strings.Split(buf.String(), "\n") }
 
@@ -253,7 +253,7 @@ func TestJSONLoggerInternalErrorHandling(t *testing.T) {
 func TestJSONLoggerWriteMessageFailure(t *testing.T) {
 	errBuf := &bytes.Buffer{}
 	errSink := &spywrite.WriteSyncer{Writer: errBuf}
-	logger := NewJSON(AllLevel, Output(AddSync(spywrite.FailWriter{})), ErrorOutput(errSink))
+	logger := NewJSON(DebugLevel, Output(AddSync(spywrite.FailWriter{})), ErrorOutput(errSink))
 
 	logger.Info("foo")
 	// Should log the error.
@@ -281,7 +281,7 @@ func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
 
 func TestJSONLoggerSyncsOutput(t *testing.T) {
 	sink := &spywrite.WriteSyncer{Writer: ioutil.Discard}
-	logger := NewJSON(AllLevel, Output(sink))
+	logger := NewJSON(DebugLevel, Output(sink))
 
 	logger.Error("foo")
 	assert.False(t, sink.Called(), "Didn't expect logging at error level to Sync underlying WriteCloser.")

--- a/zbark/bark_test.go
+++ b/zbark/bark_test.go
@@ -59,7 +59,7 @@ func (l loggable) MarshalLog(kv zap.KeyValue) error {
 
 func newBark() (bark.Logger, *bytes.Buffer) {
 	buf := &bytes.Buffer{}
-	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.AddSync(buf)))
+	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.AddSync(buf)))
 	return Barkify(logger), buf
 }
 

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -38,7 +38,7 @@ func WithIter(l zap.Logger, n int) zap.Logger {
 
 func fakeSampler(tick time.Duration, first, thereafter int, development bool) (zap.Logger, *spy.Sink) {
 	base, sink := spy.New()
-	base.SetLevel(zap.AllLevel)
+	base.SetLevel(zap.DebugLevel)
 	base.SetDevelopment(development)
 	sampler := Sample(base, tick, first, thereafter)
 	return sampler, sink

--- a/zwrap/standard_test.go
+++ b/zwrap/standard_test.go
@@ -33,13 +33,13 @@ import (
 
 func newStd(lvl zap.Level) (StandardLogger, *bytes.Buffer, error) {
 	buf := &bytes.Buffer{}
-	logger := zap.NewJSON(zap.AllLevel, zap.Output(zap.AddSync(buf)))
+	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.AddSync(buf)))
 	std, err := Standardize(logger, lvl)
 	return std, buf, err
 }
 
 func TestStandardizeInvalidLevels(t *testing.T) {
-	for _, level := range []zap.Level{zap.AllLevel, zap.PanicLevel, zap.FatalLevel, zap.NoneLevel, zap.Level(42)} {
+	for _, level := range []zap.Level{zap.PanicLevel, zap.FatalLevel, zap.Level(42)} {
 		_, _, err := newStd(level)
 		assert.Equal(t, ErrInvalidLevel, err, "Expected ErrInvalidLevel when passing an invalid level to Standardize.")
 	}


### PR DESCRIPTION
Before opening your pull request, please make sure that you've:

- [x] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [x] added tests to cover your changes;
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).

These don't add any user-facing value over `DebugLevel` and `FatalLevel`. Keep the package API small and remove them.

Fixes #80.