### PR TITLE
Flatten serialized entries

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -51,9 +51,9 @@ func Example() {
 	child.Error("Oh no!")
 
 	// Output:
-	// {"msg":"Log without structured data...","level":"warn","ts":0,"fields":{}}
-	// {"msg":"Or use strongly-typed wrappers to add structured context.","level":"warn","ts":0,"fields":{"library":"zap","latency":1}}
-	// {"msg":"Oh no!","level":"error","ts":0,"fields":{"user":"jane@test.com","visits":42}}
+	// {"level":"warn","ts":0,"msg":"Log without structured data..."}
+	// {"level":"warn","ts":0,"msg":"Or use strongly-typed wrappers to add structured context.","library":"zap","latency":1}
+	// {"level":"error","ts":0,"msg":"Oh no!","user":"jane@test.com","visits":42}
 }
 
 func Example_fileOutput() {
@@ -75,7 +75,7 @@ func Example_fileOutput() {
 	logger.Info("This is an info log.", zap.Int("foo", 42))
 
 	// Sync the file so logs are written to disk, and print the file contents.
-	// zap will call Sync when logging at FatalLevel or PanicLevel.
+	// zap will call Sync automatically when logging at FatalLevel or PanicLevel.
 	f.Sync()
 	contents, err := ioutil.ReadFile(f.Name())
 	if err != nil {
@@ -84,7 +84,7 @@ func Example_fileOutput() {
 
 	fmt.Println(string(contents))
 	// Output:
-	// {"msg":"This is an info log.","level":"info","ts":0,"fields":{"foo":42}}
+	// {"level":"info","ts":0,"msg":"This is an info log.","foo":42}
 }
 
 func ExampleNest() {
@@ -97,7 +97,7 @@ func ExampleNest() {
 	logger.Info("Logging a nested field.", nest)
 
 	// Output:
-	// {"msg":"Logging a nested field.","level":"info","ts":0,"fields":{"outer":{"inner":42}}}
+	// {"level":"info","ts":0,"msg":"Logging a nested field.","outer":{"inner":42}}
 }
 
 func ExampleNewJSON() {
@@ -112,7 +112,7 @@ func ExampleNewJSON() {
 	logger.Info("This is an info log.")
 
 	// Output:
-	// {"msg":"This is an info log.","level":"info","ts":0,"fields":{}}
+	// {"level":"info","ts":0,"msg":"This is an info log."}
 }
 
 func ExampleNewJSON_options() {
@@ -129,8 +129,8 @@ func ExampleNewJSON_options() {
 	logger.Info("This is an info log.")
 
 	// Output:
-	// {"msg":"This is a debug log.","level":"debug","ts":0,"fields":{"count":1}}
-	// {"msg":"This is an info log.","level":"info","ts":0,"fields":{"count":1}}
+	// {"level":"debug","ts":0,"msg":"This is a debug log.","count":1}
+	// {"level":"info","ts":0,"msg":"This is an info log.","count":1}
 }
 
 func ExampleCheckedMessage() {
@@ -153,7 +153,7 @@ func ExampleCheckedMessage() {
 	}
 
 	// Output:
-	// {"msg":"This is an info log.","level":"info","ts":0,"fields":{}}
+	// {"level":"info","ts":0,"msg":"This is an info log."}
 }
 
 func ExampleLevel_MarshalText() {

--- a/hook.go
+++ b/hook.go
@@ -58,7 +58,8 @@ func AddCaller() Option {
 		}
 
 		// Re-use a buffer from the pool.
-		enc := newJSONEncoder()
+		enc := jsonPool.Get().(*jsonEncoder)
+		enc.truncate()
 		buf := enc.bytes
 		buf = append(buf, filepath.Base(filename)...)
 		buf = append(buf, ':')

--- a/hook_test.go
+++ b/hook_test.go
@@ -29,17 +29,17 @@ import (
 )
 
 func TestHookAddCaller(t *testing.T) {
-	buf := newTestBuffer()
+	buf := &testBuffer{}
 	logger := NewJSON(DebugLevel, Output(buf), AddCaller())
 	logger.Info("Callers.")
 
 	re := regexp.MustCompile(`"msg":"hook_test.go:[\d]+: Callers\."`)
-	assert.Regexp(t, re, buf.String(), "Expected to find package name and file name in output.")
+	assert.Regexp(t, re, buf.Stripped(), "Expected to find package name and file name in output.")
 }
 
 func TestHookAddCallerFail(t *testing.T) {
-	buf := newTestBuffer()
-	errBuf := newTestBuffer()
+	buf := &testBuffer{}
+	errBuf := &testBuffer{}
 
 	originalSkip := _callerSkip
 	_callerSkip = 1e3
@@ -52,7 +52,7 @@ func TestHookAddCallerFail(t *testing.T) {
 }
 
 func TestHookAddStacks(t *testing.T) {
-	buf := newTestBuffer()
+	buf := &testBuffer{}
 	logger := NewJSON(DebugLevel, Output(buf), AddStacks(InfoLevel))
 
 	logger.Info("Stacks.")

--- a/json_encoder.go
+++ b/json_encoder.go
@@ -195,7 +195,7 @@ func (enc *jsonEncoder) WriteEntry(sink io.Writer, msg string, lvl Level, t time
 		}
 		final.bytes = append(final.bytes, enc.bytes...)
 	}
-	final.bytes = append(final.bytes, "}\n"...)
+	final.bytes = append(final.bytes, '}', '\n')
 
 	expectedBytes := len(final.bytes)
 	n, err := sink.Write(final.bytes)

--- a/json_encoder.go
+++ b/json_encoder.go
@@ -189,7 +189,10 @@ func (enc *jsonEncoder) WriteEntry(sink io.Writer, msg string, lvl Level, t time
 	enc.timeF(t).AddTo(final)
 	enc.messageF(msg).AddTo(final)
 	if len(enc.bytes) > 0 {
-		final.bytes = append(final.bytes, ',')
+		if len(final.bytes) > 1 {
+			// All the formatters may have been no-ops.
+			final.bytes = append(final.bytes, ',')
+		}
 		final.bytes = append(final.bytes, enc.bytes...)
 	}
 	final.bytes = append(final.bytes, "}\n"...)

--- a/logger.go
+++ b/logger.go
@@ -94,6 +94,16 @@ func NewJSON(options ...Option) Logger {
 	return &logger
 }
 
+// TODO: export as New and replace NewJSON.
+func newLogger(enc encoder, options ...Option) Logger {
+	meta := NewMeta()
+	meta.Encoder = enc
+	for _, opt := range options {
+		opt.apply(meta)
+	}
+	return &jsonLogger{Meta: meta}
+}
+
 func (jl *jsonLogger) With(fields ...Field) Logger {
 	clone := &jsonLogger{
 		Meta:        jl.Meta.Clone(),
@@ -154,6 +164,7 @@ func (jl *jsonLogger) Fatal(msg string, fields ...Field) {
 func (jl *jsonLogger) DFatal(msg string, fields ...Field) {
 	if jl.Development {
 		jl.Fatal(msg, fields...)
+		return
 	}
 	jl.Error(msg, fields...)
 }

--- a/logger.go
+++ b/logger.go
@@ -96,12 +96,14 @@ func NewJSON(options ...Option) Logger {
 
 // TODO: export as New and replace NewJSON.
 func newLogger(enc encoder, options ...Option) Logger {
-	meta := NewMeta()
-	meta.Encoder = enc
-	for _, opt := range options {
-		opt.apply(meta)
+	logger := jsonLogger{
+		Meta: MakeMeta(),
 	}
-	return &jsonLogger{Meta: meta}
+	logger.Meta.Encoder = enc
+	for _, opt := range options {
+		opt.apply(&logger.Meta)
+	}
+	return &logger
 }
 
 func (jl *jsonLogger) With(fields ...Field) Logger {

--- a/marshaler_example_test.go
+++ b/marshaler_example_test.go
@@ -68,5 +68,5 @@ func ExampleMarshaler() {
 	logger.Info("Successful login.", zap.Marshaler("user", jane))
 
 	// Output:
-	// {"msg":"Successful login.","level":"info","ts":0,"fields":{"user":{"name":"Jane Doe","age":42,"auth":{"expires_at":100,"token":"---"}}}}
+	// {"level":"info","ts":0,"msg":"Successful login.","user":{"name":"Jane Doe","age":42,"auth":{"expires_at":100,"token":"---"}}}
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -30,18 +30,6 @@ import (
 	"github.com/uber-go/zap/spywrite"
 )
 
-type testBuffer struct {
-	*bytes.Buffer
-}
-
-func newTestBuffer() testBuffer {
-	return testBuffer{&bytes.Buffer{}}
-}
-
-func (t testBuffer) Sync() error {
-	return nil
-}
-
 func requireWriteWorks(t testing.TB, ws WriteSyncer) {
 	n, err := ws.Write([]byte("foo"))
 	require.NoError(t, err, "Unexpected error writing to WriteSyncer.")

--- a/zbark/bark_test.go
+++ b/zbark/bark_test.go
@@ -124,7 +124,7 @@ func TestWithField(t *testing.T) {
 		assert.Contains(
 			t,
 			out.String(),
-			fmt.Sprintf(`"fields":{"thing":%s}`, tt.expected),
+			fmt.Sprintf(`,"thing":%s}`, tt.expected),
 			"Unexpected fields output. Expected %+v to serialize as %s.", tt.val, tt.expected,
 		)
 	}
@@ -136,7 +136,7 @@ func TestWithFieldSerializationError(t *testing.T) {
 	assert.Contains(
 		t,
 		out.String(),
-		`"fields":{"thingError":"json: error calling MarshalJSON for type zbark.noJSON: fail"}`,
+		`,"thingError":"json: error calling MarshalJSON for type zbark.noJSON: fail"}`,
 		"Expected JSON serialization errors to be logged.",
 	)
 }
@@ -150,8 +150,8 @@ func TestWithFields(t *testing.T) {
 
 	output := out.String()
 	// Map iteration order is random.
-	orderSame := `"fields":{"foo":"bar","baz":42}`
-	orderReversed := `"fields":{"baz":42,"foo":"bar"}`
+	orderSame := `,"foo":"bar","baz":42}`
+	orderReversed := `,"baz":42,"foo":"bar"}`
 	if !strings.Contains(output, orderSame) {
 		assert.Contains(t, output, orderReversed, "Expected output to contain both fields.")
 	}

--- a/zbark/example_test.go
+++ b/zbark/example_test.go
@@ -37,5 +37,5 @@ func Example() {
 	logger.WithField("errors", 0).Infof("%v accepts arbitrary types.", "Bark")
 
 	// Output:
-	// {"msg":"Bark accepts arbitrary types.","level":"info","ts":0,"fields":{"errors":0}}
+	// {"level":"info","ts":0,"msg":"Bark accepts arbitrary types.","errors":0}
 }

--- a/zwrap/example_test.go
+++ b/zwrap/example_test.go
@@ -45,7 +45,7 @@ func Example_standardize() {
 	stdLogger.Printf("Encountered %d errors.", 0)
 
 	// Output:
-	// {"msg":"Encountered 0 errors.","level":"warn","ts":0,"fields":{}}
+	// {"level":"warn","ts":0,"msg":"Encountered 0 errors."}
 }
 
 func Example_sample() {
@@ -60,7 +60,7 @@ func Example_sample() {
 	sampledLogger.Error("Unusual failure.")
 
 	// Output:
-	// {"msg":"Common failure.","level":"error","ts":0,"fields":{"n":1}}
-	// {"msg":"Common failure.","level":"error","ts":0,"fields":{"n":101}}
-	// {"msg":"Unusual failure.","level":"error","ts":0,"fields":{}}
+	// {"level":"error","ts":0,"msg":"Common failure.","n":1}
+	// {"level":"error","ts":0,"msg":"Common failure.","n":101}
+	// {"level":"error","ts":0,"msg":"Unusual failure."}
 }


### PR DESCRIPTION
Log aggregation and processing systems typically require some metadata in the top-level JSON. In zap, we included the message, level, and timestamp, but that's clearly not enough to support many use cases. We could support adding information to this envelope via a separate API, but the simplest option is to flatten the entry.

This is a small change to the production code, but it requires large changes to the tests. To keep review semi-sane, the production and test changes are in separate commits.