### PR TITLE
[v1, 5/8] Remove StubTime in favor of Encoder options

### DIFF
--- a/spy/logger.go
+++ b/spy/logger.go
@@ -79,9 +79,6 @@ func New() (*Logger, *Sink) {
 	}, s
 }
 
-// StubTime is a no-op, since the spy logger omits time entirely.
-func (l *Logger) StubTime() {}
-
 // With creates a new Logger with additional fields added to the logging context.
 func (l *Logger) With(fields ...zap.Field) zap.Logger {
 	return &Logger{


### PR DESCRIPTION
Our ugly `StubTime` hack is no longer necessary now that we have the `NoTime` option for the JSON encoder. Remove it!

This is the fifth of eight PRs to finish up the large pre-v1.0.0 refactoring:
- [x] Meta constructor takes an encoder
- [x] Export Encoder type
- [x] Export the JSON encoder constructor
- [x] Add a `New` constructor and remove `NewJSON`
- [ ] Remove `StubTime`
- [ ] Export the Hook type
- [ ] Remove `Encoder.AddFields` (since we already have `Field.AddTo`)
- [ ] Improve GoDoc.

The remaining items in the v1 milestone shouldn't require large-scale changes.