### PR TITLE
Add a DiscardOutput option

### DIFF
--- a/benchmarks/logrus_bench_test.go
+++ b/benchmarks/logrus_bench_test.go
@@ -66,7 +66,7 @@ func BenchmarkZapBarkifyAddingFields(b *testing.B) {
 	logger := zbark.Barkify(zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -113,7 +113,7 @@ func BenchmarkZapBarkifyWithAccumulatedContext(b *testing.B) {
 	baseLogger := zbark.Barkify(zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	))
 	logger := baseLogger.WithFields(bark.Fields{
 		"int":               1,

--- a/benchmarks/stdlib_bench_test.go
+++ b/benchmarks/stdlib_bench_test.go
@@ -40,10 +40,12 @@ func BenchmarkStandardLibraryWithoutFields(b *testing.B) {
 }
 
 func BenchmarkZapStandardizeWithoutFields(b *testing.B) {
-	logger, err := zwrap.Standardize(zap.New(
-		zap.NewJSONEncoder(),
-		zap.DebugLevel,
-		zap.Output(zap.Discard)),
+	logger, err := zwrap.Standardize(
+		zap.New(
+			zap.NewJSONEncoder(),
+			zap.DebugLevel,
+			zap.DiscardOutput,
+		),
 		zap.InfoLevel,
 	)
 	if err != nil {

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -75,7 +75,7 @@ func fakeMessages(n int) []string {
 }
 
 func BenchmarkZapDisabledLevelsWithoutFields(b *testing.B) {
-	logger := zap.New(zap.NewJSONEncoder(), zap.ErrorLevel, zap.Output(zap.Discard))
+	logger := zap.New(zap.NewJSONEncoder(), zap.ErrorLevel, zap.DiscardOutput)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -89,7 +89,7 @@ func BenchmarkZapDisabledLevelsAccumulatedContext(b *testing.B) {
 	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.ErrorLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 		zap.Fields(context...),
 	)
 	b.ResetTimer()
@@ -104,7 +104,7 @@ func BenchmarkZapDisabledLevelsAddingFields(b *testing.B) {
 	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.ErrorLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -118,7 +118,7 @@ func BenchmarkZapDisabledLevelsCheckAddingFields(b *testing.B) {
 	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.ErrorLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -134,7 +134,7 @@ func BenchmarkZapAddingFields(b *testing.B) {
 	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -149,7 +149,7 @@ func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 		zap.Fields(context...),
 	)
 	b.ResetTimer()
@@ -164,7 +164,7 @@ func BenchmarkZapWithoutFields(b *testing.B) {
 	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -179,7 +179,7 @@ func BenchmarkZapSampleWithoutFields(b *testing.B) {
 	base := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	)
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
@@ -197,7 +197,7 @@ func BenchmarkZapSampleAddingFields(b *testing.B) {
 	base := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	)
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
@@ -215,7 +215,7 @@ func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
 	base := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	)
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()
@@ -235,7 +235,7 @@ func BenchmarkZapSampleCheckAddingFields(b *testing.B) {
 	base := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	)
 	logger := zwrap.Sample(base, time.Second, 10, 10000)
 	b.ResetTimer()

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -51,7 +51,7 @@ func withBenchedLogger(b *testing.B, f func(zap.Logger)) {
 	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -144,7 +144,7 @@ func BenchmarkObjectField(b *testing.B) {
 func BenchmarkAddCallerHook(b *testing.B) {
 	logger := zap.New(
 		zap.NewJSONEncoder(),
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 		zap.AddCaller(),
 	)
 	b.ResetTimer()
@@ -177,7 +177,7 @@ func Benchmark100Fields(b *testing.B) {
 	logger := zap.New(
 		zap.NewJSONEncoder(),
 		zap.DebugLevel,
-		zap.Output(zap.Discard),
+		zap.DiscardOutput,
 	)
 
 	// Don't include allocating these helper slices in the benchmark. Since

--- a/writer.go
+++ b/writer.go
@@ -26,8 +26,14 @@ import (
 	"sync"
 )
 
-// Discard is a convenience wrapper around ioutil.Discard.
-var Discard = AddSync(ioutil.Discard)
+var (
+	// Discard is a convenience wrapper around ioutil.Discard.
+	Discard = AddSync(ioutil.Discard)
+	// DiscardOutput is an Option that discards logger output.
+	DiscardOutput = Output(Discard)
+	// DiscardErrorOutput is an Option that discards logger error output.
+	DiscardErrorOutput = ErrorOutput(Discard)
+)
 
 // A WriteFlusher is an io.Writer that can also flush any buffered data.
 type WriteFlusher interface {

--- a/writer.go
+++ b/writer.go
@@ -31,8 +31,6 @@ var (
 	Discard = AddSync(ioutil.Discard)
 	// DiscardOutput is an Option that discards logger output.
 	DiscardOutput = Output(Discard)
-	// DiscardErrorOutput is an Option that discards logger error output.
-	DiscardErrorOutput = ErrorOutput(Discard)
 )
 
 // A WriteFlusher is an io.Writer that can also flush any buffered data.


### PR DESCRIPTION
In tests, we frequently use `zap.Output(zap.Discard)`. This is noisy and
a bit annoying; supply a canned `zap.DiscardOutput` option instead.