### PR TITLE
[v1, 6/8] Export the Hook type

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -35,20 +35,22 @@ var (
 	_callerSkip = 3
 )
 
-// A hook is executed each time the logger writes an Entry. It can modify the
+// A Hook is executed each time the logger writes an Entry. It can modify the
 // entry, but must not retain references to the entry or any of its
 // contents. Returned errors are written to the logger's error output.
-type hook func(*Entry) error
+//
+// Hooks implement the Option interface.
+type Hook func(*Entry) error
 
 // apply implements the Option interface.
-func (h hook) apply(m *Meta) {
+func (h Hook) apply(m *Meta) {
 	m.Hooks = append(m.Hooks, h)
 }
 
 // AddCaller configures the Logger to annotate each message with the filename
 // and line number of zap's caller.
 func AddCaller() Option {
-	return hook(func(e *Entry) error {
+	return Hook(func(e *Entry) error {
 		if e == nil {
 			return errHookNilEntry
 		}
@@ -78,7 +80,7 @@ func AddCaller() Option {
 // or above a given level. Keep in mind that this is (relatively speaking) quite
 // expensive.
 func AddStacks(lvl Level) Option {
-	return hook(func(e *Entry) error {
+	return Hook(func(e *Entry) error {
 		if e == nil {
 			return errHookNilEntry
 		}

--- a/hook_test.go
+++ b/hook_test.go
@@ -72,10 +72,10 @@ func TestHookAddStacks(t *testing.T) {
 func TestHooksNilEntry(t *testing.T) {
 	tests := []struct {
 		name string
-		hook hook
+		hook Hook
 	}{
-		{"AddStacks", AddStacks(InfoLevel).(hook)},
-		{"AddCaller", AddCaller().(hook)},
+		{"AddStacks", AddStacks(InfoLevel).(Hook)},
+		{"AddCaller", AddCaller().(Hook)},
 	}
 	for _, tt := range tests {
 		assert.NotPanics(t, func() {

--- a/meta.go
+++ b/meta.go
@@ -34,7 +34,7 @@ import (
 type Meta struct {
 	Development bool
 	Encoder     Encoder
-	Hooks       []hook
+	Hooks       []Hook
 	Output      WriteSyncer
 	ErrorOutput WriteSyncer
 


### PR DESCRIPTION
Export the `Hook` type so users can define their own hooks.

This is the sixth of eight PRs to finish up the large pre-v1.0.0 refactoring:
- [x] Meta constructor takes an encoder
- [x] Export Encoder type
- [x] Export the JSON encoder constructor
- [x] Add a `New` constructor and remove `NewJSON`
- [x] Remove `StubTime`
- [ ] Export the Hook type
- [ ] Remove `Encoder.AddFields` (since we already have `Field.AddTo`)
- [ ] Improve GoDoc.

The remaining items in the v1 milestone shouldn't require large-scale changes.