### PR TITLE
Add options for JSON encoders

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -20,7 +20,10 @@
 
 package zap
 
-import "io"
+import (
+	"io"
+	"time"
+)
 
 // encoder is a format-agnostic interface for all log field encoders. It's not
 // safe for concurrent use.
@@ -30,5 +33,5 @@ type encoder interface {
 	AddFields([]Field)
 	Clone() encoder
 	Free()
-	WriteEntry(io.Writer, *Entry) error
+	WriteEntry(io.Writer, string, Level, time.Time) error
 }

--- a/json_encoder.go
+++ b/json_encoder.go
@@ -28,6 +28,7 @@ import (
 	"math"
 	"strconv"
 	"sync"
+	"time"
 	"unicode/utf8"
 )
 
@@ -39,10 +40,13 @@ const (
 )
 
 var (
-	// errNilEntry signals that Encoder.WriteEntry was called with a nil *Entry.
-	errNilEntry = errors.New("can't encode a nil *Entry")
 	// errNilSink signals that Encoder.WriteEntry was called with a nil WriteSyncer.
 	errNilSink = errors.New("can't write encoded message a nil WriteSyncer")
+
+	// Default formatters for JSON encoders.
+	defaultMessageF = MessageKey("msg")
+	defaultTimeF    = EpochFormatter("ts")
+	defaultLevelF   = LevelString("level")
 
 	jsonPool = sync.Pool{New: func() interface{} {
 		return &jsonEncoder{
@@ -54,14 +58,25 @@ var (
 
 // jsonEncoder is a logging-optimized JSON encoder.
 type jsonEncoder struct {
-	bytes []byte
+	bytes    []byte
+	messageF MessageFormatter
+	timeF    TimeFormatter
+	levelF   LevelFormatter
 }
 
 // newJSONEncoder creates an encoder, re-using one from the pool if possible. The
 // returned encoder is initialized and ready for use.
-func newJSONEncoder() *jsonEncoder {
+func newJSONEncoder(options ...JSONOption) *jsonEncoder {
 	enc := jsonPool.Get().(*jsonEncoder)
 	enc.truncate()
+
+	enc.messageF = defaultMessageF
+	enc.timeF = defaultTimeF
+	enc.levelF = defaultLevelF
+	for _, opt := range options {
+		opt.Apply(enc)
+	}
+
 	return enc
 }
 
@@ -144,8 +159,12 @@ func (enc *jsonEncoder) AddObject(key string, obj interface{}) error {
 
 // Clone copies the current encoder, including any data already encoded.
 func (enc *jsonEncoder) Clone() encoder {
-	clone := newJSONEncoder()
+	clone := jsonPool.Get().(*jsonEncoder)
+	clone.truncate()
 	clone.bytes = append(clone.bytes, enc.bytes...)
+	clone.messageF = enc.messageF
+	clone.timeF = enc.timeF
+	clone.levelF = enc.levelF
 	return clone
 }
 
@@ -158,37 +177,37 @@ func (enc *jsonEncoder) AddFields(fields []Field) {
 // the encoder's accumulated fields. It doesn't modify or lock the encoder's
 // underlying byte slice. It's safe to call from multiple goroutines, but it's
 // not safe to call WriteEntry while adding fields.
-func (enc *jsonEncoder) WriteEntry(sink io.Writer, e *Entry) error {
+func (enc *jsonEncoder) WriteEntry(sink io.Writer, msg string, lvl Level, t time.Time) error {
 	if sink == nil {
 		return errNilSink
 	}
-	if e == nil {
-		return errNilEntry
-	}
-	// Grab an encoder from the pool so that we can re-use the underlying
-	// buffer.
-	final := newJSONEncoder()
-	defer final.Free()
 
-	final.bytes = append(final.bytes, `{"msg":"`...)
-	final.safeAddString(e.Message)
-	final.bytes = append(final.bytes, `","level":"`...)
-	final.bytes = append(final.bytes, e.Level.String()...)
-	final.bytes = append(final.bytes, `","ts":`...)
-	final.bytes = strconv.AppendFloat(final.bytes, timeToSeconds(e.Time), 'f', -1, 64)
+	final := enc.Clone().(*jsonEncoder)
+
+	// TODO: When we flatten the serialized messages, remove the extra truncate
+	// and copy below. This will change the shape of the serialized message, which
+	// will require updating many tests.
+	final.truncate()
+	final.bytes = append(final.bytes, '{')
+	final.AddFields([]Field{
+		final.messageF(msg),
+		final.levelF(lvl),
+		final.timeF(t),
+	})
 	final.bytes = append(final.bytes, `,"fields":{`...)
-	if e.enc != nil {
-		final.bytes = append(final.bytes, e.enc.(*jsonEncoder).bytes...)
-	}
+	final.bytes = append(final.bytes, enc.bytes...)
 	final.bytes = append(final.bytes, "}}\n"...)
 
 	n, err := sink.Write(final.bytes)
 	if err != nil {
+		final.Free()
 		return err
 	}
 	if n != len(final.bytes) {
+		final.Free()
 		return fmt.Errorf("incomplete write: only wrote %v of %v bytes", n, len(final.bytes))
 	}
+	final.Free()
 	return nil
 }
 

--- a/json_encoder_bench_test.go
+++ b/json_encoder_bench_test.go
@@ -53,7 +53,7 @@ func BenchmarkLogMarshalerFunc(b *testing.B) {
 }
 
 func BenchmarkZapJSON(b *testing.B) {
-	e := &Entry{Level: DebugLevel, Message: "fake", Time: time.Unix(0, 0)}
+	ts := time.Unix(0, 0)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			enc := newJSONEncoder()
@@ -66,7 +66,7 @@ func BenchmarkZapJSON(b *testing.B) {
 			enc.AddString("string3", "🤔")
 			enc.AddString("string4", "🙊")
 			enc.AddBool("bool", true)
-			enc.WriteEntry(ioutil.Discard, e)
+			enc.WriteEntry(ioutil.Discard, "fake", DebugLevel, ts)
 			enc.Free()
 		}
 	})

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -270,17 +270,20 @@ func TestJSONJSONEscaping(t *testing.T) {
 }
 
 func TestJSONOptions(t *testing.T) {
-	enc := newJSONEncoder(
+	root := newJSONEncoder(
 		MessageKey("the-message"),
 		LevelString("the-level"),
 		RFC3339Formatter("the-timestamp"),
 	)
-	buf := &bytes.Buffer{}
-	enc.WriteEntry(buf, "fake msg", DebugLevel, time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC))
-	assert.Equal(
-		t,
-		`{"the-message":"fake msg","the-level":"debug","the-timestamp":"1970-01-01T00:00:00Z","fields":{}}`+"\n",
-		buf.String(),
-		"Unexpected log output with non-default encoder options.",
-	)
+
+	for _, enc := range []encoder{root, root.Clone()} {
+		buf := &bytes.Buffer{}
+		enc.WriteEntry(buf, "fake msg", DebugLevel, time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC))
+		assert.Equal(
+			t,
+			`{"the-message":"fake msg","the-level":"debug","the-timestamp":"1970-01-01T00:00:00Z","fields":{}}`+"\n",
+			buf.String(),
+			"Unexpected log output with non-default encoder options.",
+		)
+	}
 }

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -128,14 +128,17 @@ func TestJSONAddFloat64(t *testing.T) {
 func TestJSONWriteEntry(t *testing.T) {
 	withJSONEncoder(func(enc *jsonEncoder) {
 		sink := bytes.NewBuffer(nil)
+		entry := &Entry{Level: InfoLevel, Message: `hello\`, Time: time.Unix(0, 0)}
 
-		assert.Equal(t, errNilSink, enc.WriteEntry(nil, &Entry{}), "Expected an error writing to a nil sink.")
-
-		assert.Equal(t, errNilEntry, enc.WriteEntry(sink, nil), "Expected an error writing a nil message.")
-		assert.Equal(t, "", sink.String(), "Unexpected output after writing nil message.")
+		assert.Equal(t, errNilSink, enc.WriteEntry(
+			nil,
+			entry.Message,
+			entry.Level,
+			entry.Time,
+		), "Expected an error writing to a nil sink.")
 
 		// Messages should be escaped.
-		err := enc.WriteEntry(sink, &Entry{Level: InfoLevel, Message: `hello\`, Time: time.Unix(0, 0), enc: enc})
+		err := enc.WriteEntry(sink, entry.Message, entry.Level, entry.Time)
 		assert.NoError(t, err, "WriteEntry returned an unexpected error.")
 		assert.Equal(t,
 			`{"msg":"hello\\","level":"info","ts":0,"fields":{"foo":"bar"}}`,
@@ -145,10 +148,10 @@ func TestJSONWriteEntry(t *testing.T) {
 		// We should be able to re-use the encoder, preserving the accumulated
 		// fields.
 		sink.Reset()
-		err = enc.WriteEntry(sink, &Entry{Level: DebugLevel, Message: "fake msg", Time: time.Unix(100, 0), enc: enc})
+		err = enc.WriteEntry(sink, entry.Message, entry.Level, time.Unix(100, 0))
 		assert.NoError(t, err, "WriteEntry returned an unexpected error.")
 		assert.Equal(t,
-			`{"msg":"fake msg","level":"debug","ts":100,"fields":{"foo":"bar"}}`,
+			`{"msg":"hello\\","level":"info","ts":100,"fields":{"foo":"bar"}}`,
 			strings.TrimRight(sink.String(), "\n"),
 		)
 	})
@@ -159,8 +162,7 @@ func TestJSONWriteEntryLargeTimestamps(t *testing.T) {
 	withJSONEncoder(func(enc *jsonEncoder) {
 		sink := &bytes.Buffer{}
 		future := time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC)
-		entry := &Entry{Level: DebugLevel, Message: "fake msg", Time: future, enc: enc}
-		require.NoError(t, enc.WriteEntry(sink, entry))
+		require.NoError(t, enc.WriteEntry(sink, "fake msg", DebugLevel, future))
 		assert.Contains(t,
 			sink.String(),
 			`"ts":4102444800,`,
@@ -220,7 +222,7 @@ func TestJSONWriteEntryFailure(t *testing.T) {
 			{spywrite.ShortWriter{}, "Expected an error on partial writes to sink."},
 		}
 		for _, tt := range tests {
-			err := enc.WriteEntry(tt.sink, &Entry{Level: InfoLevel, Message: "hello", Time: time.Unix(0, 0), enc: enc})
+			err := enc.WriteEntry(tt.sink, "hello", InfoLevel, time.Unix(0, 0))
 			assert.Error(t, err, tt.msg)
 		}
 	})
@@ -265,4 +267,20 @@ func TestJSONJSONEscaping(t *testing.T) {
 		enc.safeAddString(input)
 		assertJSON(t, output, enc)
 	}
+}
+
+func TestJSONOptions(t *testing.T) {
+	enc := newJSONEncoder(
+		MessageKey("the-message"),
+		LevelString("the-level"),
+		RFC3339Formatter("the-timestamp"),
+	)
+	buf := &bytes.Buffer{}
+	enc.WriteEntry(buf, "fake msg", DebugLevel, time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC))
+	assert.Equal(
+		t,
+		`{"the-message":"fake msg","the-level":"debug","the-timestamp":"1970-01-01T00:00:00Z","fields":{}}`+"\n",
+		buf.String(),
+		"Unexpected log output with non-default encoder options.",
+	)
 }

--- a/json_options.go
+++ b/json_options.go
@@ -4,14 +4,13 @@ import "time"
 
 // JSONOption is used to set options for a JSON encoder.
 type JSONOption interface {
-	Apply(*jsonEncoder)
+	apply(*jsonEncoder)
 }
 
 // A MessageFormatter defines how to convert a log message into a Field.
 type MessageFormatter func(string) Field
 
-// Apply implements JSONOption.
-func (mf MessageFormatter) Apply(enc *jsonEncoder) {
+func (mf MessageFormatter) apply(enc *jsonEncoder) {
 	enc.messageF = mf
 }
 
@@ -22,19 +21,10 @@ func MessageKey(key string) MessageFormatter {
 	})
 }
 
-// NoMessage drops the message field altogether. It's sometimes useful for
-// testing.
-func NoMessage() MessageFormatter {
-	return MessageFormatter(func(_ string) Field {
-		return Skip()
-	})
-}
-
 // A TimeFormatter defines how to convert the time of a log entry into a Field.
 type TimeFormatter func(time.Time) Field
 
-// Apply implements JSONOption.
-func (tf TimeFormatter) Apply(enc *jsonEncoder) {
+func (tf TimeFormatter) apply(enc *jsonEncoder) {
 	enc.timeF = tf
 }
 
@@ -66,8 +56,7 @@ func NoTime() TimeFormatter {
 // Field.
 type LevelFormatter func(Level) Field
 
-// Apply implements JSONOption.
-func (lf LevelFormatter) Apply(enc *jsonEncoder) {
+func (lf LevelFormatter) apply(enc *jsonEncoder) {
 	enc.levelF = lf
 }
 
@@ -76,13 +65,5 @@ func (lf LevelFormatter) Apply(enc *jsonEncoder) {
 func LevelString(key string) LevelFormatter {
 	return LevelFormatter(func(l Level) Field {
 		return String(key, l.String())
-	})
-}
-
-// NoLevel drops the entry's log level altogether. It's occasionally useful in
-// testing.
-func NoLevel() LevelFormatter {
-	return LevelFormatter(func(_ Level) Field {
-		return Skip()
 	})
 }

--- a/json_options.go
+++ b/json_options.go
@@ -71,7 +71,7 @@ func (lf LevelFormatter) Apply(enc *jsonEncoder) {
 	enc.levelF = lf
 }
 
-// LevelKey encodes the entry's level under the provided key. It uses the
+// LevelString encodes the entry's level under the provided key. It uses the
 // level's String method to serialize it.
 func LevelString(key string) LevelFormatter {
 	return LevelFormatter(func(l Level) Field {

--- a/json_options.go
+++ b/json_options.go
@@ -1,0 +1,88 @@
+package zap
+
+import "time"
+
+// JSONOption is used to set options for a JSON encoder.
+type JSONOption interface {
+	Apply(*jsonEncoder)
+}
+
+// A MessageFormatter defines how to convert a log message into a Field.
+type MessageFormatter func(string) Field
+
+// Apply implements JSONOption.
+func (mf MessageFormatter) Apply(enc *jsonEncoder) {
+	enc.messageF = mf
+}
+
+// MessageKey encodes log messages under the provided key.
+func MessageKey(key string) MessageFormatter {
+	return MessageFormatter(func(msg string) Field {
+		return String(key, msg)
+	})
+}
+
+// NoMessage drops the message field altogether. It's sometimes useful for
+// testing.
+func NoMessage() MessageFormatter {
+	return MessageFormatter(func(_ string) Field {
+		return Skip()
+	})
+}
+
+// A TimeFormatter defines how to convert the time of a log entry into a Field.
+type TimeFormatter func(time.Time) Field
+
+// Apply implements JSONOption.
+func (tf TimeFormatter) Apply(enc *jsonEncoder) {
+	enc.timeF = tf
+}
+
+// EpochFormatter uses the Time field (floating-point seconds since epoch) to
+// encode the entry time under the provided key.
+func EpochFormatter(key string) TimeFormatter {
+	return TimeFormatter(func(t time.Time) Field {
+		return Time(key, t)
+	})
+}
+
+// RFC3339Formatter encodes the entry time as an RFC3339-formatted string under
+// the provided key.
+func RFC3339Formatter(key string) TimeFormatter {
+	return TimeFormatter(func(t time.Time) Field {
+		return String(key, t.Format(time.RFC3339))
+	})
+}
+
+// NoTime drops the entry time altogether. It's often useful in testing, since
+// it removes the need to stub time.Now.
+func NoTime() TimeFormatter {
+	return TimeFormatter(func(_ time.Time) Field {
+		return Skip()
+	})
+}
+
+// A LevelFormatter defines how to convert an entry's logging level into a
+// Field.
+type LevelFormatter func(Level) Field
+
+// Apply implements JSONOption.
+func (lf LevelFormatter) Apply(enc *jsonEncoder) {
+	enc.levelF = lf
+}
+
+// LevelKey encodes the entry's level under the provided key. It uses the
+// level's String method to serialize it.
+func LevelString(key string) LevelFormatter {
+	return LevelFormatter(func(l Level) Field {
+		return String(key, l.String())
+	})
+}
+
+// NoLevel drops the entry's log level altogether. It's occasionally useful in
+// testing.
+func NoLevel() LevelFormatter {
+	return LevelFormatter(func(_ Level) Field {
+		return Skip()
+	})
+}

--- a/json_options_test.go
+++ b/json_options_test.go
@@ -16,7 +16,6 @@ func TestMessageFormatters(t *testing.T) {
 		expected  Field
 	}{
 		{"MessageKey", MessageKey("the-message"), String("the-message", msg)},
-		{"NoMessage", NoMessage(), Skip()},
 		{"Default", defaultMessageF, String("msg", msg)},
 	}
 
@@ -52,7 +51,6 @@ func TestLevelFormatters(t *testing.T) {
 		expected  Field
 	}{
 		{"LevelString", LevelString("the-level"), String("the-level", "info")},
-		{"NoLevel", NoLevel(), Skip()},
 		{"Default", defaultLevelF, String("level", "info")},
 	}
 

--- a/json_options_test.go
+++ b/json_options_test.go
@@ -1,0 +1,62 @@
+package zap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessageFormatters(t *testing.T) {
+	const msg = "foo"
+
+	tests := []struct {
+		name      string
+		formatter MessageFormatter
+		expected  Field
+	}{
+		{"MessageKey", MessageKey("the-message"), String("the-message", msg)},
+		{"NoMessage", NoMessage(), Skip()},
+		{"Default", defaultMessageF, String("msg", msg)},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.formatter(msg), "Unexpected output from MessageFormatter %s.", tt.name)
+	}
+}
+
+func TestTimeFormatters(t *testing.T) {
+	ts := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		formatter TimeFormatter
+		expected  Field
+	}{
+		{"EpochFormatter", EpochFormatter("the-time"), Float64("the-time", 0)},
+		{"RFC3339", RFC3339Formatter("ts"), String("ts", "1970-01-01T00:00:00Z")},
+		{"NoTime", NoTime(), Skip()},
+		{"Default", defaultTimeF, Float64("ts", 0)},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.formatter(ts), "Unexpected output from TimeFormatter %s.", tt.name)
+	}
+}
+
+func TestLevelFormatters(t *testing.T) {
+	const lvl = InfoLevel
+	tests := []struct {
+		name      string
+		formatter LevelFormatter
+		expected  Field
+	}{
+		{"LevelString", LevelString("the-level"), String("the-level", "info")},
+		{"NoLevel", NoLevel(), Skip()},
+		{"Default", defaultLevelF, String("level", "info")},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.formatter(lvl), "Unexpected output from LevelFormatter %s.", tt.name)
+	}
+}

--- a/logger.go
+++ b/logger.go
@@ -174,7 +174,7 @@ func (jl *jsonLogger) log(lvl Level, msg string, fields []Field) {
 		}
 	}
 
-	if err := temp.WriteEntry(jl.Output, entry); err != nil {
+	if err := temp.WriteEntry(jl.Output, entry.Message, entry.Level, entry.Time); err != nil {
 		jl.internalError(err.Error())
 	}
 	temp.Free()


### PR DESCRIPTION
Let users specify how they'd like the message, level, and timestamp formatted for each log entry. 

In order to keep the proposed change small, this PR introduces a small performance regression in `jsonEncoder.WriteEntry` - it copies more bytes than necessary. In the next PR, I'm going to flatten the message structure, which will remove this extra copy and require many changes to the test code.

(I'm holding off on marking the related issues resolved until we export the `newJSONEncoder` function.)