### PR TITLE
Fix licence check script

### DIFF
--- a/check_license.sh
+++ b/check_license.sh
@@ -8,8 +8,8 @@ do
     head -1 ${file} | grep -q "${text}"
     if [ $? -ne 0 ]; then
         echo "$file is missing license header."
-        ERROR_COUNT+=1
+        (( ERROR_COUNT++ ))
     fi
-done < <(git ls-files "\.go")
+done < <(git ls-files "*\.go")
 
 exit $ERROR_COUNT


### PR DESCRIPTION
Bash arithmetic is weird. Also git ls-files needs a pattern.

```
zap - fix-license-check ❯ git ls-files "\.go" | wc -l
       0
zap - fix-license-check ❯ git ls-files "*\.go" | wc -l
      70
```