### PR TITLE
Link to v1.0 project instead of milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Log a static string, without any context or `printf`-style formatting:
 
 ## Development Status: Beta
 Ready for adventurous users, but we're planning several breaking changes before
-releasing version 1.0. [This milestone][v1] tracks our progress toward a stable
+releasing version 1.0. [This project][v1] tracks our progress toward a stable
 release.
 
 <hr>
@@ -99,4 +99,4 @@ pinned in zap's [glide.lock][] file. [↩](#anchor-versions)
 [benchmarking suite]: https://github.com/uber-go/zap/tree/master/benchmarks
 [glide.lock]: https://github.com/uber-go/zap/blob/master/glide.lock
 [bark]: https://github.com/uber-common/bark
-[v1]: https://github.com/uber-go/zap/milestones
+[v1]: https://github.com/uber-go/zap/projects/1


### PR DESCRIPTION
GitHub's emphasizing projects instead of milestones; let's give them a try.