### PR TITLE
[v1, 2/8] Export the Encoder type

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -25,13 +25,13 @@ import (
 	"time"
 )
 
-// encoder is a format-agnostic interface for all log field encoders. It's not
+// Encoder is a format-agnostic interface for all log field encoders. It's not
 // safe for concurrent use.
-type encoder interface {
+type Encoder interface {
 	KeyValue
 
 	AddFields([]Field)
-	Clone() encoder
+	Clone() Encoder
 	Free()
 	WriteEntry(io.Writer, string, Level, time.Time) error
 }

--- a/entry.go
+++ b/entry.go
@@ -40,10 +40,10 @@ type Entry struct {
 	Level   Level
 	Time    time.Time
 	Message string
-	enc     encoder
+	enc     Encoder
 }
 
-func newEntry(lvl Level, msg string, enc encoder) *Entry {
+func newEntry(lvl Level, msg string, enc Encoder) *Entry {
 	e := _entryPool.Get().(*Entry)
 	e.Level = lvl
 	e.Message = msg

--- a/json_encoder.go
+++ b/json_encoder.go
@@ -158,7 +158,7 @@ func (enc *jsonEncoder) AddObject(key string, obj interface{}) error {
 }
 
 // Clone copies the current encoder, including any data already encoded.
-func (enc *jsonEncoder) Clone() encoder {
+func (enc *jsonEncoder) Clone() Encoder {
 	clone := jsonPool.Get().(*jsonEncoder)
 	clone.truncate()
 	clone.bytes = append(clone.bytes, enc.bytes...)

--- a/json_encoder_bench_test.go
+++ b/json_encoder_bench_test.go
@@ -37,7 +37,7 @@ type logRecord struct {
 // newEncoder returns the encoder interface, which is how end users would use
 // the LogMarshalerFunc type. Using the JSON encoder type directly allows
 // inlining which reduces allocs artificially.
-func newEncoder() encoder {
+func newEncoder() Encoder {
 	return newJSONEncoder()
 }
 

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -78,7 +78,7 @@ func (l loggable) MarshalLog(kv KeyValue) error {
 	return nil
 }
 
-func assertOutput(t testing.TB, desc string, expected string, f func(encoder)) {
+func assertOutput(t testing.TB, desc string, expected string, f func(Encoder)) {
 	withJSONEncoder(func(enc *jsonEncoder) {
 		f(enc)
 		assert.Equal(t, expected, string(enc.bytes), "Unexpected encoder output after adding a %s.", desc)
@@ -100,40 +100,40 @@ func TestJSONEncoderFields(t *testing.T) {
 	tests := []struct {
 		desc     string
 		expected string
-		f        func(encoder)
+		f        func(Encoder)
 	}{
-		{"string", `"k":"v"`, func(e encoder) { e.AddString("k", "v") }},
-		{"string", `"k":""`, func(e encoder) { e.AddString("k", "") }},
-		{"string", `"k\\":"v\\"`, func(e encoder) { e.AddString(`k\`, `v\`) }},
-		{"bool", `"k":true`, func(e encoder) { e.AddBool("k", true) }},
-		{"bool", `"k":false`, func(e encoder) { e.AddBool("k", false) }},
-		{"bool", `"k\\":true`, func(e encoder) { e.AddBool(`k\`, true) }},
-		{"int", `"k":42`, func(e encoder) { e.AddInt("k", 42) }},
-		{"int", `"k\\":42`, func(e encoder) { e.AddInt(`k\`, 42) }},
-		{"int64", `"k":42`, func(e encoder) { e.AddInt64("k", 42) }},
-		{"int64", `"k\\":42`, func(e encoder) { e.AddInt64(`k\`, 42) }},
-		{"float64", `"k":1`, func(e encoder) { e.AddFloat64("k", 1.0) }},
-		{"float64", `"k\\":1`, func(e encoder) { e.AddFloat64(`k\`, 1.0) }},
-		{"float64", `"k":10000000000`, func(e encoder) { e.AddFloat64("k", 1e10) }},
-		{"float64", `"k":"NaN"`, func(e encoder) { e.AddFloat64("k", math.NaN()) }},
-		{"float64", `"k":"+Inf"`, func(e encoder) { e.AddFloat64("k", math.Inf(1)) }},
-		{"float64", `"k":"-Inf"`, func(e encoder) { e.AddFloat64("k", math.Inf(-1)) }},
-		{"marshaler", `"k":{"loggable":"yes"}`, func(e encoder) {
+		{"string", `"k":"v"`, func(e Encoder) { e.AddString("k", "v") }},
+		{"string", `"k":""`, func(e Encoder) { e.AddString("k", "") }},
+		{"string", `"k\\":"v\\"`, func(e Encoder) { e.AddString(`k\`, `v\`) }},
+		{"bool", `"k":true`, func(e Encoder) { e.AddBool("k", true) }},
+		{"bool", `"k":false`, func(e Encoder) { e.AddBool("k", false) }},
+		{"bool", `"k\\":true`, func(e Encoder) { e.AddBool(`k\`, true) }},
+		{"int", `"k":42`, func(e Encoder) { e.AddInt("k", 42) }},
+		{"int", `"k\\":42`, func(e Encoder) { e.AddInt(`k\`, 42) }},
+		{"int64", `"k":42`, func(e Encoder) { e.AddInt64("k", 42) }},
+		{"int64", `"k\\":42`, func(e Encoder) { e.AddInt64(`k\`, 42) }},
+		{"float64", `"k":1`, func(e Encoder) { e.AddFloat64("k", 1.0) }},
+		{"float64", `"k\\":1`, func(e Encoder) { e.AddFloat64(`k\`, 1.0) }},
+		{"float64", `"k":10000000000`, func(e Encoder) { e.AddFloat64("k", 1e10) }},
+		{"float64", `"k":"NaN"`, func(e Encoder) { e.AddFloat64("k", math.NaN()) }},
+		{"float64", `"k":"+Inf"`, func(e Encoder) { e.AddFloat64("k", math.Inf(1)) }},
+		{"float64", `"k":"-Inf"`, func(e Encoder) { e.AddFloat64("k", math.Inf(-1)) }},
+		{"marshaler", `"k":{"loggable":"yes"}`, func(e Encoder) {
 			assert.NoError(t, e.AddMarshaler("k", loggable{true}), "Unexpected error calling MarshalLog.")
 		}},
-		{"marshaler", `"k\\":{"loggable":"yes"}`, func(e encoder) {
+		{"marshaler", `"k\\":{"loggable":"yes"}`, func(e Encoder) {
 			assert.NoError(t, e.AddMarshaler(`k\`, loggable{true}), "Unexpected error calling MarshalLog.")
 		}},
-		{"marshaler", `"k":{}`, func(e encoder) {
+		{"marshaler", `"k":{}`, func(e Encoder) {
 			assert.Error(t, e.AddMarshaler("k", loggable{false}), "Expected an error calling MarshalLog.")
 		}},
-		{"arbitrary object", `"k":{"loggable":"yes"}`, func(e encoder) {
+		{"arbitrary object", `"k":{"loggable":"yes"}`, func(e Encoder) {
 			assert.NoError(t, e.AddObject("k", map[string]string{"loggable": "yes"}), "Unexpected error JSON-serializing a map.")
 		}},
-		{"arbitrary object", `"k\\":{"loggable":"yes"}`, func(e encoder) {
+		{"arbitrary object", `"k\\":{"loggable":"yes"}`, func(e Encoder) {
 			assert.NoError(t, e.AddObject(`k\`, map[string]string{"loggable": "yes"}), "Unexpected error JSON-serializing a map.")
 		}},
-		{"arbitrary object", "", func(e encoder) {
+		{"arbitrary object", "", func(e Encoder) {
 			assert.Error(t, e.AddObject("k", noJSON{}), "Unexpected success JSON-serializing a noJSON.")
 		}},
 	}
@@ -268,7 +268,7 @@ func TestJSONOptions(t *testing.T) {
 		RFC3339Formatter("the-timestamp"),
 	)
 
-	for _, enc := range []encoder{root, root.Clone()} {
+	for _, enc := range []Encoder{root, root.Clone()} {
 		buf := &bytes.Buffer{}
 		enc.WriteEntry(buf, "fake msg", DebugLevel, time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC))
 		assert.Equal(

--- a/logger.go
+++ b/logger.go
@@ -95,7 +95,7 @@ func NewJSON(options ...Option) Logger {
 }
 
 // TODO: export as New and replace NewJSON.
-func newLogger(enc encoder, options ...Option) Logger {
+func newLogger(enc Encoder, options ...Option) Logger {
 	logger := jsonLogger{
 		Meta: MakeMeta(enc),
 	}

--- a/meta.go
+++ b/meta.go
@@ -33,7 +33,7 @@ import (
 // use, the remaining fields are not.
 type Meta struct {
 	Development bool
-	Encoder     encoder
+	Encoder     Encoder
 	Hooks       []hook
 	Output      WriteSyncer
 	ErrorOutput WriteSyncer
@@ -44,7 +44,7 @@ type Meta struct {
 // MakeMeta returns a new meta struct with sensible defaults: logging at
 // InfoLevel, a JSON encoder, development mode off, and writing to standard error
 // and standard out.
-func MakeMeta(enc encoder) Meta {
+func MakeMeta(enc Encoder) Meta {
 	if enc == nil {
 		// TODO: remove once we export the encoder constructors.
 		enc = newJSONEncoder()


### PR DESCRIPTION
Export the Encoder type, since we'd like to allow external implementations. (Exporting a constructor for the JSON encoder comes in the next PR.)

This is the second of eight PRs to finish up the large pre-v1.0.0 refactoring:
- [x] Meta constructor takes an encoder
- [ ] Export Encoder type
- [ ] Export the JSON encoder constructor
- [ ] Add a `NewLogger` constructor and remove `NewJSON`
- [ ] Remove `StubTime`
- [ ] Export the Hook type
- [ ] Remove `Encoder.AddFields` (since we already have `Field.AddTo`)
- [ ] Improve GoDoc.

The remaining items in the v1 milestone shouldn't require large-scale changes.