### PR TITLE
[v1, 3/8] Export the JSON encoder constructor

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -182,3 +182,19 @@ func ExampleLevel_UnmarshalText() {
 	// info
 	// error
 }
+
+func ExampleNewJSONEncoder() {
+	// An encoder with the default settings.
+	zap.NewJSONEncoder()
+
+	// Dropping timestamps is often useful in tests.
+	zap.NewJSONEncoder(zap.NoTime())
+
+	// In production, customize the encoder to work with your log aggregation
+	// system.
+	zap.NewJSONEncoder(
+		zap.RFC3339Formatter("@timestamp"), // human-readable timestamps
+		zap.MessageKey("@message"),         // customize the message key
+		zap.LevelString("@level"),          // stringify the log level
+	)
+}

--- a/field.go
+++ b/field.go
@@ -124,7 +124,8 @@ func Error(err error) Field {
 // allocation and takes ~10 microseconds.
 func Stack() Field {
 	// Try to avoid allocating a buffer.
-	enc := newJSONEncoder()
+	enc := jsonPool.Get().(*jsonEncoder)
+	enc.truncate()
 	bs := enc.bytes[:cap(enc.bytes)]
 	// Returning the stacktrace as a string costs an allocation, but saves us
 	// from expanding the Field union struct to include a byte slice. Since

--- a/field_test.go
+++ b/field_test.go
@@ -64,7 +64,7 @@ func assertCanBeReused(t testing.TB, field Field) {
 	var wg sync.WaitGroup
 
 	for i := 0; i < 100; i++ {
-		enc := newJSONEncoder()
+		enc := NewJSONEncoder()
 		defer enc.Free()
 
 		// Ensure using the field in multiple encoders in separate goroutines
@@ -196,7 +196,7 @@ func TestStackField(t *testing.T) {
 }
 
 func TestUnknownField(t *testing.T) {
-	enc := newJSONEncoder()
+	enc := NewJSONEncoder()
 	defer enc.Free()
 
 	for _, ft := range []fieldType{unknownType, -42} {

--- a/json_encoder.go
+++ b/json_encoder.go
@@ -64,9 +64,19 @@ type jsonEncoder struct {
 	levelF   LevelFormatter
 }
 
-// newJSONEncoder creates an encoder, re-using one from the pool if possible. The
-// returned encoder is initialized and ready for use.
-func newJSONEncoder(options ...JSONOption) *jsonEncoder {
+// NewJSONEncoder creates a logging-optimized JSON encoder. By default, JSON
+// encoders put the log message under the "msg" key, the timestamp (as
+// floating-point seconds since epoch) under the "ts" key, and the log level
+// under the "level" key.
+//
+// Note that the encoder doesn't deduplicate keys, so it's possible to produce a
+// message like
+//   {"foo":"bar","foo":"baz"}
+// This is permitted by the JSON specification, but not encouraged. Many
+// libraries will ignore duplicate key-value pairs (typically keeping the last
+// pair) when unmarshaling, but it's the user's responsibility to avoid duplicate
+// keys.
+func NewJSONEncoder(options ...JSONOption) Encoder {
 	enc := jsonPool.Get().(*jsonEncoder)
 	enc.truncate()
 

--- a/json_encoder_bench_test.go
+++ b/json_encoder_bench_test.go
@@ -34,16 +34,9 @@ type logRecord struct {
 	Fields  map[string]interface{} `json:"fields"`
 }
 
-// newEncoder returns the encoder interface, which is how end users would use
-// the LogMarshalerFunc type. Using the JSON encoder type directly allows
-// inlining which reduces allocs artificially.
-func newEncoder() Encoder {
-	return newJSONEncoder()
-}
-
 func BenchmarkLogMarshalerFunc(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		enc := newEncoder()
+		enc := NewJSONEncoder()
 		enc.AddMarshaler("nested", LogMarshalerFunc(func(kv KeyValue) error {
 			kv.AddInt("i", i)
 			return nil
@@ -56,7 +49,7 @@ func BenchmarkZapJSON(b *testing.B) {
 	ts := time.Unix(0, 0)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			enc := newJSONEncoder()
+			enc := NewJSONEncoder()
 			enc.AddString("str", "foo")
 			enc.AddInt("int", 1)
 			enc.AddInt64("int64", 1)

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -35,6 +35,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newJSONEncoder(opts ...JSONOption) *jsonEncoder {
+	return NewJSONEncoder(opts...).(*jsonEncoder)
+}
+
 func assertJSON(t *testing.T, expected string, enc *jsonEncoder) {
 	assert.Equal(t, expected, string(enc.bytes), "Encoded JSON didn't match expectations.")
 }
@@ -145,7 +149,7 @@ func TestJSONEncoderFields(t *testing.T) {
 
 func TestJSONWriteEntry(t *testing.T) {
 	entry := &Entry{Level: InfoLevel, Message: `hello\`, Time: time.Unix(0, 0)}
-	enc := newJSONEncoder()
+	enc := NewJSONEncoder()
 
 	assert.Equal(t, errNilSink, enc.WriteEntry(
 		nil,
@@ -180,7 +184,7 @@ func TestJSONWriteEntry(t *testing.T) {
 func TestJSONWriteEntryLargeTimestamps(t *testing.T) {
 	// Ensure that we don't switch to exponential notation when encoding dates far in the future.
 	sink := &testBuffer{}
-	enc := newJSONEncoder()
+	enc := NewJSONEncoder()
 	future := time.Date(2100, time.January, 1, 0, 0, 0, 0, time.UTC)
 	require.NoError(t, enc.WriteEntry(sink, "fake msg", DebugLevel, future))
 	assert.Contains(
@@ -262,7 +266,7 @@ func TestJSONEscaping(t *testing.T) {
 }
 
 func TestJSONOptions(t *testing.T) {
-	root := newJSONEncoder(
+	root := NewJSONEncoder(
 		MessageKey("the-message"),
 		LevelString("the-level"),
 		RFC3339Formatter("the-timestamp"),

--- a/logger.go
+++ b/logger.go
@@ -82,11 +82,11 @@ type jsonLogger struct {
 // By default, the logger will write Info logs or higher to standard
 // out. Any errors during logging will be written to standard error.
 //
-// Options can change the log level, the output location, or the initial
-// fields that should be added as context.
+// Options can change the log level, the output location, the initial
+// fields that should be added as context, and many other behaviors.
 func NewJSON(options ...Option) Logger {
 	logger := jsonLogger{
-		Meta: MakeMeta(newJSONEncoder()),
+		Meta: MakeMeta(NewJSONEncoder()),
 	}
 	for _, opt := range options {
 		opt.apply(&logger.Meta)

--- a/meta.go
+++ b/meta.go
@@ -45,10 +45,6 @@ type Meta struct {
 // InfoLevel, a JSON encoder, development mode off, and writing to standard error
 // and standard out.
 func MakeMeta(enc Encoder) Meta {
-	if enc == nil {
-		// TODO: remove once we export the encoder constructors.
-		enc = newJSONEncoder()
-	}
 	return Meta{
 		lvl:         atomic.NewInt32(int32(InfoLevel)),
 		Encoder:     enc,

--- a/spy/logger.go
+++ b/spy/logger.go
@@ -74,7 +74,7 @@ type Logger struct {
 func New() (*Logger, *Sink) {
 	s := &Sink{}
 	return &Logger{
-		Meta: zap.MakeMeta(nil),
+		Meta: zap.MakeMeta(zap.NewJSONEncoder(zap.NoTime())),
 		sink: s,
 	}, s
 }


### PR DESCRIPTION
Export a constructor for the `JSONEncoder` type.

This is the third of eight PRs to finish up the large pre-v1.0.0 refactoring:
- [x] Meta constructor takes an encoder
- [x] Export Encoder type
- [ ] Export the JSON encoder constructor
- [ ] Add a `NewLogger` constructor and remove `NewJSON`
- [ ] Remove `StubTime`
- [ ] Export the Hook type
- [ ] Remove `Encoder.AddFields` (since we already have `Field.AddTo`)
- [ ] Improve GoDoc.

The remaining items in the v1 milestone shouldn't require large-scale changes.