### PR TITLE
Add Tee to write to multiple sinks

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -129,6 +129,19 @@ func ExampleNew_textEncoder() {
 	// [I] This is a text log. foo=42
 }
 
+func ExampleNew_tee() {
+	// To send output to multiple sources, use Tee.
+	textLogger := zap.New(
+		zap.NewTextEncoder(zap.TextNoTime()),
+		zap.Output(zap.Tee(os.Stdout, os.Stdout)),
+	)
+
+	textLogger.Info("One becomes two")
+	// Output:
+	// [I] One becomes two
+	// [I] One becomes two
+}
+
 func ExampleNew_options() {
 	// We can pass multiple options to the NewJSON method to configure
 	// the logging level, output location, or even the initial context.

--- a/tee.go
+++ b/tee.go
@@ -23,7 +23,7 @@ package zap
 import "io"
 
 // Tee creates a WriteSyncer that duplicates its writes and
-// sync calls. It is similar to io.MultiWriter
+// sync calls. It is similar to io.MultiWriter.
 func Tee(writeSyncers ...WriteSyncer) WriteSyncer {
 	// Copy to protect against https://github.com/golang/go/issues/7809
 	ws := make([]WriteSyncer, len(writeSyncers))

--- a/tee.go
+++ b/tee.go
@@ -35,7 +35,7 @@ func Tee(writeSyncers ...WriteSyncer) WriteSyncer {
 
 // See https://golang.org/src/io/multi.go
 // In the case where not all underlying syncs writer all bytes, we return the smallest number of bytes wtirren
-// but still call Write() on allthe underlying syncs.
+// but still call Write() on all the underlying syncs.
 func (t *teeWriteSyncer) Write(p []byte) (int, error) {
 	errs := make([]error, 0, len(t.writeSyncers))
 	nWritten := 0
@@ -57,7 +57,7 @@ func (t *teeWriteSyncer) Sync() error {
 	return wrapMutiError(t.writeSyncers...)
 }
 
-// Run a series of `f`s, collecting and aggregating errors ig presenta`
+// Run a series of `f`s, collecting and aggregating errors if presents
 func wrapMutiError(fs ...WriteSyncer) error {
 	errs := make([]error, 0, len(fs))
 	for _, f := range fs {

--- a/tee.go
+++ b/tee.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import "io"
+
+// Tee creates a WriteSyncer that duplicates its writes and
+// sync calls. It is similar to io.MultiWriter
+func Tee(writeSyncers ...WriteSyncer) WriteSyncer {
+	// Copy to protect against https://github.com/golang/go/issues/7809
+	ws := make([]WriteSyncer, len(writeSyncers))
+	copy(ws, writeSyncers)
+	return &teeWriteSyncer{
+		writeSyncers: ws,
+	}
+}
+
+// See https://golang.org/src/io/multi.go
+func (t *teeWriteSyncer) Write(p []byte) (int, error) {
+	for _, w := range t.writeSyncers {
+		n, err := w.Write(p)
+		if err != nil {
+			return 0, err
+		}
+		if n != len(p) {
+			return n, io.ErrShortWrite
+		}
+	}
+	return len(p), nil
+}
+
+func (t *teeWriteSyncer) Sync() error {
+	for _, w := range t.writeSyncers {
+		if err := w.Sync(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type teeWriteSyncer struct {
+	writeSyncers []WriteSyncer
+}

--- a/tee.go
+++ b/tee.go
@@ -50,10 +50,7 @@ func (t *teeWriteSyncer) Write(p []byte) (int, error) {
 			nWritten = n
 		}
 	}
-	if len(errs) > 0 {
-		return nWritten, errs
-	}
-	return nWritten, nil
+	return nWritten, errs.asError()
 }
 
 func (t *teeWriteSyncer) Sync() error {
@@ -68,13 +65,17 @@ func wrapMutiError(fs ...WriteSyncer) error {
 			errs = append(errs, err)
 		}
 	}
-	if len(errs) > 0 {
-		return errs
-	}
-	return nil
+	return errs.asError()
 }
 
 type multiError []error
+
+func (m multiError) asError() error {
+	if len(m) > 0 {
+		return m
+	}
+	return nil
+}
 
 func (m multiError) Error() string {
 	sb := bytes.Buffer{}

--- a/tee_test.go
+++ b/tee_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTeeWritesBoth(t *testing.T) {
+	first := &bytes.Buffer{}
+	second := &bytes.Buffer{}
+	ws := Tee(AddSync(first), AddSync(second))
+
+	msg := []byte("dumbledore")
+	n, err := ws.Write(msg)
+	require.NoError(t, err, "Expected successful buffer write")
+	assert.Equal(t, len(msg), n)
+
+	assert.Equal(t, msg, first.Bytes())
+	assert.Equal(t, msg, second.Bytes())
+}
+
+func TestTeeFailsWrite(t *testing.T) {
+	failer := failingWriter{err: errors.New("can't touch this")}
+	ws := Tee(AddSync(failer))
+
+	_, err := ws.Write([]byte("test"))
+	assert.Error(t, err, "Write error should propagate")
+}
+
+func TestTeeFailsShortWrite(t *testing.T) {
+	shorter := failingWriter{nBytes: 1}
+	ws := Tee(AddSync(shorter))
+
+	n, err := ws.Write([]byte("test"))
+	assert.Error(t, err, "Expected error from short write")
+	assert.Equal(t, 1, n, "Expected byte count to return from underlying writer")
+}
+
+func TestTeeSync_PropagatesErrors(t *testing.T) {
+	badsink := &unsyncable{}
+	ws := Tee(Discard, badsink)
+
+	assert.Error(t, ws.Sync(), "Expected sync error to propagate")
+}
+
+func TestTeeSync_NoErrorsOnDiscard(t *testing.T) {
+	ws := Tee(Discard)
+	assert.NoError(t, ws.Sync(), "Expected error-free sync to /dev/null")
+}
+
+type failingWriter struct {
+	err    error
+	nBytes int
+}
+
+func (f failingWriter) Write(p []byte) (int, error) {
+	return f.nBytes, f.err
+}
+
+type unsyncable struct {
+	bytes.Buffer
+}
+
+func (unsyncable) Sync() error { return errors.New("can't sink") }


### PR DESCRIPTION
Fixes #144 

- [x] Figure out if errors should fail early or we should try to write/sync all backends
- [x] Decide whether we care about short writes and returning `io.ErrShortWriter`