### PR TITLE
[v1, 1/8] Alter MakeMeta to take an encoder

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -86,7 +86,7 @@ type jsonLogger struct {
 // fields that should be added as context.
 func NewJSON(options ...Option) Logger {
 	logger := jsonLogger{
-		Meta: MakeMeta(),
+		Meta: MakeMeta(newJSONEncoder()),
 	}
 	for _, opt := range options {
 		opt.apply(&logger.Meta)
@@ -97,9 +97,8 @@ func NewJSON(options ...Option) Logger {
 // TODO: export as New and replace NewJSON.
 func newLogger(enc encoder, options ...Option) Logger {
 	logger := jsonLogger{
-		Meta: MakeMeta(),
+		Meta: MakeMeta(enc),
 	}
-	logger.Meta.Encoder = enc
 	for _, opt := range options {
 		opt.apply(&logger.Meta)
 	}

--- a/meta.go
+++ b/meta.go
@@ -27,12 +27,10 @@ import (
 )
 
 // Meta is implementation-agnostic state management for Loggers. Most Logger
-// implementations can reduce the required boilerplate by embedding a *Meta.
+// implementations can reduce the required boilerplate by embedding a Meta.
 //
 // Note that while the level-related fields and methods are safe for concurrent
 // use, the remaining fields are not.
-//
-// TODO: Consider better names for this before releasing 1.0.
 type Meta struct {
 	Development bool
 	Encoder     encoder
@@ -46,10 +44,14 @@ type Meta struct {
 // MakeMeta returns a new meta struct with sensible defaults: logging at
 // InfoLevel, a JSON encoder, development mode off, and writing to standard error
 // and standard out.
-func MakeMeta() Meta {
+func MakeMeta(enc encoder) Meta {
+	if enc == nil {
+		// TODO: remove once we export the encoder constructors.
+		enc = newJSONEncoder()
+	}
 	return Meta{
 		lvl:         atomic.NewInt32(int32(InfoLevel)),
-		Encoder:     newJSONEncoder(),
+		Encoder:     enc,
 		Output:      newLockedWriteSyncer(os.Stdout),
 		ErrorOutput: newLockedWriteSyncer(os.Stderr),
 	}

--- a/spy/logger.go
+++ b/spy/logger.go
@@ -74,7 +74,7 @@ type Logger struct {
 func New() (*Logger, *Sink) {
 	s := &Sink{}
 	return &Logger{
-		Meta: zap.MakeMeta(),
+		Meta: zap.MakeMeta(nil),
 		sink: s,
 	}, s
 }


### PR DESCRIPTION
Since we're planning to have the logger constructor take an encoder, it's convenient to have the `Meta` constructor take an encoder too.

This is the first of eight PRs to finish up the large pre-v1.0.0 refactoring:
- [ ] Meta constructor takes an encoder
- [ ] Export Encoder type
- [ ] Export the JSON encoder constructor
- [ ] Add a `NewLogger` constructor and remove `NewJSON`
- [ ] Remove `StubTime`
- [ ] Export the Hook type
- [ ] Remove `Encoder.AddFields` (since we already have `Field.AddTo`)
- [ ] Improve GoDoc.

The remaining items in the v1 milestone shouldn't require large-scale changes.