### PR TITLE
Add a human-optimized text encoder

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -151,10 +151,10 @@ func ExampleNew_textEncoderNestedObject() {
 	textLogger := zap.New(zap.NewTextEncoder(
 		zap.TextNoTime(), // drop timestamps in tests.
 	))
-	textLogger.Info("With Marshaler", zap.String("fake", "{"), zap.Marshaler("m", zap.LogMarshalerFunc(m)))
+	textLogger.Info("With Marshaler", zap.Marshaler("m", zap.LogMarshalerFunc(m)))
 
 	// Output:
-	// [I] With Marshaler fake={ m={loggable=yes number=1}
+	// [I] With Marshaler m={loggable=yes number=1}
 }
 
 func ExampleNew_options() {

--- a/example_test.go
+++ b/example_test.go
@@ -105,9 +105,9 @@ func ExampleNest() {
 func ExampleNew() {
 	// The default logger outputs to standard out and only writes logs that are
 	// Info level or higher.
-	logger := zap.New(
-		zap.NewJSONEncoder(zap.NoTime()), // drop timestamps in tests
-	)
+	logger := zap.New(zap.NewJSONEncoder(
+		zap.NoTime(), // drop timestamps in tests
+	))
 
 	// The default logger does not print Debug logs.
 	logger.Debug("This won't be printed.")
@@ -115,6 +115,46 @@ func ExampleNew() {
 
 	// Output:
 	// {"level":"info","msg":"This is an info log."}
+}
+
+func ExampleNew_textEncoder() {
+	// For more human-readable output in the console, use a TextEncoder.
+	textLogger := zap.New(zap.NewTextEncoder(
+		zap.TextNoTime(), // drop timestamps in tests.
+	))
+	textLogger.Info("This is a text log.")
+
+	// Output:
+	// [I] This is a text log.
+}
+
+func ExampleNew_textEncoderSingleCurlyBrace() {
+	textLogger := zap.New(zap.NewTextEncoder(
+		zap.TextNoTime(), // drop timestamps in tests.
+	))
+	textLogger.Info("Test 1.")
+	textLogger.Info("With fields", zap.String("f1", "v1"), zap.String("f2", "v2"))
+	textLogger.Info("With fields", zap.String("f1", "{"), zap.String("f2", "v2"))
+
+	// Output:
+	// [I] Test 1.
+	// [I] With fields f1=v1 f2=v2
+	// [I] With fields f1={ f2=v2
+}
+
+func ExampleNew_textEncoderNestedObject() {
+	m := func(kv zap.KeyValue) error {
+		kv.AddString("loggable", "yes")
+		kv.AddInt("number", 1)
+		return nil
+	}
+	textLogger := zap.New(zap.NewTextEncoder(
+		zap.TextNoTime(), // drop timestamps in tests.
+	))
+	textLogger.Info("With Marshaler", zap.String("fake", "{"), zap.Marshaler("m", zap.LogMarshalerFunc(m)))
+
+	// Output:
+	// [I] With Marshaler fake={ m={loggable=yes number=1}
 }
 
 func ExampleNew_options() {
@@ -198,4 +238,15 @@ func ExampleNewJSONEncoder() {
 		zap.MessageKey("@message"),         // customize the message key
 		zap.LevelString("@level"),          // stringify the log level
 	)
+}
+
+func ExampleNewTextEncoder() {
+	// A text encoder with the default settings.
+	zap.NewTextEncoder()
+
+	// Dropping timestamps is often useful in tests.
+	zap.NewTextEncoder(zap.TextNoTime())
+
+	// If you don't like the default timestamp formatting, choose another.
+	zap.NewTextEncoder(zap.TextTimeFormat(time.RFC822))
 }

--- a/example_test.go
+++ b/example_test.go
@@ -122,39 +122,11 @@ func ExampleNew_textEncoder() {
 	textLogger := zap.New(zap.NewTextEncoder(
 		zap.TextNoTime(), // drop timestamps in tests.
 	))
-	textLogger.Info("This is a text log.")
+
+	textLogger.Info("This is a text log.", zap.Int("foo", 42))
 
 	// Output:
-	// [I] This is a text log.
-}
-
-func ExampleNew_textEncoderSingleCurlyBrace() {
-	textLogger := zap.New(zap.NewTextEncoder(
-		zap.TextNoTime(), // drop timestamps in tests.
-	))
-	textLogger.Info("Test 1.")
-	textLogger.Info("With fields", zap.String("f1", "v1"), zap.String("f2", "v2"))
-	textLogger.Info("With fields", zap.String("f1", "{"), zap.String("f2", "v2"))
-
-	// Output:
-	// [I] Test 1.
-	// [I] With fields f1=v1 f2=v2
-	// [I] With fields f1={ f2=v2
-}
-
-func ExampleNew_textEncoderNestedObject() {
-	m := func(kv zap.KeyValue) error {
-		kv.AddString("loggable", "yes")
-		kv.AddInt("number", 1)
-		return nil
-	}
-	textLogger := zap.New(zap.NewTextEncoder(
-		zap.TextNoTime(), // drop timestamps in tests.
-	))
-	textLogger.Info("With Marshaler", zap.Marshaler("m", zap.LogMarshalerFunc(m)))
-
-	// Output:
-	// [I] With Marshaler m={loggable=yes number=1}
+	// [I] This is a text log. foo=42
 }
 
 func ExampleNew_options() {

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var epoch = time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+
 func newJSONEncoder(opts ...JSONOption) *jsonEncoder {
 	return NewJSONEncoder(opts...).(*jsonEncoder)
 }
@@ -280,7 +282,7 @@ func TestJSONOptions(t *testing.T) {
 
 	for _, enc := range []Encoder{root, root.Clone()} {
 		buf := &bytes.Buffer{}
-		enc.WriteEntry(buf, "fake msg", DebugLevel, time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC))
+		enc.WriteEntry(buf, "fake msg", DebugLevel, epoch)
 		assert.Equal(
 			t,
 			`{"the-level":"debug","the-timestamp":"1970-01-01T00:00:00Z","the-message":"fake msg"}`+"\n",

--- a/json_options_test.go
+++ b/json_options_test.go
@@ -22,7 +22,6 @@ package zap
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -45,8 +44,6 @@ func TestMessageFormatters(t *testing.T) {
 }
 
 func TestTimeFormatters(t *testing.T) {
-	ts := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
-
 	tests := []struct {
 		name      string
 		formatter TimeFormatter
@@ -59,7 +56,7 @@ func TestTimeFormatters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.expected, tt.formatter(ts), "Unexpected output from TimeFormatter %s.", tt.name)
+		assert.Equal(t, tt.expected, tt.formatter(epoch), "Unexpected output from TimeFormatter %s.", tt.name)
 	}
 }
 

--- a/text_encoder.go
+++ b/text_encoder.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"sync"
+	"time"
+)
+
+var textPool = sync.Pool{New: func() interface{} {
+	return &textEncoder{
+		bytes: make([]byte, 0, _initialBufSize),
+	}
+}}
+
+type textEncoder struct {
+	bytes   []byte
+	timeFmt string
+	nested  bool
+}
+
+// NewTextEncoder creates a line-oriented text encoder whose output is optimized
+// for human, rather than machine, consumption. By default, the encoder uses
+// RFC3339-formatted timestamps.
+func NewTextEncoder(options ...TextOption) Encoder {
+	enc := textPool.Get().(*textEncoder)
+	enc.truncate()
+	enc.timeFmt = time.RFC3339
+	for _, opt := range options {
+		opt.apply(enc)
+	}
+	return enc
+}
+
+func (enc *textEncoder) Free() {
+	textPool.Put(enc)
+}
+
+func (enc *textEncoder) AddString(key, val string) {
+	enc.addKey(key)
+	enc.bytes = append(enc.bytes, val...)
+}
+
+func (enc *textEncoder) AddBool(key string, val bool) {
+	enc.addKey(key)
+	if val {
+		enc.bytes = append(enc.bytes, "true"...)
+		return
+	}
+	enc.bytes = append(enc.bytes, "false"...)
+}
+
+func (enc *textEncoder) AddInt(key string, val int) {
+	enc.AddInt64(key, int64(val))
+}
+
+func (enc *textEncoder) AddInt64(key string, val int64) {
+	enc.addKey(key)
+	enc.bytes = strconv.AppendInt(enc.bytes, val, 10)
+}
+
+func (enc *textEncoder) AddUint(key string, val uint) {
+	enc.AddUint64(key, uint64(val))
+}
+
+func (enc *textEncoder) AddUint64(key string, val uint64) {
+	enc.addKey(key)
+	enc.bytes = strconv.AppendUint(enc.bytes, val, 10)
+}
+
+func (enc *textEncoder) AddFloat64(key string, val float64) {
+	enc.addKey(key)
+	switch {
+	case math.IsNaN(val):
+		enc.bytes = append(enc.bytes, "NaN"...)
+	case math.IsInf(val, 1):
+		enc.bytes = append(enc.bytes, "+Inf"...)
+	case math.IsInf(val, -1):
+		enc.bytes = append(enc.bytes, "-Inf"...)
+	default:
+		enc.bytes = strconv.AppendFloat(enc.bytes, val, 'f', -1, 64)
+	}
+}
+
+func (enc *textEncoder) AddMarshaler(key string, obj LogMarshaler) error {
+	enc.addKey(key)
+	enc.nested = true
+	enc.bytes = append(enc.bytes, '{')
+	err := obj.MarshalLog(enc)
+	enc.bytes = append(enc.bytes, '}')
+	return err
+}
+
+func (enc *textEncoder) AddObject(key string, obj interface{}) error {
+	enc.AddString(key, fmt.Sprintf("%+v", obj))
+	return nil
+}
+
+func (enc *textEncoder) Clone() Encoder {
+	clone := textPool.Get().(*textEncoder)
+	clone.truncate()
+	clone.bytes = append(clone.bytes, enc.bytes...)
+	clone.timeFmt = enc.timeFmt
+	clone.nested = enc.nested
+	return clone
+}
+
+func (enc *textEncoder) WriteEntry(sink io.Writer, msg string, lvl Level, t time.Time) error {
+	if sink == nil {
+		return errNilSink
+	}
+
+	final := textPool.Get().(*textEncoder)
+	final.truncate()
+	enc.addLevel(final, lvl)
+	enc.addTime(final, t)
+	enc.addMessage(final, msg)
+
+	if len(enc.bytes) > 0 {
+		final.bytes = append(final.bytes, ' ')
+		final.bytes = append(final.bytes, enc.bytes...)
+	}
+	final.bytes = append(final.bytes, '\n')
+
+	expectedBytes := len(final.bytes)
+	n, err := sink.Write(final.bytes)
+	final.Free()
+	if err != nil {
+		return err
+	}
+	if n != expectedBytes {
+		return fmt.Errorf("incomplete write: only wrote %v of %v bytes", n, expectedBytes)
+	}
+	return nil
+}
+
+func (enc *textEncoder) truncate() {
+	enc.bytes = enc.bytes[:0]
+}
+
+func (enc *textEncoder) addKey(key string) {
+	lastIdx := len(enc.bytes) - 1
+	if lastIdx >= 0 && !enc.nested {
+		enc.bytes = append(enc.bytes, ' ')
+	} else {
+		enc.nested = false
+	}
+	enc.bytes = append(enc.bytes, key...)
+	enc.bytes = append(enc.bytes, '=')
+}
+
+func (enc *textEncoder) addLevel(final *textEncoder, lvl Level) {
+	final.bytes = append(final.bytes, '[')
+	switch lvl {
+	case DebugLevel:
+		final.bytes = append(final.bytes, 'D')
+	case InfoLevel:
+		final.bytes = append(final.bytes, 'I')
+	case WarnLevel:
+		final.bytes = append(final.bytes, 'W')
+	case ErrorLevel:
+		final.bytes = append(final.bytes, 'E')
+	case PanicLevel:
+		final.bytes = append(final.bytes, 'P')
+	case FatalLevel:
+		final.bytes = append(final.bytes, 'F')
+	default:
+		final.bytes = strconv.AppendInt(final.bytes, int64(lvl), 10)
+	}
+	final.bytes = append(final.bytes, ']')
+}
+
+func (enc *textEncoder) addTime(final *textEncoder, t time.Time) {
+	if enc.timeFmt == "" {
+		return
+	}
+	final.bytes = append(final.bytes, ' ')
+	final.bytes = t.AppendFormat(final.bytes, enc.timeFmt)
+}
+
+func (enc *textEncoder) addMessage(final *textEncoder, msg string) {
+	final.bytes = append(final.bytes, ' ')
+	final.bytes = append(final.bytes, msg...)
+}
+
+// A TextOption is used to set options for a text encoder.
+type TextOption interface {
+	apply(*textEncoder)
+}
+
+type textOptionFunc func(*textEncoder)
+
+func (opt textOptionFunc) apply(enc *textEncoder) {
+	opt(enc)
+}
+
+// TextTimeFormat sets the format for log timestamps, using the same layout
+// strings supported by time.Parse.
+func TextTimeFormat(layout string) TextOption {
+	return textOptionFunc(func(enc *textEncoder) {
+		enc.timeFmt = layout
+	})
+}
+
+// TextNoTime omits timestamps from the serialized log entries.
+func TextNoTime() TextOption {
+	return TextTimeFormat("")
+}

--- a/text_encoder.go
+++ b/text_encoder.go
@@ -23,7 +23,6 @@ package zap
 import (
 	"fmt"
 	"io"
-	"math"
 	"strconv"
 	"sync"
 	"time"
@@ -65,11 +64,7 @@ func (enc *textEncoder) AddString(key, val string) {
 
 func (enc *textEncoder) AddBool(key string, val bool) {
 	enc.addKey(key)
-	if val {
-		enc.bytes = append(enc.bytes, "true"...)
-		return
-	}
-	enc.bytes = append(enc.bytes, "false"...)
+	enc.bytes = strconv.AppendBool(enc.bytes, val)
 }
 
 func (enc *textEncoder) AddInt(key string, val int) {
@@ -92,16 +87,7 @@ func (enc *textEncoder) AddUint64(key string, val uint64) {
 
 func (enc *textEncoder) AddFloat64(key string, val float64) {
 	enc.addKey(key)
-	switch {
-	case math.IsNaN(val):
-		enc.bytes = append(enc.bytes, "NaN"...)
-	case math.IsInf(val, 1):
-		enc.bytes = append(enc.bytes, "+Inf"...)
-	case math.IsInf(val, -1):
-		enc.bytes = append(enc.bytes, "-Inf"...)
-	default:
-		enc.bytes = strconv.AppendFloat(enc.bytes, val, 'f', -1, 64)
-	}
+	enc.bytes = strconv.AppendFloat(enc.bytes, val, 'f', -1, 64)
 }
 
 func (enc *textEncoder) AddMarshaler(key string, obj LogMarshaler) error {
@@ -110,6 +96,7 @@ func (enc *textEncoder) AddMarshaler(key string, obj LogMarshaler) error {
 	enc.bytes = append(enc.bytes, '{')
 	err := obj.MarshalLog(enc)
 	enc.bytes = append(enc.bytes, '}')
+	enc.firstNested = false
 	return err
 }
 

--- a/text_encoder_test.go
+++ b/text_encoder_test.go
@@ -31,8 +31,12 @@ import (
 	"github.com/uber-go/zap/spywrite"
 )
 
+func newTextEncoder(opts ...TextOption) *textEncoder {
+	return NewTextEncoder(opts...).(*textEncoder)
+}
+
 func withTextEncoder(f func(*textEncoder)) {
-	enc := NewTextEncoder().(*textEncoder)
+	enc := newTextEncoder()
 	f(enc)
 	enc.Free()
 }

--- a/text_encoder_test.go
+++ b/text_encoder_test.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/zap/spywrite"
+)
+
+func withTextEncoder(f func(*textEncoder)) {
+	enc := NewTextEncoder().(*textEncoder)
+	f(enc)
+	enc.Free()
+}
+
+func assertTextOutput(t testing.TB, desc string, expected string, f func(Encoder)) {
+	withTextEncoder(func(enc *textEncoder) {
+		f(enc)
+		assert.Equal(t, expected, string(enc.bytes), "Unexpected encoder output after adding a %s.", desc)
+	})
+	withTextEncoder(func(enc *textEncoder) {
+		enc.AddString("foo", "bar")
+		f(enc)
+		expectedPrefix := "foo=bar"
+		if expected != "" {
+			// If we expect output, it should be space-separated from the previous
+			// field.
+			expectedPrefix += " "
+		}
+		assert.Equal(t, expectedPrefix+expected, string(enc.bytes), "Unexpected encoder output after adding a %s as a second field.", desc)
+	})
+}
+
+func TestTextEncoderFields(t *testing.T) {
+	tests := []struct {
+		desc     string
+		expected string
+		f        func(Encoder)
+	}{
+		{"string", "k=v", func(e Encoder) { e.AddString("k", "v") }},
+		{"string", "k=", func(e Encoder) { e.AddString("k", "") }},
+		{"bool", "k=true", func(e Encoder) { e.AddBool("k", true) }},
+		{"bool", "k=false", func(e Encoder) { e.AddBool("k", false) }},
+		{"int", "k=42", func(e Encoder) { e.AddInt("k", 42) }},
+		{"int64", "k=42", func(e Encoder) { e.AddInt64("k", 42) }},
+		{"int64", fmt.Sprintf("k=%d", math.MaxInt64), func(e Encoder) { e.AddInt64("k", math.MaxInt64) }},
+		{"uint", "k=42", func(e Encoder) { e.AddUint("k", 42) }},
+		{"uint64", "k=42", func(e Encoder) { e.AddUint64("k", 42) }},
+		{"uint64", fmt.Sprintf("k=%d", uint64(math.MaxUint64)), func(e Encoder) { e.AddUint64("k", math.MaxUint64) }},
+		{"float64", "k=1", func(e Encoder) { e.AddFloat64("k", 1.0) }},
+		{"float64", "k=10000000000", func(e Encoder) { e.AddFloat64("k", 1e10) }},
+		{"float64", "k=NaN", func(e Encoder) { e.AddFloat64("k", math.NaN()) }},
+		{"float64", "k=+Inf", func(e Encoder) { e.AddFloat64("k", math.Inf(1)) }},
+		{"float64", "k=-Inf", func(e Encoder) { e.AddFloat64("k", math.Inf(-1)) }},
+		{"marshaler", "k={loggable=yes}", func(e Encoder) {
+			assert.NoError(t, e.AddMarshaler("k", loggable{true}), "Unexpected error calling MarshalLog.")
+		}},
+		{"marshaler", "k={}", func(e Encoder) {
+			assert.Error(t, e.AddMarshaler("k", loggable{false}), "Expected an error calling MarshalLog.")
+		}},
+		{"map[string]string", "k=map[loggable:yes]", func(e Encoder) {
+			assert.NoError(t, e.AddObject("k", map[string]string{"loggable": "yes"}), "Unexpected error serializing a map.")
+		}},
+		{"arbitrary object", "k={Name:jane}", func(e Encoder) {
+			assert.NoError(t, e.AddObject("k", struct{ Name string }{"jane"}), "Unexpected error serializing a struct.")
+		}},
+	}
+
+	for _, tt := range tests {
+		assertTextOutput(t, tt.desc, tt.expected, tt.f)
+	}
+}
+
+func TestTextWriteEntry(t *testing.T) {
+	entry := &Entry{Level: InfoLevel, Message: "Something happened.", Time: epoch}
+	tests := []struct {
+		enc      Encoder
+		expected string
+		name     string
+	}{
+		{
+			enc:      NewTextEncoder(),
+			expected: "[I] 1970-01-01T00:00:00Z Something happened.",
+			name:     "RFC822",
+		},
+		{
+			enc:      NewTextEncoder(TextTimeFormat(time.RFC822)),
+			expected: "[I] 01 Jan 70 00:00 UTC Something happened.",
+			name:     "RFC822",
+		},
+		{
+			enc:      NewTextEncoder(TextTimeFormat("")),
+			expected: "[I] Something happened.",
+			name:     "empty layout",
+		},
+		{
+			enc:      NewTextEncoder(TextNoTime()),
+			expected: "[I] Something happened.",
+			name:     "NoTime",
+		},
+	}
+
+	sink := &testBuffer{}
+	for _, tt := range tests {
+		assert.NoError(
+			t,
+			tt.enc.WriteEntry(sink, entry.Message, entry.Level, entry.Time),
+			"Unexpected failure writing entry with text time formatter %s.", tt.name,
+		)
+		assert.Equal(t, tt.expected, sink.Stripped(), "Unexpected output from text time formatter %s.", tt.name)
+		sink.Reset()
+	}
+}
+
+func TestTextWriteEntryLevels(t *testing.T) {
+	tests := []struct {
+		level    Level
+		expected string
+	}{
+		{DebugLevel, "D"},
+		{InfoLevel, "I"},
+		{WarnLevel, "W"},
+		{ErrorLevel, "E"},
+		{PanicLevel, "P"},
+		{FatalLevel, "F"},
+		{Level(42), "42"},
+	}
+
+	sink := &testBuffer{}
+	enc := NewTextEncoder(TextNoTime())
+	for _, tt := range tests {
+		assert.NoError(
+			t,
+			enc.WriteEntry(sink, "Fake message.", tt.level, epoch),
+			"Unexpected failure writing entry with level %s.", tt.level,
+		)
+		expected := fmt.Sprintf("[%s] Fake message.", tt.expected)
+		assert.Equal(t, expected, sink.Stripped(), "Unexpected text output for level %s.", tt.level)
+		sink.Reset()
+	}
+}
+
+func TestTextClone(t *testing.T) {
+	parent := &textEncoder{bytes: make([]byte, 0, 128)}
+	clone := parent.Clone()
+
+	// Adding to the parent shouldn't affect the clone, and vice versa.
+	parent.AddString("foo", "bar")
+	clone.AddString("baz", "bing")
+
+	assert.Equal(t, "foo=bar", string(parent.bytes), "Unexpected serialized fields in parent encoder.")
+	assert.Equal(t, "baz=bing", string(clone.(*textEncoder).bytes), "Unexpected serialized fields in cloned encoder.")
+}
+
+func TestTextWriteEntryFailure(t *testing.T) {
+	withTextEncoder(func(enc *textEncoder) {
+		tests := []struct {
+			sink io.Writer
+			msg  string
+		}{
+			{nil, "Expected an error when writing to a nil sink."},
+			{spywrite.FailWriter{}, "Expected an error when writing to sink fails."},
+			{spywrite.ShortWriter{}, "Expected an error on partial writes to sink."},
+		}
+		for _, tt := range tests {
+			err := enc.WriteEntry(tt.sink, "hello", InfoLevel, time.Unix(0, 0))
+			assert.Error(t, err, tt.msg)
+		}
+	})
+}
+
+func TestTextTimeOptions(t *testing.T) {
+	epoch := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+	entry := &Entry{Level: InfoLevel, Message: "Something happened.", Time: epoch}
+
+	enc := NewTextEncoder()
+
+	sink := &testBuffer{}
+	enc.AddString("foo", "bar")
+	err := enc.WriteEntry(sink, entry.Message, entry.Level, entry.Time)
+	assert.NoError(t, err, "WriteEntry returned an unexpected error.")
+	assert.Equal(
+		t,
+		"[I] 1970-01-01T00:00:00Z Something happened. foo=bar",
+		sink.Stripped(),
+	)
+}

--- a/text_logger_test.go
+++ b/text_logger_test.go
@@ -58,3 +58,11 @@ func TestTextLoggerNestedMarshal(t *testing.T) {
 		assert.Equal(t, "[I] Fields f1={ m={loggable=yes number=1}", buf.Stripped(), "Unexpected output from logger")
 	})
 }
+
+func TestTextLoggerAddMarshalEmpty(t *testing.T) {
+	empty := LogMarshalerFunc(func(_ KeyValue) error { return nil })
+	withTextLogger(t, nil, func(logger Logger, buf *testBuffer) {
+		logger.Info("Empty", Marshaler("m", empty), String("something", "val"))
+		assert.Equal(t, "[I] Empty m={} something=val", buf.Stripped(), "Unexpected output from logger")
+	})
+}

--- a/text_logger_test.go
+++ b/text_logger_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func withTextLogger(t testing.TB, opts []Option, f func(Logger, *testBuffer)) {
+	sink := &testBuffer{}
+	errSink := &testBuffer{}
+
+	allOpts := make([]Option, 0, 3+len(opts))
+	allOpts = append(allOpts, DebugLevel, Output(sink), ErrorOutput(errSink))
+	allOpts = append(allOpts, opts...)
+	logger := New(newTextEncoder(TextNoTime()), allOpts...)
+
+	f(logger, sink)
+	assert.Empty(t, errSink.String(), "Expected error sink to be empty.")
+}
+
+func TestTextLoggerDebugLevel(t *testing.T) {
+	withTextLogger(t, nil, func(logger Logger, buf *testBuffer) {
+		logger.Log(DebugLevel, "foo")
+		assert.Equal(t, "[D] foo", buf.Stripped(), "Unexpected output from logger")
+	})
+}
+
+func TestTextLoggerNestedMarshal(t *testing.T) {
+	m := LogMarshalerFunc(func(kv KeyValue) error {
+		kv.AddString("loggable", "yes")
+		kv.AddInt("number", 1)
+		return nil
+	})
+
+	withTextLogger(t, nil, func(logger Logger, buf *testBuffer) {
+		logger.Info("Fields", String("f1", "{"), Marshaler("m", m))
+		assert.Equal(t, "[I] Fields f1={ m={loggable=yes number=1}", buf.Stripped(), "Unexpected output from logger")
+	})
+}


### PR DESCRIPTION
Add a text encoder that's friendlier for human consumption. By default, the `TextEncoder` output looks like this:

```
[I] 1970-01-01T00:00:00Z Something happened. foo=bar baz=bing
```

The timestamp format is configurable via functional options, and the encoder includes support for unsigned ints (in advance of #116).

Resolves #59.