### PR TITLE
Make meta options easier to re-use; use options in the spy logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -71,13 +71,9 @@ type logger struct{ Meta }
 // Options can change the log level, the output location, the initial fields
 // that should be added as context, and many other behaviors.
 func New(enc Encoder, options ...Option) Logger {
-	logger := logger{
-		Meta: MakeMeta(enc),
+	return &logger{
+		Meta: MakeMeta(enc, options...),
 	}
-	for _, opt := range options {
-		opt.apply(&logger.Meta)
-	}
-	return &logger
 }
 
 func (log *logger) With(fields ...Field) Logger {

--- a/meta.go
+++ b/meta.go
@@ -44,13 +44,17 @@ type Meta struct {
 // MakeMeta returns a new meta struct with sensible defaults: logging at
 // InfoLevel, development mode off, and writing to standard error and standard
 // out.
-func MakeMeta(enc Encoder) Meta {
-	return Meta{
+func MakeMeta(enc Encoder, options ...Option) Meta {
+	m := Meta{
 		lvl:         atomic.NewInt32(int32(InfoLevel)),
 		Encoder:     enc,
 		Output:      newLockedWriteSyncer(os.Stdout),
 		ErrorOutput: newLockedWriteSyncer(os.Stderr),
 	}
+	for _, opt := range options {
+		opt.apply(&m)
+	}
+	return m
 }
 
 // Level returns the minimum enabled log level. It's safe to call concurrently.

--- a/spy/logger.go
+++ b/spy/logger.go
@@ -70,11 +70,15 @@ type Logger struct {
 	context []zap.Field
 }
 
-// New returns a new spy logger at the default level and its sink.
-func New() (*Logger, *Sink) {
+// New constructs a spy logger that collects spy.Log records to a Sink. It
+// returns the logger and its sink.
+//
+// Options can change things like log level and initial fields, but any output
+// related options will not be honored.
+func New(options ...zap.Option) (*Logger, *Sink) {
 	s := &Sink{}
 	return &Logger{
-		Meta: zap.MakeMeta(zap.NewJSONEncoder(zap.NoTime())),
+		Meta: zap.MakeMeta(zap.NewJSONEncoder(zap.NoTime()), options...),
 		sink: s,
 	}, s
 }

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -37,8 +37,7 @@ func WithIter(l zap.Logger, n int) zap.Logger {
 }
 
 func fakeSampler(tick time.Duration, first, thereafter int, development bool) (zap.Logger, *spy.Sink) {
-	base, sink := spy.New()
-	base.SetLevel(zap.DebugLevel)
+	base, sink := spy.New(zap.DebugLevel)
 	base.Development = development
 	sampler := Sample(base, tick, first, thereafter)
 	return sampler, sink


### PR DESCRIPTION
Inspired by #162 and other upcoming work towards a lazy logger.