### PR TITLE
Add a slightly slower, but less verbose, logger

### DIFF
--- a/benchmarks/zap_sugar_bench_test.go
+++ b/benchmarks/zap_sugar_bench_test.go
@@ -99,7 +99,7 @@ func BenchmarkZapSugarAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapSugarWithAccumulatedContext(b *testing.B) {
-	logger, _ := newSugarLogger().With(fakeSugarFields()...)
+	logger := newSugarLogger().With(fakeSugarFields()...)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/benchmarks/zap_sugar_bench_test.go
+++ b/benchmarks/zap_sugar_bench_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmarks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/uber-go/zap"
+	"github.com/uber-go/zap/zwrap"
+)
+
+func fakeSugarFields() []interface{} {
+	return []interface{}{
+		errExample,
+		"int", 1,
+		"int64", 2,
+		"float", 3.0,
+		"string", "four!",
+		"stringer", zap.DebugLevel,
+		"bool", true,
+		"time", time.Unix(0, 0),
+		"duration", time.Second,
+		"another string", "done!",
+	}
+}
+
+func BenchmarkZapSugarDisabledLevelsWithoutFields(b *testing.B) {
+	logger := zap.NewSugar(zap.New(zap.NewJSONEncoder(), zap.ErrorLevel, zap.DiscardOutput))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Should be discarded.")
+		}
+	})
+}
+
+func BenchmarkZapSugarDisabledLevelsAccumulatedContext(b *testing.B) {
+	context := fakeFields()
+	logger := zap.NewSugar(zap.New(
+		zap.NewJSONEncoder(),
+		zap.ErrorLevel,
+		zap.DiscardOutput,
+		zap.Fields(context...),
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Should be discarded.")
+		}
+	})
+}
+
+func BenchmarkZapSugarDisabledLevelsAddingFields(b *testing.B) {
+	logger := zap.NewSugar(zap.New(
+		zap.NewJSONEncoder(),
+		zap.ErrorLevel,
+		zap.DiscardOutput,
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Should be discarded.", fakeSugarFields()...)
+		}
+	})
+}
+
+func BenchmarkZapSugarAddingFields(b *testing.B) {
+	logger := zap.NewSugar(zap.New(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.DiscardOutput,
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go fast.", fakeSugarFields()...)
+		}
+	})
+}
+
+func BenchmarkZapSugarWithAccumulatedContext(b *testing.B) {
+	logger, _ := zap.NewSugar(zap.New(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.DiscardOutput,
+	)).With(fakeSugarFields()...)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go really fast.")
+		}
+	})
+}
+
+func BenchmarkZapSugarWithoutFields(b *testing.B) {
+	logger := zap.New(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.DiscardOutput,
+	)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go fast.")
+		}
+	})
+}
+
+func BenchmarkZapSugarSampleWithoutFields(b *testing.B) {
+	messages := fakeMessages(1000)
+	base := zap.New(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.DiscardOutput,
+	)
+	logger := zap.NewSugar(zwrap.Sample(base, time.Second, 10, 10000))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			i++
+			logger.Info(messages[i%1000])
+		}
+	})
+}
+
+func BenchmarkZapSugarSampleAddingFields(b *testing.B) {
+	messages := fakeMessages(1000)
+	base := zap.New(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.DiscardOutput,
+	)
+	logger := zap.NewSugar(zwrap.Sample(base, time.Second, 10, 10000))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			i++
+			logger.Info(messages[i%1000], fakeSugarFields()...)
+		}
+	})
+}

--- a/sugar.go
+++ b/sugar.go
@@ -112,31 +112,33 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 				return nil, errors.New("field name must be string")
 			}
 		} else {
-			switch value := value.(type) {
-			case bool:
-				fields = append(fields, Bool(key, value))
-			case float64:
-				fields = append(fields, Float64(key, value))
-			case int:
-				fields = append(fields, Int(key, value))
-			case int64:
-				fields = append(fields, Int64(key, value))
-			case uint:
-				fields = append(fields, Uint(key, value))
-			case uint64:
-				fields = append(fields, Uint64(key, value))
-			case string:
-				fields = append(fields, String(key, value))
-			case time.Time:
-				fields = append(fields, Time(key, value))
-			case time.Duration:
-				fields = append(fields, Duration(key, value))
-			case fmt.Stringer:
-				fields = append(fields, Stringer(key, value))
+			switch v := value.(type) {
 			case error:
 				return nil, errors.New("error can only be the first argument")
+			case bool:
+				fields = append(fields, Bool(key, v))
+			case float64:
+				fields = append(fields, Float64(key, v))
+			case int:
+				fields = append(fields, Int(key, v))
+			case int64:
+				fields = append(fields, Int64(key, v))
+			case uint:
+				fields = append(fields, Uint(key, v))
+			case uint64:
+				fields = append(fields, Uint64(key, v))
+			case string:
+				fields = append(fields, String(key, v))
+			case time.Time:
+				fields = append(fields, Time(key, v))
+			case time.Duration:
+				fields = append(fields, Duration(key, v))
+			case fmt.Stringer:
+				fields = append(fields, Stringer(key, v))
+			case LogMarshaler:
+				fields = append(fields, Marshaler(key, v))
 			default:
-				return nil, errors.New("invalid argument type")
+				fields = append(fields, Object(key, value))
 			}
 		}
 	}

--- a/sugar.go
+++ b/sugar.go
@@ -192,9 +192,9 @@ func (s *sugar) Fatal(msg string, args ...interface{}) {
 }
 
 func (s *sugar) DFatal(msg string, args ...interface{}) {
-	lvl := ErrorLevel
-	if s.core.(*logger).Development {
-		lvl = FatalLevel
+	fields, err := getSugarFields(args...)
+	if err != nil {
+		s.internalError(err.Error())
 	}
-	s.Log(lvl, msg, args...)
+	s.core.DFatal(msg, fields...)
 }

--- a/sugar.go
+++ b/sugar.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Sugar is a wrapper around core logger whith less verbose API
+type Sugar interface {
+	// Check the minimum enabled log level.
+	Level() Level
+	// Change the level of this logger, as well as all its ancestors and
+	// descendants. This makes it easy to change the log level at runtime
+	// without restarting your application.
+	SetLevel(Level)
+
+	// Create a child logger, and optionally add some context to that logger.
+	With(...interface{}) (Sugar, error)
+
+	// Log a message at the given level. Messages include any context that's
+	// accumulated on the logger, as well as any fields added at the log site.
+	Log(Level, string, ...interface{}) error
+	Debug(string, ...interface{}) error
+	Info(string, ...interface{}) error
+	Warn(string, ...interface{}) error
+	Error(string, ...interface{}) error
+	Panic(string, ...interface{}) error
+	Fatal(string, ...interface{}) error
+	// If the logger is in development mode (via the Development option), DFatal
+	// logs at the Fatal level. Otherwise, it logs at the Error level.
+	DFatal(string, ...interface{}) error
+}
+
+type sugar struct {
+	core Logger
+}
+
+// NewSugar is a constructor for Sugar
+func NewSugar(core Logger) Sugar {
+	return &sugar{core}
+}
+
+func (s *sugar) Level() Level {
+	return s.core.Level()
+}
+
+func (s *sugar) SetLevel(lvl Level) {
+	s.core.SetLevel(lvl)
+}
+
+func (s *sugar) With(args ...interface{}) (Sugar, error) {
+	fields, err := getSugarFields(args...)
+	if err != nil {
+		return nil, err
+	}
+	return NewSugar(s.core.With(fields...)), nil
+}
+
+func getSugarFields(args ...interface{}) ([]Field, error) {
+	if (len(args) % 2) != 0 {
+		return nil, errors.New("invalid number of arguments")
+	}
+	var (
+		fields []Field
+		ii     int
+		key    string
+		value  interface{}
+	)
+	for ii, value = range args {
+		if (ii % 2) == 0 {
+			switch value.(type) {
+			case string:
+				key = value.(string)
+			default:
+				return nil, errors.New("field name must be string")
+			}
+		} else {
+			switch value.(type) {
+			case bool:
+				fields = append(fields, Bool(key, value.(bool)))
+			case float64:
+				fields = append(fields, Float64(key, value.(float64)))
+			case int:
+				fields = append(fields, Int(key, value.(int)))
+			case int64:
+				fields = append(fields, Int64(key, value.(int64)))
+			case uint:
+				fields = append(fields, Uint(key, value.(uint)))
+			case uint64:
+				fields = append(fields, Uint64(key, value.(uint64)))
+			case string:
+				fields = append(fields, String(key, value.(string)))
+			case time.Time:
+				fields = append(fields, Time(key, value.(time.Time)))
+			case time.Duration:
+				fields = append(fields, Duration(key, value.(time.Duration)))
+			case fmt.Stringer:
+				fields = append(fields, Stringer(key, value.(fmt.Stringer)))
+			default:
+				return nil, errors.New("invalid argument type")
+			}
+		}
+	}
+	return fields, nil
+}
+
+// Log ...
+func (s *sugar) Log(lvl Level, msg string, args ...interface{}) error {
+	fields, err := getSugarFields(args...)
+	if err != nil {
+		return err
+	}
+	s.core.Log(lvl, msg, fields...)
+	return nil
+}
+
+func (s *sugar) Debug(msg string, args ...interface{}) error {
+	return s.Log(DebugLevel, msg, args...)
+}
+
+func (s *sugar) Info(msg string, args ...interface{}) error {
+	return s.Log(InfoLevel, msg, args...)
+}
+
+func (s *sugar) Warn(msg string, args ...interface{}) error {
+	return s.Log(WarnLevel, msg, args...)
+}
+
+func (s *sugar) Error(msg string, args ...interface{}) error {
+	return s.Log(ErrorLevel, msg, args...)
+}
+
+func (s *sugar) Panic(msg string, args ...interface{}) error {
+	return s.Log(PanicLevel, msg, args...)
+}
+
+func (s *sugar) Fatal(msg string, args ...interface{}) error {
+	return s.Log(FatalLevel, msg, args...)
+}
+
+func (s *sugar) DFatal(msg string, args ...interface{}) error {
+	fields, err := getSugarFields(args...)
+	if err != nil {
+		return err
+	}
+	s.core.DFatal(msg, fields...)
+	return nil
+}

--- a/sugar.go
+++ b/sugar.go
@@ -112,27 +112,27 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 				return nil, errors.New("field name must be string")
 			}
 		} else {
-			switch value.(type) {
+			switch value := value.(type) {
 			case bool:
-				fields = append(fields, Bool(key, value.(bool)))
+				fields = append(fields, Bool(key, value))
 			case float64:
-				fields = append(fields, Float64(key, value.(float64)))
+				fields = append(fields, Float64(key, value))
 			case int:
-				fields = append(fields, Int(key, value.(int)))
+				fields = append(fields, Int(key, value))
 			case int64:
-				fields = append(fields, Int64(key, value.(int64)))
+				fields = append(fields, Int64(key, value))
 			case uint:
-				fields = append(fields, Uint(key, value.(uint)))
+				fields = append(fields, Uint(key, value))
 			case uint64:
-				fields = append(fields, Uint64(key, value.(uint64)))
+				fields = append(fields, Uint64(key, value))
 			case string:
-				fields = append(fields, String(key, value.(string)))
+				fields = append(fields, String(key, value))
 			case time.Time:
-				fields = append(fields, Time(key, value.(time.Time)))
+				fields = append(fields, Time(key, value))
 			case time.Duration:
-				fields = append(fields, Duration(key, value.(time.Duration)))
+				fields = append(fields, Duration(key, value))
 			case fmt.Stringer:
-				fields = append(fields, Stringer(key, value.(fmt.Stringer)))
+				fields = append(fields, Stringer(key, value))
 			case error:
 				return nil, errors.New("error can only be the first argument")
 			default:

--- a/sugar.go
+++ b/sugar.go
@@ -80,12 +80,12 @@ func (s *sugar) With(args ...interface{}) (Sugar, error) {
 func getSugarFields(args ...interface{}) ([]Field, error) {
 	var (
 		noErrArgs []interface{}
-		fields    []Field
 
 		ii    int
 		key   string
 		value interface{}
 	)
+	fields := make([]Field, 0, len(args)/2)
 
 	if len(args) == 0 {
 		return fields, nil

--- a/sugar.go
+++ b/sugar.go
@@ -112,6 +112,9 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 				return nil, errors.New("field name must be string")
 			}
 		} else {
+			// TODO: Add LogMarshaler support, it once been here, but
+			//       had to be removed because type switch won't catch
+			//       this intarface properly for some mystical reason.
 			switch v := value.(type) {
 			case error:
 				return nil, errors.New("error can only be the first argument")
@@ -135,8 +138,6 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 				fields = append(fields, Duration(key, v))
 			case fmt.Stringer:
 				fields = append(fields, Stringer(key, v))
-			case LogMarshaler:
-				fields = append(fields, Marshaler(key, v))
 			default:
 				fields = append(fields, Object(key, value))
 			}

--- a/sugar.go
+++ b/sugar.go
@@ -145,11 +145,13 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 
 // Log ...
 func (s *sugar) Log(lvl Level, msg string, args ...interface{}) error {
-	fields, err := getSugarFields(args...)
-	if err != nil {
-		return err
+	if cm := s.core.Check(lvl, msg); cm.OK() {
+		fields, err := getSugarFields(args...)
+		if err != nil {
+			return err
+		}
+		cm.Write(fields...)
 	}
-	s.core.Log(lvl, msg, fields...)
 	return nil
 }
 
@@ -178,10 +180,9 @@ func (s *sugar) Fatal(msg string, args ...interface{}) error {
 }
 
 func (s *sugar) DFatal(msg string, args ...interface{}) error {
-	fields, err := getSugarFields(args...)
-	if err != nil {
-		return err
+	lvl := ErrorLevel
+	if s.core.(*logger).Development {
+		lvl = FatalLevel
 	}
-	s.core.DFatal(msg, fields...)
-	return nil
+	return s.Log(lvl, msg, args...)
 }

--- a/sugar.go
+++ b/sugar.go
@@ -28,14 +28,16 @@ import (
 
 // Sugar is a wrapper around core logger with less verbose API
 type Sugar interface {
-	// Check the minimum enabled log level.
+	// Level returns the minimum enabled log level
 	Level() Level
-	// Change the level of this logger, as well as all its ancestors and
-	// descendants. This makes it easy to change the log level at runtime
+
+	// SetLevel changes the level of this logger, as well as all its ancestors
+	// and descendants. This makes it easy to change the log level at runtime
 	// without restarting your application.
 	SetLevel(Level)
 
-	// Create a child logger, and optionally add some context to that logger.
+	// With creates a child logger, and optionally add some context to that
+	// logger
 	With(...interface{}) (Sugar, error)
 
 	// Log a message at the given level. Messages include any context that's
@@ -47,8 +49,9 @@ type Sugar interface {
 	Error(string, ...interface{})
 	Panic(string, ...interface{})
 	Fatal(string, ...interface{})
-	// If the logger is in development mode (via the Development option), DFatal
-	// logs at the Fatal level. Otherwise, it logs at the Error level.
+
+	// DFatal logs at the Fatal level if the logger is in development mode (via
+	// the Development option), otherwise it logs at the Error level.
 	DFatal(string, ...interface{})
 }
 
@@ -146,7 +149,6 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 	return fields, nil
 }
 
-// Log ...
 func (s *sugar) Log(lvl Level, msg string, args ...interface{}) {
 	var (
 		fields []Field

--- a/sugar.go
+++ b/sugar.go
@@ -26,7 +26,7 @@ import (
 	"time"
 )
 
-// Sugar is a wrapper around core logger whith less verbose API
+// Sugar is a wrapper around core logger with less verbose API
 type Sugar interface {
 	// Check the minimum enabled log level.
 	Level() Level

--- a/sugar.go
+++ b/sugar.go
@@ -40,16 +40,16 @@ type Sugar interface {
 
 	// Log a message at the given level. Messages include any context that's
 	// accumulated on the logger, as well as any fields added at the log site.
-	Log(Level, string, ...interface{}) error
-	Debug(string, ...interface{}) error
-	Info(string, ...interface{}) error
-	Warn(string, ...interface{}) error
-	Error(string, ...interface{}) error
-	Panic(string, ...interface{}) error
-	Fatal(string, ...interface{}) error
+	Log(Level, string, ...interface{})
+	Debug(string, ...interface{})
+	Info(string, ...interface{})
+	Warn(string, ...interface{})
+	Error(string, ...interface{})
+	Panic(string, ...interface{})
+	Fatal(string, ...interface{})
 	// If the logger is in development mode (via the Development option), DFatal
 	// logs at the Fatal level. Otherwise, it logs at the Error level.
-	DFatal(string, ...interface{}) error
+	DFatal(string, ...interface{})
 }
 
 type sugar struct {
@@ -91,9 +91,9 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 		return fields, nil
 	}
 
-	switch args[0].(type) {
+	switch err := args[0].(type) {
 	case error:
-		fields = append(fields, Error(args[0].(error)))
+		fields = append(fields, Error(err))
 		noErrArgs = args[1:]
 	default:
 		noErrArgs = args
@@ -144,45 +144,48 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 }
 
 // Log ...
-func (s *sugar) Log(lvl Level, msg string, args ...interface{}) error {
+func (s *sugar) Log(lvl Level, msg string, args ...interface{}) {
+	var (
+		fields []Field
+		err    error
+	)
 	if cm := s.core.Check(lvl, msg); cm.OK() {
-		fields, err := getSugarFields(args...)
+		fields, err = getSugarFields(args...)
 		if err != nil {
-			return err
+			fields = []Field{Error(err)}
 		}
 		cm.Write(fields...)
 	}
-	return nil
 }
 
-func (s *sugar) Debug(msg string, args ...interface{}) error {
-	return s.Log(DebugLevel, msg, args...)
+func (s *sugar) Debug(msg string, args ...interface{}) {
+	s.Log(DebugLevel, msg, args...)
 }
 
-func (s *sugar) Info(msg string, args ...interface{}) error {
-	return s.Log(InfoLevel, msg, args...)
+func (s *sugar) Info(msg string, args ...interface{}) {
+	s.Log(InfoLevel, msg, args...)
 }
 
-func (s *sugar) Warn(msg string, args ...interface{}) error {
-	return s.Log(WarnLevel, msg, args...)
+func (s *sugar) Warn(msg string, args ...interface{}) {
+	s.Log(WarnLevel, msg, args...)
 }
 
-func (s *sugar) Error(msg string, args ...interface{}) error {
-	return s.Log(ErrorLevel, msg, args...)
+func (s *sugar) Error(msg string, args ...interface{}) {
+	s.Log(ErrorLevel, msg, args...)
 }
 
-func (s *sugar) Panic(msg string, args ...interface{}) error {
-	return s.Log(PanicLevel, msg, args...)
+func (s *sugar) Panic(msg string, args ...interface{}) {
+	s.Log(PanicLevel, msg, args...)
 }
 
-func (s *sugar) Fatal(msg string, args ...interface{}) error {
-	return s.Log(FatalLevel, msg, args...)
+func (s *sugar) Fatal(msg string, args ...interface{}) {
+	s.Log(FatalLevel, msg, args...)
 }
 
-func (s *sugar) DFatal(msg string, args ...interface{}) error {
+func (s *sugar) DFatal(msg string, args ...interface{}) {
 	lvl := ErrorLevel
 	if s.core.(*logger).Development {
 		lvl = FatalLevel
 	}
-	return s.Log(lvl, msg, args...)
+	s.Log(lvl, msg, args...)
 }

--- a/sugar.go
+++ b/sugar.go
@@ -77,12 +77,6 @@ func (s *sugar) With(args ...interface{}) (Sugar, error) {
 	return NewSugar(s.core.With(fields...)), nil
 }
 
-const (
-	expectFirst = iota
-	expectString
-	expectValue
-)
-
 func getSugarFields(args ...interface{}) ([]Field, error) {
 	var (
 		noErrArgs []interface{}

--- a/sugar_bench_test.go
+++ b/sugar_bench_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import "testing"
+
+func withBenchedSugar(b *testing.B, f func(Sugar)) {
+	logger := NewSugar(New(
+		NewJSONEncoder(),
+		DebugLevel,
+		DiscardOutput,
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			f(logger)
+		}
+	})
+}
+
+func Benchmark10FieldsSugar(b *testing.B) {
+	withBenchedSugar(b, func(log Sugar) {
+		log.Info("Ten fields, passed at the log site.",
+			"one", 1,
+			"two", 2,
+			"three", 3,
+			"four", 4,
+			"five", 5,
+			"six", 6,
+			"seven", 7,
+			"eight", 8,
+			"nine", 9,
+			"ten", 10,
+		)
+	})
+}

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -46,6 +46,9 @@ func TestSugarGetSugarFields(t *testing.T) {
 	_, err = getSugarFields("test1", nil)
 	assert.Error(t, err, "Should return error on argument of unknown type")
 
+	_, err = getSugarFields("test1", 1, "error", errors.New(""))
+	assert.Error(t, err, "Should return error when error passed as value (special case of unknown type)")
+
 	_, err = getSugarFields(1, 1)
 	assert.Error(t, err, "Should return error on non-string field name")
 

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSugarGetSugarFields(t *testing.T) {
+	// logger := NewSugar(New(NewJSONEncoder()))
+	// assert.Error(t, logger.getFields("test"), )
+
+	var (
+		fields []Field
+		err    error
+	)
+
+	_, err = getSugarFields("test")
+	assert.Error(t, err, "Should return error on invalid number of arguments")
+
+	_, err = getSugarFields("test1", 1, "test2")
+	assert.Error(t, err, "Should return error on invalid number of arguments")
+
+	_, err = getSugarFields("test1", nil)
+	assert.Error(t, err, "Should return error on argument of unknown type")
+
+	_, err = getSugarFields(1, 1)
+	assert.Error(t, err, "Should return error on non-string field name")
+
+	fields, _ = getSugarFields("test", 1)
+	assert.Equal(t, 1, len(fields), "Should return 1 field")
+
+	fields, _ = getSugarFields("test1", 1, "test2", 2)
+	assert.Equal(t, 2, len(fields), "Should return 2 fields")
+}
+
+func withSugarLogger(t testing.TB, opts []Option, f func(Sugar, *testBuffer)) {
+	sink := &testBuffer{}
+	errSink := &testBuffer{}
+
+	allOpts := make([]Option, 0, 3+len(opts))
+	allOpts = append(allOpts, DebugLevel, Output(sink), ErrorOutput(errSink))
+	allOpts = append(allOpts, opts...)
+	logger := New(newJSONEncoder(NoTime()), allOpts...)
+	sugar := NewSugar(logger)
+
+	f(sugar, sink)
+}
+
+func TestSugarLog(t *testing.T) {
+	opts := opts(Fields(Int("foo", 42)))
+	withSugarLogger(t, opts, func(logger Sugar, buf *testBuffer) {
+		logger.Debug("debug message", "a", "b")
+		logger.Info("info message", "c", "d")
+		logger.Warn("warn message", "e", "f")
+		logger.Error("error message", "g", "h")
+		assert.Equal(t, []string{
+			`{"level":"debug","msg":"debug message","foo":42,"a":"b"}`,
+			`{"level":"info","msg":"info message","foo":42,"c":"d"}`,
+			`{"level":"warn","msg":"warn message","foo":42,"e":"f"}`,
+			`{"level":"error","msg":"error message","foo":42,"g":"h"}`,
+		}, buf.Lines(), "Incorrect output from logger")
+	})
+}
+
+func TestSugarWith(t *testing.T) {
+	opts := opts()
+	withSugarLogger(t, opts, func(logger Sugar, buf *testBuffer) {
+		child, _ := logger.With("a", "b")
+		child.Debug("debug message", "c", "d")
+		assert.Equal(t, []string{
+			`{"level":"debug","msg":"debug message","a":"b","c":"d"}`,
+		}, buf.Lines(), "Incorrect output from logger")
+	})
+}

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -145,6 +145,11 @@ func TestSugarDFatal(t *testing.T) {
 		assert.Equal(t, `{"level":"error","msg":"foo"}`, buf.Stripped(), "Unexpected output from dfatal")
 	})
 
+	withSugarLogger(t, nil, func(logger Sugar, buf *testBuffer) {
+		err := logger.DFatal("foo", "a")
+		assert.Error(t, err, "DFatal should fail with invalid arguments")
+	})
+
 	stub := stubExit()
 	defer stub.Unstub()
 	opts := opts(Development())

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -81,13 +81,13 @@ func withSugarLogger(t testing.TB, opts []Option, f func(Sugar, *testBuffer)) {
 }
 
 type m9e struct {
-	Foo int  `json:"foo"`
-	Bar bool `json:"bar"`
+	foo int
+	bar bool
 }
 
 func (m *m9e) MarshalLog(kv KeyValue) error {
-	kv.AddInt("foo", m.Foo)
-	kv.AddBool("bar", m.Bar)
+	kv.AddInt("foo", m.foo)
+	kv.AddBool("bar", m.bar)
 	return nil
 }
 

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -52,6 +53,9 @@ func TestSugarGetSugarFields(t *testing.T) {
 	assert.Equal(t, 1, len(fields), "Should return 1 field")
 
 	fields, _ = getSugarFields("test1", 1, "test2", 2)
+	assert.Equal(t, 2, len(fields), "Should return 2 fields")
+
+	fields, _ = getSugarFields(errors.New("error"), "test1", 1)
 	assert.Equal(t, 2, len(fields), "Should return 2 fields")
 }
 
@@ -118,6 +122,24 @@ func TestSugarLogTypes(t *testing.T) {
 			`{"level":"debug","msg":"","time":0}`,
 			`{"level":"debug","msg":"","duration":1000000000}`,
 			`{"level":"debug","msg":"","stringer":"debug"}`,
+		}, buf.Lines(), "Incorrect output from logger")
+	})
+}
+
+func TestSugarLogNoArgs(t *testing.T) {
+	withSugarLogger(t, nil, func(logger Sugar, buf *testBuffer) {
+		logger.Debug("no args message")
+		assert.Equal(t, []string{
+			`{"level":"debug","msg":"no args message"}`,
+		}, buf.Lines(), "Incorrect output from logger")
+	})
+}
+
+func TestSugarLogError(t *testing.T) {
+	withSugarLogger(t, nil, func(logger Sugar, buf *testBuffer) {
+		logger.Debug("with error", errors.New("this is a error"))
+		assert.Equal(t, []string{
+			`{"level":"debug","msg":"with error","error":"this is a error"}`,
 		}, buf.Lines(), "Incorrect output from logger")
 	})
 }

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -80,17 +80,6 @@ func withSugarLogger(t testing.TB, opts []Option, f func(Sugar, *testBuffer)) {
 	f(sugar, sink)
 }
 
-type m9e struct {
-	foo int
-	bar bool
-}
-
-func (m *m9e) MarshalLog(kv KeyValue) error {
-	kv.AddInt("foo", m.foo)
-	kv.AddBool("bar", m.bar)
-	return nil
-}
-
 func TestSugarLog(t *testing.T) {
 	opts := opts(Fields(Int("foo", 42)))
 	withSugarLogger(t, opts, func(logger Sugar, buf *testBuffer) {
@@ -120,7 +109,6 @@ func TestSugarLogTypes(t *testing.T) {
 		logger.Debug("", "time", time.Unix(0, 0))
 		logger.Debug("", "duration", time.Second)
 		logger.Debug("", "stringer", DebugLevel)
-		logger.Debug("", "marshaler", m9e{1, true})
 		logger.Debug("", "object", []string{"foo", "bar"})
 		assert.Equal(t, []string{
 			`{"level":"debug","msg":""}`,
@@ -134,7 +122,6 @@ func TestSugarLogTypes(t *testing.T) {
 			`{"level":"debug","msg":"","time":0}`,
 			`{"level":"debug","msg":"","duration":1000000000}`,
 			`{"level":"debug","msg":"","stringer":"debug"}`,
-			`{"level":"debug","msg":"","marshaler":{"foo":1,"bar":true}}`,
 			`{"level":"debug","msg":"","object":["foo","bar"]}`,
 		}, buf.Lines(), "Incorrect output from logger")
 	})

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -169,6 +169,14 @@ func TestSugarDFatal(t *testing.T) {
 	})
 }
 
+func TestSugarDFatalErrors(t *testing.T) {
+	opts := opts()
+	withSugarLogger(t, opts, func(logger Sugar, _ *testBuffer, err *testBuffer) {
+		logger.DFatal("foo", "bar")
+		assert.Equal(t, "invalid number of arguments", err.Stripped(), "Should log invalid number of arguments")
+	})
+}
+
 func TestSugarLogErrors(t *testing.T) {
 	withSugarLogger(t, nil, func(logger Sugar, out *testBuffer, err *testBuffer) {
 		logger.Log(InfoLevel, "foo", "a")

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -186,8 +186,20 @@ func TestSugarDFatal(t *testing.T) {
 }
 
 func TestSugarLogFails(t *testing.T) {
-	sugar := NewSugar(New(NewJSONEncoder()))
-	assert.Error(t, sugar.Log(DebugLevel, "message", "a"), "Should fail with invalid args")
+	withSugarLogger(t, nil, func(logger Sugar, buf *testBuffer) {
+		assert.Error(t, logger.Log(DebugLevel, "message", "a"), "Should fail with invalid args")
+	})
+}
+
+func TestSugarLogDiscards(t *testing.T) {
+	withSugarLogger(t, opts(InfoLevel), func(logger Sugar, buf *testBuffer) {
+		logger.Debug("should be discarded")
+		logger.Debug("should be discarded even with invalid arg count", "bla")
+		logger.Info("should be logged")
+		assert.Equal(t, []string{
+			`{"level":"info","msg":"should be logged"}`,
+		}, buf.Lines(), "")
+	})
 }
 
 func TestSugarWith(t *testing.T) {


### PR DESCRIPTION
```
Benchmark10FieldsSugar-8     1000000          1365 ns/op        2554 B/op         26 allocs/op
Benchmark10Fields-8          2000000           597 ns/op         642 B/op          1 allocs/op
```

This sugar implementation is twice as slow if compared to core, but still twice as fast if compared to nearest competition.
