### PR TITLE
	Meta is embedded by value

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -71,7 +71,7 @@ type Logger interface {
 }
 
 type jsonLogger struct {
-	*Meta
+	Meta
 
 	alwaysEpoch bool
 }
@@ -85,11 +85,13 @@ type jsonLogger struct {
 // Options can change the log level, the output location, or the initial
 // fields that should be added as context.
 func NewJSON(options ...Option) Logger {
-	meta := NewMeta()
-	for _, opt := range options {
-		opt.apply(meta)
+	logger := jsonLogger{
+		Meta: MakeMeta(),
 	}
-	return &jsonLogger{Meta: meta}
+	for _, opt := range options {
+		opt.apply(&logger.Meta)
+	}
+	return &logger
 }
 
 func (jl *jsonLogger) With(fields ...Field) Logger {

--- a/meta.go
+++ b/meta.go
@@ -43,11 +43,11 @@ type Meta struct {
 	lvl *atomic.Int32
 }
 
-// NewMeta returns a new meta struct with sensible defaults: logging at
+// MakeMeta returns a new meta struct with sensible defaults: logging at
 // InfoLevel, a JSON encoder, development mode off, and writing to standard error
 // and standard out.
-func NewMeta() *Meta {
-	return &Meta{
+func MakeMeta() Meta {
+	return Meta{
 		lvl:         atomic.NewInt32(int32(InfoLevel)),
 		Encoder:     newJSONEncoder(),
 		Output:      newLockedWriteSyncer(os.Stdout),
@@ -56,25 +56,19 @@ func NewMeta() *Meta {
 }
 
 // Level returns the minimum enabled log level. It's safe to call concurrently.
-func (m *Meta) Level() Level {
+func (m Meta) Level() Level {
 	return Level(m.lvl.Load())
 }
 
 // SetLevel atomically alters the the logging level for this configuration and
 // all its clones.
-func (m *Meta) SetLevel(lvl Level) {
+func (m Meta) SetLevel(lvl Level) {
 	m.lvl.Store(int32(lvl))
 }
 
 // Clone creates a copy of the meta struct. It deep-copies the encoder, but
 // not the hooks (since they rarely change).
-func (m *Meta) Clone() *Meta {
-	return &Meta{
-		lvl:         m.lvl,
-		Encoder:     m.Encoder.Clone(),
-		Development: m.Development,
-		Output:      m.Output,
-		ErrorOutput: m.ErrorOutput,
-		Hooks:       m.Hooks,
-	}
+func (m Meta) Clone() Meta {
+	m.Encoder = m.Encoder.Clone()
+	return m
 }

--- a/spy/logger.go
+++ b/spy/logger.go
@@ -64,7 +64,7 @@ func (s *Sink) Logs() []Log {
 // Logger satisfies zap.Logger, but makes testing convenient.
 type Logger struct {
 	sync.Mutex
-	*zap.Meta
+	zap.Meta
 
 	sink    *Sink
 	context []zap.Field
@@ -74,7 +74,7 @@ type Logger struct {
 func New() (*Logger, *Sink) {
 	s := &Sink{}
 	return &Logger{
-		Meta: zap.NewMeta(),
+		Meta: zap.MakeMeta(),
 		sink: s,
 	}, s
 }


### PR DESCRIPTION
```
name                                    old time/op    new time/op    delta
ApexLogAddingFields-24                    21.0µs ± 2%    20.9µs ± 3%    ~           (p=0.353 n=10+10)
ApexLogWithAccumulatedContext-24          16.9µs ± 2%    17.0µs ± 2%    ~           (p=0.363 n=10+10)
ApexLogWithoutFields-24                   3.67µs ± 1%    3.69µs ± 1%    ~           (p=0.148 n=10+10)
GoKitAddingFields-24                      3.41µs ± 4%    3.35µs ± 4%    ~             (p=0.340 n=9+9)
GoKitWithAccumulatedContext-24            2.77µs ± 1%    2.77µs ± 1%    ~            (p=0.484 n=9+10)
GoKitWithoutFields-24                      544ns ± 2%     541ns ± 1%    ~            (p=0.096 n=10+9)
Log15AddingFields-24                      29.9µs ± 4%    29.3µs ± 3%  -2.16%        (p=0.043 n=10+10)
Log15WithAccumulatedContext-24            27.8µs ± 1%    27.7µs ± 2%    ~            (p=0.356 n=10+9)
Log15WithoutFields-24                     6.62µs ± 2%    6.57µs ± 2%    ~           (p=0.138 n=10+10)
LogrusAddingFields-24                     6.37µs ± 4%    6.36µs ± 3%    ~             (p=0.524 n=9+8)
ZapBarkifyAddingFields-24                 4.03µs ± 5%    4.03µs ± 2%    ~           (p=0.617 n=10+10)
LogrusWithAccumulatedContext-24           4.60µs ± 3%    4.55µs ± 1%    ~           (p=0.436 n=10+10)
ZapBarkifyWithAccumulatedContext-24        343ns ± 7%     343ns ± 3%    ~           (p=1.000 n=10+10)
LogrusWithoutFields-24                    1.78µs ± 4%    1.73µs ± 1%  -2.69%         (p=0.001 n=10+8)
StandardLibraryWithoutFields-24            822ns ± 6%     827ns ± 5%    ~           (p=0.927 n=10+10)
ZapStandardizeWithoutFields-24             345ns ± 6%     353ns ± 6%    ~             (p=0.214 n=9+9)
ZapDisabledLevelsWithoutFields-24         1.15ns ± 0%    1.15ns ± 1%    ~            (p=0.099 n=10+8)
ZapDisabledLevelsAccumulatedContext-24    1.15ns ± 0%    1.15ns ± 1%    ~           (p=0.087 n=10+10)
ZapDisabledLevelsAddingFields-24           399ns ± 2%     403ns ± 2%    ~             (p=0.083 n=9+9)
ZapDisabledLevelsCheckAddingFields-24     0.92ns ± 0%    0.93ns ± 0%  +1.09%          (p=0.001 n=8+6)
ZapAddingFields-24                         782ns ± 2%     786ns ± 2%    ~            (p=0.563 n=10+9)
ZapWithAccumulatedContext-24               309ns ± 6%     308ns ± 8%    ~           (p=0.755 n=10+10)
ZapWithoutFields-24                        316ns ± 7%     317ns ± 7%    ~           (p=0.424 n=10+10)
ZapSampleWithoutFields-24                 62.1ns ± 6%    63.3ns ± 5%    ~           (p=0.305 n=10+10)
ZapSampleAddingFields-24                   914ns ±23%     901ns ±23%    ~           (p=0.755 n=10+10)
ZapSampleCheckWithoutFields-24            64.3ns ± 6%    64.3ns ± 3%    ~            (p=0.764 n=10+9)
ZapSampleCheckAddingFields-24             65.4ns ± 5%    64.3ns ± 5%    ~           (p=0.240 n=10+10)

name                                    old alloc/op   new alloc/op   delta
ApexLogAddingFields-24                    3.61kB ± 0%    3.61kB ± 0%    ~           (p=1.000 n=10+10)
ApexLogWithAccumulatedContext-24          2.39kB ± 0%    2.39kB ± 0%    ~     (all samples are equal)
ApexLogWithoutFields-24                     584B ± 0%      584B ± 0%    ~     (all samples are equal)
GoKitAddingFields-24                      3.22kB ± 0%    3.22kB ± 0%    ~             (p=1.000 n=9+9)
GoKitWithAccumulatedContext-24            2.50kB ± 0%    2.50kB ± 0%    ~     (all samples are equal)
GoKitWithoutFields-24                       625B ± 0%      625B ± 0%    ~     (all samples are equal)
Log15AddingFields-24                      4.79kB ± 0%    4.79kB ± 0%  -0.01%         (p=0.029 n=7+10)
Log15WithAccumulatedContext-24            4.13kB ± 0%    4.13kB ± 0%    ~            (p=0.442 n=6+10)
Log15WithoutFields-24                     1.18kB ± 0%    1.18kB ± 0%    ~     (all samples are equal)
LogrusAddingFields-24                     5.30kB ± 0%    5.30kB ± 0%    ~            (p=0.081 n=7+10)
ZapBarkifyAddingFields-24                 3.67kB ± 0%    3.67kB ± 0%  +0.02%         (p=0.012 n=10+7)
LogrusWithAccumulatedContext-24           3.45kB ± 0%    3.45kB ± 0%  +0.02%        (p=0.011 n=10+10)
ZapBarkifyWithAccumulatedContext-24        48.0B ± 0%     48.0B ± 0%    ~     (all samples are equal)
LogrusWithoutFields-24                    1.18kB ± 0%    1.18kB ± 0%    ~     (all samples are equal)
StandardLibraryWithoutFields-24            32.0B ± 0%     32.0B ± 0%    ~     (all samples are equal)
ZapStandardizeWithoutFields-24             40.0B ± 0%     40.0B ± 0%    ~     (all samples are equal)
ZapDisabledLevelsWithoutFields-24         0.00B ±NaN%    0.00B ±NaN%    ~     (all samples are equal)
ZapDisabledLevelsAccumulatedContext-24    0.00B ±NaN%    0.00B ±NaN%    ~     (all samples are equal)
ZapDisabledLevelsAddingFields-24            704B ± 0%      704B ± 0%    ~     (all samples are equal)
ZapDisabledLevelsCheckAddingFields-24     0.00B ±NaN%    0.00B ±NaN%    ~     (all samples are equal)
ZapAddingFields-24                          712B ± 0%      712B ± 0%    ~            (p=0.137 n=10+8)
ZapWithAccumulatedContext-24              0.00B ±NaN%    0.00B ±NaN%    ~     (all samples are equal)
ZapWithoutFields-24                       0.00B ±NaN%    0.00B ±NaN%    ~     (all samples are equal)
ZapSampleWithoutFields-24                 0.00B ±NaN%    0.00B ±NaN%    ~     (all samples are equal)
ZapSampleAddingFields-24                    704B ± 0%      704B ± 0%    ~            (p=0.294 n=8+10)
ZapSampleCheckWithoutFields-24            0.00B ±NaN%    0.00B ±NaN%    ~     (all samples are equal)
ZapSampleCheckAddingFields-24             0.00B ±NaN%    0.00B ±NaN%    ~     (all samples are equal)

name                                    old allocs/op  new allocs/op  delta
ApexLogAddingFields-24                      63.0 ± 0%      63.0 ± 0%    ~     (all samples are equal)
ApexLogWithAccumulatedContext-24            48.0 ± 0%      48.0 ± 0%    ~     (all samples are equal)
ApexLogWithoutFields-24                     11.0 ± 0%      11.0 ± 0%    ~     (all samples are equal)
GoKitAddingFields-24                        70.0 ± 0%      70.0 ± 0%    ~     (all samples are equal)
GoKitWithAccumulatedContext-24              48.0 ± 0%      48.0 ± 0%    ~     (all samples are equal)
GoKitWithoutFields-24                       13.0 ± 0%      13.0 ± 0%    ~     (all samples are equal)
Log15AddingFields-24                        91.0 ± 0%      91.0 ± 0%    ~     (all samples are equal)
Log15WithAccumulatedContext-24              70.0 ± 0%      70.0 ± 0%    ~     (all samples are equal)
Log15WithoutFields-24                       22.0 ± 0%      22.0 ± 0%    ~     (all samples are equal)
LogrusAddingFields-24                       78.0 ± 0%      78.0 ± 0%    ~     (all samples are equal)
ZapBarkifyAddingFields-24                   24.0 ± 0%      24.0 ± 0%    ~     (all samples are equal)
LogrusWithAccumulatedContext-24             61.0 ± 0%      61.0 ± 0%    ~     (all samples are equal)
ZapBarkifyWithAccumulatedContext-24         3.00 ± 0%      3.00 ± 0%    ~     (all samples are equal)
LogrusWithoutFields-24                      25.0 ± 0%      25.0 ± 0%    ~     (all samples are equal)
StandardLibraryWithoutFields-24             2.00 ± 0%      2.00 ± 0%    ~     (all samples are equal)
ZapStandardizeWithoutFields-24              3.00 ± 0%      3.00 ± 0%    ~     (all samples are equal)
ZapDisabledLevelsWithoutFields-24          0.00 ±NaN%     0.00 ±NaN%    ~     (all samples are equal)
ZapDisabledLevelsAccumulatedContext-24     0.00 ±NaN%     0.00 ±NaN%    ~     (all samples are equal)
ZapDisabledLevelsAddingFields-24            2.00 ± 0%      2.00 ± 0%    ~     (all samples are equal)
ZapDisabledLevelsCheckAddingFields-24      0.00 ±NaN%     0.00 ±NaN%    ~     (all samples are equal)
ZapAddingFields-24                          2.00 ± 0%      2.00 ± 0%    ~     (all samples are equal)
ZapWithAccumulatedContext-24               0.00 ±NaN%     0.00 ±NaN%    ~     (all samples are equal)
ZapWithoutFields-24                        0.00 ±NaN%     0.00 ±NaN%    ~     (all samples are equal)
ZapSampleWithoutFields-24                  0.00 ±NaN%     0.00 ±NaN%    ~     (all samples are equal)
ZapSampleAddingFields-24                    2.00 ± 0%      2.00 ± 0%    ~     (all samples are equal)
ZapSampleCheckWithoutFields-24             0.00 ±NaN%     0.00 ±NaN%    ~     (all samples are equal)
ZapSampleCheckAddingFields-24              0.00 ±NaN%     0.00 ±NaN%    ~     (all samples are equal)
```