### PR TITLE
Add Base64 field for encoding byte slices

### DIFF
--- a/field.go
+++ b/field.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"encoding/base64"
 	"fmt"
 	"math"
 	"time"
@@ -55,6 +56,12 @@ type Field struct {
 // Skip constructs a no-op Field.
 func Skip() Field {
 	return Field{fieldType: skipType}
+}
+
+// Base64 constructs a field that encodes the given value as a
+// padded base64 string.
+func Base64(key string, val []byte) Field {
+	return String(key, base64.StdEncoding.EncodeToString(val))
 }
 
 // Bool constructs a Field with the given key and value.

--- a/field.go
+++ b/field.go
@@ -59,7 +59,8 @@ func Skip() Field {
 }
 
 // Base64 constructs a field that encodes the given value as a
-// padded base64 string.
+// padded base64 string. The byte slice is converted to a base64
+// string immediately.
 func Base64(key string, val []byte) Field {
 	return String(key, base64.StdEncoding.EncodeToString(val))
 }

--- a/field_test.go
+++ b/field_test.go
@@ -172,6 +172,13 @@ func TestNestField(t *testing.T) {
 	assertCanBeReused(t, nest)
 }
 
+func TestBase64Field(t *testing.T) {
+	assertFieldJSON(t, `"foo":"YWIxMg=="`,
+		Base64("foo", []byte("ab12")),
+	)
+	assertCanBeReused(t, Base64("foo", []byte("bar")))
+}
+
 func TestLogMarshalerFunc(t *testing.T) {
 	assertFieldJSON(t, `"foo":{"name":"phil"}`,
 		Marshaler("foo", LogMarshalerFunc(fakeUser{"phil"}.MarshalLog)))


### PR DESCRIPTION
The `Base64` field encodes the byte slice into a base64 string (with padding).

The data is encoded immediately for a couple of reasons:
 - all other primitive types (ints, strings, etc.) are either immutable or the value is copied. Since byte slices are mutable, if we kept a reference around, it may change between creating the field and encoding the value.
 - we don't want to add yet another union field to the `Field` type. We could store the contents as a `string` but we'd either need to do a full copy of the contents, or use unsafe to create a string out of the byte slice.

Fixes #97 
