### PR TITLE
[v1, 7/8] Remove Encoder.AddFields

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -30,7 +30,6 @@ import (
 type Encoder interface {
 	KeyValue
 
-	AddFields([]Field)
 	Clone() Encoder
 	Free()
 	WriteEntry(io.Writer, string, Level, time.Time) error

--- a/json_encoder.go
+++ b/json_encoder.go
@@ -178,11 +178,6 @@ func (enc *jsonEncoder) Clone() Encoder {
 	return clone
 }
 
-// AddFields applies the passed fields to this encoder.
-func (enc *jsonEncoder) AddFields(fields []Field) {
-	addFields(enc, fields)
-}
-
 // WriteEntry writes a complete log message to the supplied writer, including
 // the encoder's accumulated fields. It doesn't modify or lock the encoder's
 // underlying byte slice. It's safe to call from multiple goroutines, but it's

--- a/logger.go
+++ b/logger.go
@@ -84,7 +84,7 @@ func (log *logger) With(fields ...Field) Logger {
 	clone := &logger{
 		Meta: log.Meta.Clone(),
 	}
-	clone.Encoder.AddFields(fields)
+	addFields(clone.Encoder, fields)
 	return clone
 }
 
@@ -146,7 +146,7 @@ func (log *logger) log(lvl Level, msg string, fields []Field) {
 	}
 
 	temp := log.Encoder.Clone()
-	temp.AddFields(fields)
+	addFields(temp, fields)
 
 	entry := newEntry(lvl, msg, temp)
 	for _, hook := range log.Hooks {

--- a/options.go
+++ b/options.go
@@ -40,7 +40,7 @@ func (l Level) apply(m *Meta) {
 // Fields sets the initial fields for the logger.
 func Fields(fields ...Field) Option {
 	return optionFunc(func(m *Meta) {
-		m.Encoder.AddFields(fields)
+		addFields(m.Encoder, fields)
 	})
 }
 


### PR DESCRIPTION
Remove `AddFields` from the `Encoder` interface: it increases the number of methods each encoder must implement, and it's not actually adding much value. Users can rely on `Field.AddTo` and a for loop, and within zap we're already using a small helper function.

This is the seventh of eight PRs to finish up the large pre-v1.0.0 refactoring:
- [x] Meta constructor takes an encoder
- [x] Export Encoder type
- [x] Export the JSON encoder constructor
- [x] Add a `New` constructor and remove `NewJSON`
- [x] Remove `StubTime`
- [x] Export the Hook type
- [ ] Remove `Encoder.AddFields` (since we already have `Field.AddTo`)
- [ ] Improve GoDoc.

The remaining items in the v1 milestone shouldn't require large-scale changes.