### PR TITLE
Move benchmark dependencies under testImports

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,55 +1,72 @@
-hash: 64d5a2692f570c258ae1c30e683872ea1f8e7f79595fef4f84517aed055dbb83
-updated: 2016-06-02T18:44:39.806767976-07:00
+hash: f5ae7eb388d73896f86ea3a474de6a78f4cc81646bd75e8d59a99de3e2583a24
+updated: 2016-11-07T12:51:01.366849633-08:00
 imports:
-- name: github.com/apex/log
-  version: a999c1b29c986b1972ec53b15092b63a8051ec83
-  subpackages:
-  - handler/json
-- name: github.com/axw/gocov
-  version: f5b2b5cf8644b8b432436eaee1c8a73d2f4cf86e
-  subpackages:
-  - gocov
 - name: github.com/cactus/go-statsd-client
-  version: 5517f304319b9a066354b84860cb264c89655f69
+  version: d8eabe07bc70ff9ba6a56836cde99d1ea3d005f7
   subpackages:
   - statsd
-- name: github.com/go-kit/kit
-  version: 2ecaaad4b9ff04d9da92fe4babb270c54d88841f
-  subpackages:
-  - log
-- name: github.com/go-logfmt/logfmt
-  version: 08ab82a63ef462ac643ec79e659f023891f588f5
-- name: github.com/golang/lint
-  version: 8f348af5e29faa4262efdc14302797f23774e477
-  subpackages:
-  - golint
-- name: github.com/mattn/go-colorable
-  version: 9cbef7c35391cca05f15f8181dc0b18bc9736dbb
-- name: github.com/mattn/goveralls
-  version: b8787b61088a1fa0593616c35add0ba8a412fc85
-- name: github.com/pborman/uuid
-  version: c55201b036063326c5b1b89ccfe45a184973d073
 - name: github.com/Sirupsen/logrus
-  version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
-- name: github.com/stretchr/testify
-  version: 6fe211e493929a8aac0469b93f28b1d0688a9a3a
-  subpackages:
-  - assert
-  - require
+  version: 08a8a7c27e3d058a8989316a850daad1c10bf4ab
 - name: github.com/uber-common/bark
   version: d52ffa061726911f47fcd3d9e8b9b55f22794772
 - name: github.com/uber-go/atomic
-  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
+  version: 0c9e689d64f004564b79d9a663634756df322902
 - name: golang.org/x/sys
-  version: f64b50fbea64174967a8882830d621a18ee1548e
+  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
   subpackages:
   - unix
+testImports:
+- name: github.com/apex/log
+  version: 4ea85e918cc8389903d5f12d7ccac5c23ab7d89b
+  subpackages:
+  - handlers/json
+- name: github.com/axw/gocov
+  version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b
+  subpackages:
+  - gocov
+- name: github.com/davecgh/go-spew
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  subpackages:
+  - spew
+- name: github.com/go-kit/kit
+  version: b30b670b3bd120d0d807f3e0bf4788a25167e187
+  subpackages:
+  - log
+- name: github.com/go-logfmt/logfmt
+  version: d4327190ff838312623b09bfeb50d7c93c8d9c1d
+- name: github.com/go-stack/stack
+  version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
+- name: github.com/golang/lint
+  version: 3390df4df2787994aea98de825b964ac7944b817
+  subpackages:
+  - golint
+- name: github.com/kr/logfmt
+  version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
+- name: github.com/mattn/go-colorable
+  version: d228849504861217f796da67fae4f6e347643f15
+- name: github.com/mattn/go-isatty
+  version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
+- name: github.com/mattn/goveralls
+  version: edf7508a2bcb40ec1160e94518c983c2fc169f02
+- name: github.com/pborman/uuid
+  version: c55201b036063326c5b1b89ccfe45a184973d073
+- name: github.com/pmezard/go-difflib
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
+  subpackages:
+  - assert
+  - require
 - name: golang.org/x/tools
-  version: fe1488f8abd7e0eea44f1950dad93a6ff6880a60
+  version: 3f4088edb48e8a4e3c66a5f8e7b2a78615fcb83f
   subpackages:
   - cover
 - name: gopkg.in/inconshreveable/log15.v2
   version: b105bd37f74e5d9dc7b6ad7806715c7a2b83fd3f
+  subpackages:
+  - stack
+  - term
 - name: gopkg.in/stack.v1
-  version: 0585967eab0016c8e4e2d55ac20585b469574cec
-devImports: []
+  version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,8 @@
 package: github.com/uber-go/zap
 import:
+- package: github.com/uber-common/bark
+- package: github.com/uber-go/atomic
+testImport:
 - package: github.com/stretchr/testify
   subpackages:
   - assert
@@ -22,9 +25,6 @@ import:
 - package: github.com/golang/lint
   subpackages:
   - golint
-- package: github.com/mattn/go-colorable
-- package: github.com/uber-common/bark
 - package: github.com/apex/log
   subpackages:
-  - handler/json
-- package: github.com/uber-go/atomic
+  - handlers/json


### PR DESCRIPTION
Inspired by #164, move all the dependencies we pull in to run benchmark tests into the test import section. Otherwise, consumers of this library will pull in a bunch of dependencies they don't need.