### PR TITLE
Fix Check not triggering panic/exit on Panic/Fatal

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -89,8 +89,15 @@ func (log *logger) With(fields ...Field) Logger {
 }
 
 func (log *logger) Check(lvl Level, msg string) *CheckedMessage {
-	if !(lvl >= log.Level()) {
-		return nil
+	switch lvl {
+	case PanicLevel, FatalLevel:
+		// Panic and Fatal should always cause a panic/exit, even if the level
+		// is disabled.
+		break
+	default:
+		if lvl < log.Level() {
+			return nil
+		}
 	}
 	return NewCheckedMessage(log, lvl, msg)
 }

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -153,7 +153,13 @@ func (s *sampler) DFatal(msg string, fields ...zap.Field) {
 }
 
 func (s *sampler) check(lvl zap.Level, msg string) bool {
-	if !(lvl >= s.Level()) {
+	switch lvl {
+	case zap.PanicLevel, zap.FatalLevel:
+		// Ignore sampling for Panic and Fatal, since it should always
+		// cause a panic or exit.
+		return true
+	}
+	if lvl < s.Level() {
 		return false
 	}
 	n := s.counts.Inc(msg)


### PR DESCRIPTION
Panic and Fatal should always cause a panic or exit, even if the level
is disabled. This is handled correctly in logger.Panic/Fatal/Log, but
when the CheckedMessage is used, we're not calling panic/exit.

We should always return a valid message from Check when the level is
Fatal or Panic. This means that Panic/Fatal will not be sampled, since
the sampler should not call panic/exit directly, but should defer to the
underlying logger, and there's no way to specify don't log, but call the
panic/exit functions.

Fixes #125 