### PR TITLE
Always use grade-school notation for floats

### DIFF
--- a/field.go
+++ b/field.go
@@ -75,9 +75,8 @@ func Bool(key string, val bool) Field {
 	return Field{key: key, fieldType: boolType, ival: ival}
 }
 
-// Float64 constructs a Field with the given key and value. The floating-point
-// value is encoded using strconv.FormatFloat's 'g' option (exponential notation
-// for large exponents, grade-school notation otherwise).
+// Float64 constructs a Field with the given key and value. The way the
+// floating-point value is represented is encoder-dependent.
 func Float64(key string, val float64) Field {
 	return Field{key: key, fieldType: floatType, ival: int64(math.Float64bits(val))}
 }

--- a/json_encoder.go
+++ b/json_encoder.go
@@ -106,8 +106,8 @@ func (enc *jsonEncoder) AddInt64(key string, val int64) {
 
 // AddFloat64 adds a string key and float64 value to the encoder's fields. The
 // key is JSON-escaped, and the floating-point value is encoded using
-// strconv.FormatFloat's 'g' option (exponential notation for large exponents,
-// grade-school notation otherwise).
+// strconv.FormatFloat's 'f' option (always use grade-school notation, even for
+// large exponents).
 func (enc *jsonEncoder) AddFloat64(key string, val float64) {
 	enc.addKey(key)
 	switch {
@@ -118,13 +118,11 @@ func (enc *jsonEncoder) AddFloat64(key string, val float64) {
 	case math.IsInf(val, -1):
 		enc.bytes = append(enc.bytes, `"-Inf"`...)
 	default:
-		enc.bytes = strconv.AppendFloat(enc.bytes, val, 'g', -1, 64)
+		enc.bytes = strconv.AppendFloat(enc.bytes, val, 'f', -1, 64)
 	}
 }
 
 // AddMarshaler adds a LogMarshaler to the encoder's fields.
-//
-// TODO: Encode the error into the message instead of returning.
 func (enc *jsonEncoder) AddMarshaler(key string, obj LogMarshaler) error {
 	enc.addKey(key)
 	enc.bytes = append(enc.bytes, '{')

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -103,7 +103,7 @@ func TestJSONAddInt64(t *testing.T) {
 func TestJSONAddFloat64(t *testing.T) {
 	withJSONEncoder(func(enc *jsonEncoder) {
 		enc.AddFloat64("baz", 1e10)
-		assertJSON(t, `"foo":"bar","baz":1e+10`, enc)
+		assertJSON(t, `"foo":"bar","baz":10000000000`, enc)
 
 		// Keys should be escaped.
 		enc.truncate()


### PR DESCRIPTION
In JSON output, always use grade-school notation for floats. Exponential
notation is allowed by the JSON spec, but this is more obviously
correct (and it matches the desired behavior for timestamps, which will
soon use float fields).