### PR TITLE
[v1, 4/8] Replace NewJSON constructor with NewLogger

### DIFF
--- a/benchmarks/logrus_bench_test.go
+++ b/benchmarks/logrus_bench_test.go
@@ -63,7 +63,11 @@ func BenchmarkLogrusAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapBarkifyAddingFields(b *testing.B) {
-	logger := zbark.Barkify(zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard)))
+	logger := zbark.Barkify(zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard),
+	))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -106,7 +110,11 @@ func BenchmarkLogrusWithAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapBarkifyWithAccumulatedContext(b *testing.B) {
-	baseLogger := zbark.Barkify(zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard)))
+	baseLogger := zbark.Barkify(zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard),
+	))
 	logger := baseLogger.WithFields(bark.Fields{
 		"int":               1,
 		"int64":             int64(1),

--- a/benchmarks/logrus_bench_test.go
+++ b/benchmarks/logrus_bench_test.go
@@ -63,7 +63,7 @@ func BenchmarkLogrusAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapBarkifyAddingFields(b *testing.B) {
-	logger := zbark.Barkify(zap.NewLogger(
+	logger := zbark.Barkify(zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard),
@@ -110,7 +110,7 @@ func BenchmarkLogrusWithAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapBarkifyWithAccumulatedContext(b *testing.B) {
-	baseLogger := zbark.Barkify(zap.NewLogger(
+	baseLogger := zbark.Barkify(zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard),

--- a/benchmarks/stdlib_bench_test.go
+++ b/benchmarks/stdlib_bench_test.go
@@ -40,8 +40,10 @@ func BenchmarkStandardLibraryWithoutFields(b *testing.B) {
 }
 
 func BenchmarkZapStandardizeWithoutFields(b *testing.B) {
-	logger, err := zwrap.Standardize(
-		zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard)),
+	logger, err := zwrap.Standardize(zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard)),
 		zap.InfoLevel,
 	)
 	if err != nil {

--- a/benchmarks/stdlib_bench_test.go
+++ b/benchmarks/stdlib_bench_test.go
@@ -40,7 +40,7 @@ func BenchmarkStandardLibraryWithoutFields(b *testing.B) {
 }
 
 func BenchmarkZapStandardizeWithoutFields(b *testing.B) {
-	logger, err := zwrap.Standardize(zap.NewLogger(
+	logger, err := zwrap.Standardize(zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard)),

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -75,7 +75,7 @@ func fakeMessages(n int) []string {
 }
 
 func BenchmarkZapDisabledLevelsWithoutFields(b *testing.B) {
-	logger := zap.NewJSON(zap.ErrorLevel, zap.Output(zap.Discard))
+	logger := zap.NewLogger(zap.NewJSONEncoder(), zap.ErrorLevel, zap.Output(zap.Discard))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -86,7 +86,12 @@ func BenchmarkZapDisabledLevelsWithoutFields(b *testing.B) {
 
 func BenchmarkZapDisabledLevelsAccumulatedContext(b *testing.B) {
 	context := fakeFields()
-	logger := zap.NewJSON(zap.ErrorLevel, zap.Output(zap.Discard), zap.Fields(context...))
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.ErrorLevel,
+		zap.Output(zap.Discard),
+		zap.Fields(context...),
+	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -96,7 +101,11 @@ func BenchmarkZapDisabledLevelsAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapDisabledLevelsAddingFields(b *testing.B) {
-	logger := zap.NewJSON(zap.ErrorLevel, zap.Output(zap.Discard))
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.ErrorLevel,
+		zap.Output(zap.Discard),
+	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -106,7 +115,11 @@ func BenchmarkZapDisabledLevelsAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapDisabledLevelsCheckAddingFields(b *testing.B) {
-	logger := zap.NewJSON(zap.ErrorLevel, zap.Output(zap.Discard))
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.ErrorLevel,
+		zap.Output(zap.Discard),
+	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -118,7 +131,11 @@ func BenchmarkZapDisabledLevelsCheckAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapAddingFields(b *testing.B) {
-	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard),
+	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -129,7 +146,12 @@ func BenchmarkZapAddingFields(b *testing.B) {
 
 func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 	context := fakeFields()
-	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard), zap.Fields(context...))
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard),
+		zap.Fields(context...),
+	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -139,7 +161,11 @@ func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapWithoutFields(b *testing.B) {
-	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard),
+	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -150,7 +176,11 @@ func BenchmarkZapWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleWithoutFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
+	base := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard),
+	)
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -164,7 +194,11 @@ func BenchmarkZapSampleWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleAddingFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
+	base := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard),
+	)
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -178,7 +212,11 @@ func BenchmarkZapSampleAddingFields(b *testing.B) {
 
 func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
+	base := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard),
+	)
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -194,7 +232,11 @@ func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleCheckAddingFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
+	base := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard),
+	)
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -75,7 +75,7 @@ func fakeMessages(n int) []string {
 }
 
 func BenchmarkZapDisabledLevelsWithoutFields(b *testing.B) {
-	logger := zap.NewLogger(zap.NewJSONEncoder(), zap.ErrorLevel, zap.Output(zap.Discard))
+	logger := zap.New(zap.NewJSONEncoder(), zap.ErrorLevel, zap.Output(zap.Discard))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -86,7 +86,7 @@ func BenchmarkZapDisabledLevelsWithoutFields(b *testing.B) {
 
 func BenchmarkZapDisabledLevelsAccumulatedContext(b *testing.B) {
 	context := fakeFields()
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.ErrorLevel,
 		zap.Output(zap.Discard),
@@ -101,7 +101,7 @@ func BenchmarkZapDisabledLevelsAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapDisabledLevelsAddingFields(b *testing.B) {
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.ErrorLevel,
 		zap.Output(zap.Discard),
@@ -115,7 +115,7 @@ func BenchmarkZapDisabledLevelsAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapDisabledLevelsCheckAddingFields(b *testing.B) {
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.ErrorLevel,
 		zap.Output(zap.Discard),
@@ -131,7 +131,7 @@ func BenchmarkZapDisabledLevelsCheckAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapAddingFields(b *testing.B) {
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard),
@@ -146,7 +146,7 @@ func BenchmarkZapAddingFields(b *testing.B) {
 
 func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 	context := fakeFields()
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard),
@@ -161,7 +161,7 @@ func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapWithoutFields(b *testing.B) {
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard),
@@ -176,7 +176,7 @@ func BenchmarkZapWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleWithoutFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewLogger(
+	base := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard),
@@ -194,7 +194,7 @@ func BenchmarkZapSampleWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleAddingFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewLogger(
+	base := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard),
@@ -212,7 +212,7 @@ func BenchmarkZapSampleAddingFields(b *testing.B) {
 
 func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewLogger(
+	base := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard),
@@ -232,7 +232,7 @@ func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
 
 func BenchmarkZapSampleCheckAddingFields(b *testing.B) {
 	messages := fakeMessages(1000)
-	base := zap.NewLogger(
+	base := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard),

--- a/example_test.go
+++ b/example_test.go
@@ -33,7 +33,7 @@ import (
 func Example() {
 	// Log in JSON, using zap's reflection-free JSON encoder.
 	// The default options will log any Info or higher logs to standard out.
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
 	)
 
@@ -64,7 +64,7 @@ func Example_fileOutput() {
 	}
 	defer os.Remove(f.Name())
 
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
 		// Write the logging output to the specified file instead of stdout.
 		// Any type implementing zap.WriteSyncer or zap.WriteFlusher can be used.
@@ -87,7 +87,7 @@ func Example_fileOutput() {
 }
 
 func ExampleNest() {
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
 	)
 
@@ -99,10 +99,10 @@ func ExampleNest() {
 	// {"level":"info","msg":"Logging a nested field.","outer":{"inner":42}}
 }
 
-func ExampleNewLogger() {
+func ExampleNew() {
 	// The default logger outputs to standard out and only writes logs that are
 	// Info level or higher.
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
 	)
 
@@ -114,10 +114,10 @@ func ExampleNewLogger() {
 	// {"level":"info","msg":"This is an info log."}
 }
 
-func ExampleNewLogger_options() {
+func ExampleNew_options() {
 	// We can pass multiple options to the NewJSON method to configure
 	// the logging level, output location, or even the initial context.
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
 		zap.DebugLevel,
 		zap.Fields(zap.Int("count", 1)),
@@ -132,7 +132,7 @@ func ExampleNewLogger_options() {
 }
 
 func ExampleCheckedMessage() {
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
 	)
 

--- a/example_test.go
+++ b/example_test.go
@@ -99,7 +99,7 @@ func ExampleNest() {
 	// {"level":"info","msg":"Logging a nested field.","outer":{"inner":42}}
 }
 
-func ExampleNewJSON() {
+func ExampleNewLogger() {
 	// The default logger outputs to standard out and only writes logs that are
 	// Info level or higher.
 	logger := zap.NewLogger(
@@ -114,7 +114,7 @@ func ExampleNewJSON() {
 	// {"level":"info","msg":"This is an info log."}
 }
 
-func ExampleNewJSON_options() {
+func ExampleNewLogger_options() {
 	// We can pass multiple options to the NewJSON method to configure
 	// the logging level, output location, or even the initial context.
 	logger := zap.NewLogger(

--- a/example_test.go
+++ b/example_test.go
@@ -33,9 +33,9 @@ import (
 func Example() {
 	// Log in JSON, using zap's reflection-free JSON encoder.
 	// The default options will log any Info or higher logs to standard out.
-	logger := zap.NewJSON()
-	// For repeatable tests, pretend that it's always 1970.
-	logger.StubTime()
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
+	)
 
 	logger.Warn("Log without structured data...")
 	logger.Warn(
@@ -51,9 +51,9 @@ func Example() {
 	child.Error("Oh no!")
 
 	// Output:
-	// {"level":"warn","ts":0,"msg":"Log without structured data..."}
-	// {"level":"warn","ts":0,"msg":"Or use strongly-typed wrappers to add structured context.","library":"zap","latency":1}
-	// {"level":"error","ts":0,"msg":"Oh no!","user":"jane@test.com","visits":42}
+	// {"level":"warn","msg":"Log without structured data..."}
+	// {"level":"warn","msg":"Or use strongly-typed wrappers to add structured context.","library":"zap","latency":1}
+	// {"level":"error","msg":"Oh no!","user":"jane@test.com","visits":42}
 }
 
 func Example_fileOutput() {
@@ -64,13 +64,12 @@ func Example_fileOutput() {
 	}
 	defer os.Remove(f.Name())
 
-	logger := zap.NewJSON(
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
 		// Write the logging output to the specified file instead of stdout.
 		// Any type implementing zap.WriteSyncer or zap.WriteFlusher can be used.
 		zap.Output(f),
 	)
-	// Stub the current time in tests.
-	logger.StubTime()
 
 	logger.Info("This is an info log.", zap.Int("foo", 42))
 
@@ -84,59 +83,58 @@ func Example_fileOutput() {
 
 	fmt.Println(string(contents))
 	// Output:
-	// {"level":"info","ts":0,"msg":"This is an info log.","foo":42}
+	// {"level":"info","msg":"This is an info log.","foo":42}
 }
 
 func ExampleNest() {
-	logger := zap.NewJSON()
-	// Stub the current time in tests.
-	logger.StubTime()
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
+	)
 
 	// We'd like the logging context to be {"outer":{"inner":42}}
 	nest := zap.Nest("outer", zap.Int("inner", 42))
 	logger.Info("Logging a nested field.", nest)
 
 	// Output:
-	// {"level":"info","ts":0,"msg":"Logging a nested field.","outer":{"inner":42}}
+	// {"level":"info","msg":"Logging a nested field.","outer":{"inner":42}}
 }
 
 func ExampleNewJSON() {
 	// The default logger outputs to standard out and only writes logs that are
 	// Info level or higher.
-	logger := zap.NewJSON()
-	// Stub the current time in tests.
-	logger.StubTime()
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
+	)
 
 	// The default logger does not print Debug logs.
 	logger.Debug("This won't be printed.")
 	logger.Info("This is an info log.")
 
 	// Output:
-	// {"level":"info","ts":0,"msg":"This is an info log."}
+	// {"level":"info","msg":"This is an info log."}
 }
 
 func ExampleNewJSON_options() {
 	// We can pass multiple options to the NewJSON method to configure
 	// the logging level, output location, or even the initial context.
-	logger := zap.NewJSON(
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
 		zap.DebugLevel,
 		zap.Fields(zap.Int("count", 1)),
 	)
-	// Stub the current time in tests.
-	logger.StubTime()
 
 	logger.Debug("This is a debug log.")
 	logger.Info("This is an info log.")
 
 	// Output:
-	// {"level":"debug","ts":0,"msg":"This is a debug log.","count":1}
-	// {"level":"info","ts":0,"msg":"This is an info log.","count":1}
+	// {"level":"debug","msg":"This is a debug log.","count":1}
+	// {"level":"info","msg":"This is an info log.","count":1}
 }
 
 func ExampleCheckedMessage() {
-	logger := zap.NewJSON()
-	// Stub the current time in tests.
-	logger.StubTime()
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
+	)
 
 	// By default, the debug logging level is disabled. However, calls to
 	// logger.Debug will still allocate a slice to hold any passed fields.
@@ -153,7 +151,7 @@ func ExampleCheckedMessage() {
 	}
 
 	// Output:
-	// {"level":"info","ts":0,"msg":"This is an info log."}
+	// {"level":"info","msg":"This is an info log."}
 }
 
 func ExampleLevel_MarshalText() {

--- a/hook_test.go
+++ b/hook_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestHookAddCaller(t *testing.T) {
 	buf := &testBuffer{}
-	logger := NewJSON(DebugLevel, Output(buf), AddCaller())
+	logger := NewLogger(NewJSONEncoder(), DebugLevel, Output(buf), AddCaller())
 	logger.Info("Callers.")
 
 	re := regexp.MustCompile(`"msg":"hook_test.go:[\d]+: Callers\."`)
@@ -45,7 +45,7 @@ func TestHookAddCallerFail(t *testing.T) {
 	_callerSkip = 1e3
 	defer func() { _callerSkip = originalSkip }()
 
-	logger := NewJSON(DebugLevel, Output(buf), ErrorOutput(errBuf), AddCaller())
+	logger := NewLogger(NewJSONEncoder(), DebugLevel, Output(buf), ErrorOutput(errBuf), AddCaller())
 	logger.Info("Failure.")
 	assert.Equal(t, "failed to get caller\n", errBuf.String(), "Didn't find expected failure message.")
 	assert.Contains(t, buf.String(), `"msg":"Failure."`, "Expected original message to survive failures in runtime.Caller.")
@@ -53,7 +53,7 @@ func TestHookAddCallerFail(t *testing.T) {
 
 func TestHookAddStacks(t *testing.T) {
 	buf := &testBuffer{}
-	logger := NewJSON(DebugLevel, Output(buf), AddStacks(InfoLevel))
+	logger := NewLogger(NewJSONEncoder(), DebugLevel, Output(buf), AddStacks(InfoLevel))
 
 	logger.Info("Stacks.")
 	output := buf.String()

--- a/hook_test.go
+++ b/hook_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestHookAddCaller(t *testing.T) {
 	buf := &testBuffer{}
-	logger := NewLogger(NewJSONEncoder(), DebugLevel, Output(buf), AddCaller())
+	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), AddCaller())
 	logger.Info("Callers.")
 
 	re := regexp.MustCompile(`"msg":"hook_test.go:[\d]+: Callers\."`)
@@ -45,7 +45,7 @@ func TestHookAddCallerFail(t *testing.T) {
 	_callerSkip = 1e3
 	defer func() { _callerSkip = originalSkip }()
 
-	logger := NewLogger(NewJSONEncoder(), DebugLevel, Output(buf), ErrorOutput(errBuf), AddCaller())
+	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), ErrorOutput(errBuf), AddCaller())
 	logger.Info("Failure.")
 	assert.Equal(t, "failed to get caller\n", errBuf.String(), "Didn't find expected failure message.")
 	assert.Contains(t, buf.String(), `"msg":"Failure."`, "Expected original message to survive failures in runtime.Caller.")
@@ -53,7 +53,7 @@ func TestHookAddCallerFail(t *testing.T) {
 
 func TestHookAddStacks(t *testing.T) {
 	buf := &testBuffer{}
-	logger := NewLogger(NewJSONEncoder(), DebugLevel, Output(buf), AddStacks(InfoLevel))
+	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), AddStacks(InfoLevel))
 
 	logger.Info("Stacks.")
 	output := buf.String()

--- a/logger.go
+++ b/logger.go
@@ -76,13 +76,13 @@ type logger struct {
 	alwaysEpoch bool
 }
 
-// NewLogger constructs a logger that uses the provided encoder. By default, the
+// New constructs a logger that uses the provided encoder. By default, the
 // logger will write Info logs or higher to standard out. Any errors during logging
 // will be written to standard error.
 //
 // Options can change the log level, the output location, the initial fields
 // that should be added as context, and many other behaviors.
-func NewLogger(enc Encoder, options ...Option) Logger {
+func New(enc Encoder, options ...Option) Logger {
 	logger := logger{
 		Meta: MakeMeta(enc),
 	}

--- a/logger.go
+++ b/logger.go
@@ -70,33 +70,20 @@ type Logger interface {
 	DFatal(string, ...Field)
 }
 
-type jsonLogger struct {
+type logger struct {
 	Meta
 
 	alwaysEpoch bool
 }
 
-// NewJSON returns a logger that formats its output as JSON. Zap uses a
-// customized JSON encoder to avoid reflection and minimize allocations.
+// NewLogger constructs a logger that uses the provided encoder. By default, the
+// logger will write Info logs or higher to standard out. Any errors during logging
+// will be written to standard error.
 //
-// By default, the logger will write Info logs or higher to standard
-// out. Any errors during logging will be written to standard error.
-//
-// Options can change the log level, the output location, the initial
-// fields that should be added as context, and many other behaviors.
-func NewJSON(options ...Option) Logger {
-	logger := jsonLogger{
-		Meta: MakeMeta(NewJSONEncoder()),
-	}
-	for _, opt := range options {
-		opt.apply(&logger.Meta)
-	}
-	return &logger
-}
-
-// TODO: export as New and replace NewJSON.
-func newLogger(enc Encoder, options ...Option) Logger {
-	logger := jsonLogger{
+// Options can change the log level, the output location, the initial fields
+// that should be added as context, and many other behaviors.
+func NewLogger(enc Encoder, options ...Option) Logger {
+	logger := logger{
 		Meta: MakeMeta(enc),
 	}
 	for _, opt := range options {
@@ -105,102 +92,102 @@ func newLogger(enc Encoder, options ...Option) Logger {
 	return &logger
 }
 
-func (jl *jsonLogger) With(fields ...Field) Logger {
-	clone := &jsonLogger{
-		Meta:        jl.Meta.Clone(),
-		alwaysEpoch: jl.alwaysEpoch,
+func (log *logger) With(fields ...Field) Logger {
+	clone := &logger{
+		Meta:        log.Meta.Clone(),
+		alwaysEpoch: log.alwaysEpoch,
 	}
 	clone.Encoder.AddFields(fields)
 	return clone
 }
 
-func (jl *jsonLogger) StubTime() {
-	jl.alwaysEpoch = true
+func (log *logger) StubTime() {
+	log.alwaysEpoch = true
 }
 
-func (jl *jsonLogger) Check(lvl Level, msg string) *CheckedMessage {
-	if !(lvl >= jl.Level()) {
+func (log *logger) Check(lvl Level, msg string) *CheckedMessage {
+	if !(lvl >= log.Level()) {
 		return nil
 	}
-	return NewCheckedMessage(jl, lvl, msg)
+	return NewCheckedMessage(log, lvl, msg)
 }
 
-func (jl *jsonLogger) Log(lvl Level, msg string, fields ...Field) {
+func (log *logger) Log(lvl Level, msg string, fields ...Field) {
 	switch lvl {
 	case PanicLevel:
-		jl.Panic(msg, fields...)
+		log.Panic(msg, fields...)
 	case FatalLevel:
-		jl.Fatal(msg, fields...)
+		log.Fatal(msg, fields...)
 	default:
-		jl.log(lvl, msg, fields)
+		log.log(lvl, msg, fields)
 	}
 }
 
-func (jl *jsonLogger) Debug(msg string, fields ...Field) {
-	jl.log(DebugLevel, msg, fields)
+func (log *logger) Debug(msg string, fields ...Field) {
+	log.log(DebugLevel, msg, fields)
 }
 
-func (jl *jsonLogger) Info(msg string, fields ...Field) {
-	jl.log(InfoLevel, msg, fields)
+func (log *logger) Info(msg string, fields ...Field) {
+	log.log(InfoLevel, msg, fields)
 }
 
-func (jl *jsonLogger) Warn(msg string, fields ...Field) {
-	jl.log(WarnLevel, msg, fields)
+func (log *logger) Warn(msg string, fields ...Field) {
+	log.log(WarnLevel, msg, fields)
 }
 
-func (jl *jsonLogger) Error(msg string, fields ...Field) {
-	jl.log(ErrorLevel, msg, fields)
+func (log *logger) Error(msg string, fields ...Field) {
+	log.log(ErrorLevel, msg, fields)
 }
 
-func (jl *jsonLogger) Panic(msg string, fields ...Field) {
-	jl.log(PanicLevel, msg, fields)
+func (log *logger) Panic(msg string, fields ...Field) {
+	log.log(PanicLevel, msg, fields)
 	panic(msg)
 }
 
-func (jl *jsonLogger) Fatal(msg string, fields ...Field) {
-	jl.log(FatalLevel, msg, fields)
+func (log *logger) Fatal(msg string, fields ...Field) {
+	log.log(FatalLevel, msg, fields)
 	_exit(1)
 }
 
-func (jl *jsonLogger) DFatal(msg string, fields ...Field) {
-	if jl.Development {
-		jl.Fatal(msg, fields...)
+func (log *logger) DFatal(msg string, fields ...Field) {
+	if log.Development {
+		log.Fatal(msg, fields...)
 		return
 	}
-	jl.Error(msg, fields...)
+	log.Error(msg, fields...)
 }
 
-func (jl *jsonLogger) log(lvl Level, msg string, fields []Field) {
-	if !(lvl >= jl.Level()) {
+func (log *logger) log(lvl Level, msg string, fields []Field) {
+	if !(lvl >= log.Level()) {
 		return
 	}
 
-	temp := jl.Encoder.Clone()
+	temp := log.Encoder.Clone()
 	temp.AddFields(fields)
 
 	entry := newEntry(lvl, msg, temp)
-	if jl.alwaysEpoch {
+	if log.alwaysEpoch {
 		entry.Time = time.Unix(0, 0)
 	}
-	for _, hook := range jl.Hooks {
+	for _, hook := range log.Hooks {
 		if err := hook(entry); err != nil {
-			jl.internalError(err.Error())
+			log.internalError(err.Error())
 		}
 	}
 
-	if err := temp.WriteEntry(jl.Output, entry.Message, entry.Level, entry.Time); err != nil {
-		jl.internalError(err.Error())
+	if err := temp.WriteEntry(log.Output, entry.Message, entry.Level, entry.Time); err != nil {
+		log.internalError(err.Error())
 	}
 	temp.Free()
 	entry.free()
 
 	if lvl > ErrorLevel {
 		// Sync on Panic and Fatal, since they may crash the program.
-		jl.Output.Sync()
+		log.Output.Sync()
 	}
 }
 
-func (jl *jsonLogger) internalError(msg string) {
-	fmt.Fprintln(jl.ErrorOutput, msg)
-	jl.ErrorOutput.Sync()
+func (log *logger) internalError(msg string) {
+	fmt.Fprintln(log.ErrorOutput, msg)
+	log.ErrorOutput.Sync()
 }

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -48,7 +48,11 @@ var _jane = &user{
 }
 
 func withBenchedLogger(b *testing.B, f func(zap.Logger)) {
-	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard),
+	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -138,7 +142,8 @@ func BenchmarkObjectField(b *testing.B) {
 }
 
 func BenchmarkAddCallerHook(b *testing.B) {
-	logger := zap.NewJSON(
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(),
 		zap.Output(zap.Discard),
 		zap.AddCaller(),
 	)
@@ -169,7 +174,11 @@ func Benchmark10Fields(b *testing.B) {
 
 func Benchmark100Fields(b *testing.B) {
 	const batchSize = 50
-	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.Discard))
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.Discard),
+	)
 
 	// Don't include allocating these helper slices in the benchmark. Since
 	// access to them isn't synchronized, we can't run the benchmark in

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -48,7 +48,7 @@ var _jane = &user{
 }
 
 func withBenchedLogger(b *testing.B, f func(zap.Logger)) {
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard),
@@ -142,7 +142,7 @@ func BenchmarkObjectField(b *testing.B) {
 }
 
 func BenchmarkAddCallerHook(b *testing.B) {
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.Output(zap.Discard),
 		zap.AddCaller(),
@@ -174,7 +174,7 @@ func Benchmark10Fields(b *testing.B) {
 
 func Benchmark100Fields(b *testing.B) {
 	const batchSize = 50
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.Discard),

--- a/logger_test.go
+++ b/logger_test.go
@@ -68,7 +68,7 @@ func withJSONLogger(t testing.TB, opts []Option, f func(Logger, *testBuffer)) {
 	allOpts := make([]Option, 0, 3+len(opts))
 	allOpts = append(allOpts, DebugLevel, Output(sink), ErrorOutput(errSink))
 	allOpts = append(allOpts, opts...)
-	logger := NewLogger(newJSONEncoder(NoTime()), allOpts...)
+	logger := New(newJSONEncoder(NoTime()), allOpts...)
 
 	f(logger, sink)
 	assert.Empty(t, errSink.String(), "Expected error sink to be empty.")
@@ -85,7 +85,7 @@ func TestJSONLoggerSetLevel(t *testing.T) {
 func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
 	// Test that changing a logger's level also changes the level of all
 	// ancestors and descendants.
-	grandparent := NewLogger(newJSONEncoder(), Fields(Int("generation", 1)))
+	grandparent := New(newJSONEncoder(), Fields(Int("generation", 1)))
 	parent := grandparent.With(Int("generation", 2))
 	child := parent.With(Int("generation", 3))
 
@@ -102,7 +102,7 @@ func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
 
 func TestJSONLoggerConcurrentLevelMutation(t *testing.T) {
 	// Trigger races for non-atomic level mutations.
-	logger := NewLogger(newJSONEncoder())
+	logger := New(newJSONEncoder())
 
 	proceed := make(chan struct{})
 	wg := &sync.WaitGroup{}
@@ -231,7 +231,7 @@ func TestJSONLoggerNoOpsDisabledLevels(t *testing.T) {
 func TestJSONLoggerWriteEntryFailure(t *testing.T) {
 	errBuf := &testBuffer{}
 	errSink := &spywrite.WriteSyncer{Writer: errBuf}
-	logger := NewLogger(
+	logger := New(
 		newJSONEncoder(),
 		DebugLevel,
 		Output(AddSync(spywrite.FailWriter{})),
@@ -246,7 +246,7 @@ func TestJSONLoggerWriteEntryFailure(t *testing.T) {
 
 func TestJSONLoggerSyncsOutput(t *testing.T) {
 	sink := &spywrite.WriteSyncer{Writer: ioutil.Discard}
-	logger := NewLogger(newJSONEncoder(), DebugLevel, Output(sink))
+	logger := New(newJSONEncoder(), DebugLevel, Output(sink))
 
 	logger.Error("foo")
 	assert.False(t, sink.Called(), "Didn't expect logging at error level to Sync underlying WriteCloser.")

--- a/logger_test.go
+++ b/logger_test.go
@@ -68,7 +68,7 @@ func withJSONLogger(t testing.TB, opts []Option, f func(Logger, *testBuffer)) {
 	allOpts := make([]Option, 0, 3+len(opts))
 	allOpts = append(allOpts, DebugLevel, Output(sink), ErrorOutput(errSink))
 	allOpts = append(allOpts, opts...)
-	logger := newLogger(newJSONEncoder(NoTime()), allOpts...)
+	logger := NewLogger(newJSONEncoder(NoTime()), allOpts...)
 
 	f(logger, sink)
 	assert.Empty(t, errSink.String(), "Expected error sink to be empty.")
@@ -85,7 +85,7 @@ func TestJSONLoggerSetLevel(t *testing.T) {
 func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
 	// Test that changing a logger's level also changes the level of all
 	// ancestors and descendants.
-	grandparent := newLogger(newJSONEncoder(), Fields(Int("generation", 1)))
+	grandparent := NewLogger(newJSONEncoder(), Fields(Int("generation", 1)))
 	parent := grandparent.With(Int("generation", 2))
 	child := parent.With(Int("generation", 3))
 
@@ -102,7 +102,7 @@ func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
 
 func TestJSONLoggerConcurrentLevelMutation(t *testing.T) {
 	// Trigger races for non-atomic level mutations.
-	logger := newLogger(newJSONEncoder())
+	logger := NewLogger(newJSONEncoder())
 
 	proceed := make(chan struct{})
 	wg := &sync.WaitGroup{}
@@ -231,7 +231,7 @@ func TestJSONLoggerNoOpsDisabledLevels(t *testing.T) {
 func TestJSONLoggerWriteEntryFailure(t *testing.T) {
 	errBuf := &testBuffer{}
 	errSink := &spywrite.WriteSyncer{Writer: errBuf}
-	logger := newLogger(
+	logger := NewLogger(
 		newJSONEncoder(),
 		DebugLevel,
 		Output(AddSync(spywrite.FailWriter{})),
@@ -246,7 +246,7 @@ func TestJSONLoggerWriteEntryFailure(t *testing.T) {
 
 func TestJSONLoggerSyncsOutput(t *testing.T) {
 	sink := &spywrite.WriteSyncer{Writer: ioutil.Discard}
-	logger := newLogger(newJSONEncoder(), DebugLevel, Output(sink))
+	logger := NewLogger(newJSONEncoder(), DebugLevel, Output(sink))
 
 	logger.Error("foo")
 	assert.False(t, sink.Called(), "Didn't expect logging at error level to Sync underlying WriteCloser.")

--- a/marshaler_example_test.go
+++ b/marshaler_example_test.go
@@ -62,7 +62,7 @@ func ExampleMarshaler() {
 		},
 	}
 
-	logger := zap.NewLogger(zap.NewJSONEncoder(zap.NoTime()))
+	logger := zap.New(zap.NewJSONEncoder(zap.NoTime()))
 	logger.Info("Successful login.", zap.Marshaler("user", jane))
 
 	// Output:

--- a/marshaler_example_test.go
+++ b/marshaler_example_test.go
@@ -62,11 +62,9 @@ func ExampleMarshaler() {
 		},
 	}
 
-	logger := zap.NewJSON()
-	// Stub time in tests.
-	logger.StubTime()
+	logger := zap.NewLogger(zap.NewJSONEncoder(zap.NoTime()))
 	logger.Info("Successful login.", zap.Marshaler("user", jane))
 
 	// Output:
-	// {"level":"info","ts":0,"msg":"Successful login.","user":{"name":"Jane Doe","age":42,"auth":{"expires_at":100,"token":"---"}}}
+	// {"level":"info","msg":"Successful login.","user":{"name":"Jane Doe","age":42,"auth":{"expires_at":100,"token":"---"}}}
 }

--- a/zbark/bark_test.go
+++ b/zbark/bark_test.go
@@ -59,7 +59,7 @@ func (l loggable) MarshalLog(kv zap.KeyValue) error {
 
 func newBark() (bark.Logger, *bytes.Buffer) {
 	buf := &bytes.Buffer{}
-	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.AddSync(buf)))
+	logger := zap.NewLogger(zap.NewJSONEncoder(), zap.DebugLevel, zap.Output(zap.AddSync(buf)))
 	return Barkify(logger), buf
 }
 

--- a/zbark/bark_test.go
+++ b/zbark/bark_test.go
@@ -59,7 +59,7 @@ func (l loggable) MarshalLog(kv zap.KeyValue) error {
 
 func newBark() (bark.Logger, *bytes.Buffer) {
 	buf := &bytes.Buffer{}
-	logger := zap.NewLogger(zap.NewJSONEncoder(), zap.DebugLevel, zap.Output(zap.AddSync(buf)))
+	logger := zap.New(zap.NewJSONEncoder(), zap.DebugLevel, zap.Output(zap.AddSync(buf)))
 	return Barkify(logger), buf
 }
 

--- a/zbark/example_test.go
+++ b/zbark/example_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func Example() {
-	zapLogger := zap.NewLogger(zap.NewJSONEncoder(
+	zapLogger := zap.New(zap.NewJSONEncoder(
 		zap.NoTime(), // discard timestamps in tests
 	))
 

--- a/zbark/example_test.go
+++ b/zbark/example_test.go
@@ -26,9 +26,9 @@ import (
 )
 
 func Example() {
-	zapLogger := zap.NewJSON()
-	// Stub the current time in tests.
-	zapLogger.StubTime()
+	zapLogger := zap.NewLogger(zap.NewJSONEncoder(
+		zap.NoTime(), // discard timestamps in tests
+	))
 
 	// Wrap our structured logger to mimic bark.Logger.
 	logger := zbark.Barkify(zapLogger)
@@ -37,5 +37,5 @@ func Example() {
 	logger.WithField("errors", 0).Infof("%v accepts arbitrary types.", "Bark")
 
 	// Output:
-	// {"level":"info","ts":0,"msg":"Bark accepts arbitrary types.","errors":0}
+	// {"level":"info","msg":"Bark accepts arbitrary types.","errors":0}
 }

--- a/zwrap/example_test.go
+++ b/zwrap/example_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func Example_standardize() {
-	zapLogger := zap.NewLogger(zap.NewJSONEncoder(
+	zapLogger := zap.New(zap.NewJSONEncoder(
 		zap.NoTime(), // discard timestamps in tests
 	))
 
@@ -49,7 +49,7 @@ func Example_standardize() {
 }
 
 func Example_sample() {
-	zapLogger := zap.NewLogger(zap.NewJSONEncoder(
+	zapLogger := zap.New(zap.NewJSONEncoder(
 		zap.NoTime(), // discard timestamps in tests
 	))
 	sampledLogger := zwrap.Sample(zapLogger, time.Second, 1, 100)

--- a/zwrap/example_test.go
+++ b/zwrap/example_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 func Example_standardize() {
-	zapLogger := zap.NewJSON()
-	// Stub the current time in tests.
-	zapLogger.StubTime()
+	zapLogger := zap.NewLogger(zap.NewJSONEncoder(
+		zap.NoTime(), // discard timestamps in tests
+	))
 
 	// Wrap our structured logger to mimic the standard library's log.Logger.
 	// We also specify that we want all calls to the standard logger's Print
@@ -45,13 +45,14 @@ func Example_standardize() {
 	stdLogger.Printf("Encountered %d errors.", 0)
 
 	// Output:
-	// {"level":"warn","ts":0,"msg":"Encountered 0 errors."}
+	// {"level":"warn","msg":"Encountered 0 errors."}
 }
 
 func Example_sample() {
-	sampledLogger := zwrap.Sample(zap.NewJSON(), time.Second, 1, 100)
-	// Stub the current time in tests.
-	sampledLogger.StubTime()
+	zapLogger := zap.NewLogger(zap.NewJSONEncoder(
+		zap.NoTime(), // discard timestamps in tests
+	))
+	sampledLogger := zwrap.Sample(zapLogger, time.Second, 1, 100)
 
 	for i := 1; i < 110; i++ {
 		sampledLogger.With(zap.Int("n", i)).Error("Common failure.")
@@ -60,7 +61,7 @@ func Example_sample() {
 	sampledLogger.Error("Unusual failure.")
 
 	// Output:
-	// {"level":"error","ts":0,"msg":"Common failure.","n":1}
-	// {"level":"error","ts":0,"msg":"Common failure.","n":101}
-	// {"level":"error","ts":0,"msg":"Unusual failure."}
+	// {"level":"error","msg":"Common failure.","n":1}
+	// {"level":"error","msg":"Common failure.","n":101}
+	// {"level":"error","msg":"Unusual failure."}
 }

--- a/zwrap/standard_test.go
+++ b/zwrap/standard_test.go
@@ -33,7 +33,11 @@ import (
 
 func newStd(lvl zap.Level) (StandardLogger, *bytes.Buffer, error) {
 	buf := &bytes.Buffer{}
-	logger := zap.NewJSON(zap.DebugLevel, zap.Output(zap.AddSync(buf)))
+	logger := zap.NewLogger(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.Output(zap.AddSync(buf)),
+	)
 	std, err := Standardize(logger, lvl)
 	return std, buf, err
 }

--- a/zwrap/standard_test.go
+++ b/zwrap/standard_test.go
@@ -33,7 +33,7 @@ import (
 
 func newStd(lvl zap.Level) (StandardLogger, *bytes.Buffer, error) {
 	buf := &bytes.Buffer{}
-	logger := zap.NewLogger(
+	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
 		zap.Output(zap.AddSync(buf)),


### PR DESCRIPTION
Make the logger type name more generic, since it's not actually JSON-specific, and make the logger constructor take an encoder implementation. Since we're injecting encoders, we can stop using the ugly `StubTime` hack (which we'll remove altogether in the next PR).

This is the fourth of eight PRs to finish up the large pre-v1.0.0 refactoring:
- [x] Meta constructor takes an encoder
- [x] Export Encoder type
- [x] Export the JSON encoder constructor
- [ ] Add a `NewLogger` constructor and remove `NewJSON`
- [ ] Remove `StubTime`
- [ ] Export the Hook type
- [ ] Remove `Encoder.AddFields` (since we already have `Field.AddTo`)
- [ ] Improve GoDoc.

The remaining items in the v1 milestone shouldn't require large-scale changes.