### PR TITLE
Various test improvements

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -82,24 +82,6 @@ func TestJSONLoggerSetLevel(t *testing.T) {
 	})
 }
 
-func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
-	// Test that changing a logger's level also changes the level of all
-	// ancestors and descendants.
-	grandparent := New(newJSONEncoder(), Fields(Int("generation", 1)))
-	parent := grandparent.With(Int("generation", 2))
-	child := parent.With(Int("generation", 3))
-
-	all := []Logger{grandparent, parent, child}
-	for _, logger := range all {
-		assert.Equal(t, InfoLevel, logger.Level(), "Expected all loggers to start at Info level.")
-	}
-
-	parent.SetLevel(DebugLevel)
-	for _, logger := range all {
-		assert.Equal(t, DebugLevel, logger.Level(), "Expected all loggers to switch to Debug level.")
-	}
-}
-
 func TestJSONLoggerConcurrentLevelMutation(t *testing.T) {
 	// Trigger races for non-atomic level mutations.
 	logger := New(newJSONEncoder())
@@ -116,6 +98,43 @@ func TestJSONLoggerConcurrentLevelMutation(t *testing.T) {
 	})
 	close(proceed)
 	wg.Wait()
+}
+
+func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
+	// Test that changing a logger's level also changes the level of all
+	// ancestors and descendants.
+	withJSONLogger(t, opts(InfoLevel), func(grandparent Logger, buf *testBuffer) {
+		parent := grandparent.With(Int("generation", 2))
+		child := parent.With(Int("generation", 3))
+		all := []Logger{grandparent, parent, child}
+
+		assert.Equal(t, InfoLevel, parent.Level(), "expected initial InfoLevel")
+
+		for round, lvl := range []Level{InfoLevel, DebugLevel} {
+			parent.SetLevel(lvl)
+			for loggerI, log := range all {
+				log.Debug("@debug", Int("round", round), Int("logger", loggerI))
+			}
+			for loggerI, log := range all {
+				log.Info("@info", Int("round", round), Int("logger", loggerI))
+			}
+		}
+
+		assert.Equal(t, []string{
+			// round 0 at InfoLevel
+			`{"level":"info","msg":"@info","round":0,"logger":0}`,
+			`{"level":"info","msg":"@info","generation":2,"round":0,"logger":1}`,
+			`{"level":"info","msg":"@info","generation":2,"generation":3,"round":0,"logger":2}`,
+
+			// round 1 at DebugLevel
+			`{"level":"debug","msg":"@debug","round":1,"logger":0}`,
+			`{"level":"debug","msg":"@debug","generation":2,"round":1,"logger":1}`,
+			`{"level":"debug","msg":"@debug","generation":2,"generation":3,"round":1,"logger":2}`,
+			`{"level":"info","msg":"@info","round":1,"logger":0}`,
+			`{"level":"info","msg":"@info","generation":2,"round":1,"logger":1}`,
+			`{"level":"info","msg":"@info","generation":2,"generation":3,"round":1,"logger":2}`,
+		}, strings.Split(buf.Stripped(), "\n"))
+	})
 }
 
 func TestJSONLoggerInitialFields(t *testing.T) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -110,13 +110,16 @@ func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
 
 		assert.Equal(t, InfoLevel, parent.Level(), "expected initial InfoLevel")
 
-		for round, lvl := range []Level{InfoLevel, DebugLevel} {
+		for round, lvl := range []Level{InfoLevel, DebugLevel, WarnLevel} {
 			parent.SetLevel(lvl)
 			for loggerI, log := range all {
 				log.Debug("@debug", Int("round", round), Int("logger", loggerI))
 			}
 			for loggerI, log := range all {
 				log.Info("@info", Int("round", round), Int("logger", loggerI))
+			}
+			for loggerI, log := range all {
+				log.Warn("@warn", Int("round", round), Int("logger", loggerI))
 			}
 		}
 
@@ -125,6 +128,9 @@ func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
 			`{"level":"info","msg":"@info","round":0,"logger":0}`,
 			`{"level":"info","msg":"@info","generation":2,"round":0,"logger":1}`,
 			`{"level":"info","msg":"@info","generation":2,"generation":3,"round":0,"logger":2}`,
+			`{"level":"warn","msg":"@warn","round":0,"logger":0}`,
+			`{"level":"warn","msg":"@warn","generation":2,"round":0,"logger":1}`,
+			`{"level":"warn","msg":"@warn","generation":2,"generation":3,"round":0,"logger":2}`,
 
 			// round 1 at DebugLevel
 			`{"level":"debug","msg":"@debug","round":1,"logger":0}`,
@@ -133,6 +139,14 @@ func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
 			`{"level":"info","msg":"@info","round":1,"logger":0}`,
 			`{"level":"info","msg":"@info","generation":2,"round":1,"logger":1}`,
 			`{"level":"info","msg":"@info","generation":2,"generation":3,"round":1,"logger":2}`,
+			`{"level":"warn","msg":"@warn","round":1,"logger":0}`,
+			`{"level":"warn","msg":"@warn","generation":2,"round":1,"logger":1}`,
+			`{"level":"warn","msg":"@warn","generation":2,"generation":3,"round":1,"logger":2}`,
+
+			// round 2 at WarnLevel
+			`{"level":"warn","msg":"@warn","round":2,"logger":0}`,
+			`{"level":"warn","msg":"@warn","generation":2,"round":2,"logger":1}`,
+			`{"level":"warn","msg":"@warn","generation":2,"generation":3,"round":2,"logger":2}`,
 		}, strings.Split(buf.Stripped(), "\n"))
 	})
 }

--- a/zbark/debark_test.go
+++ b/zbark/debark_test.go
@@ -41,14 +41,14 @@ func newLogrus() (bark.Logger, *bytes.Buffer) {
 	return bark.NewLoggerFromLogrus(logger), buf
 }
 
-func newDebark() (zap.Logger, *bytes.Buffer) {
+func newDebark(lvl zap.Level) (zap.Logger, *bytes.Buffer) {
 	logrus, buf := newLogrus()
-	return Debarkify(logrus, zap.DebugLevel), buf
+	return Debarkify(logrus, lvl), buf
 }
 
 func TestLogrusOutputIsTheSame(t *testing.T) {
 	logrus, lbuf := newLogrus()
-	debark, dbuf := newDebark()
+	debark, dbuf := newDebark(zap.DebugLevel)
 
 	zfields := []zap.Field{
 		zap.Bool("a", true),
@@ -93,7 +93,7 @@ var levels = []zap.Level{
 }
 
 func TestDebark_Levels(t *testing.T) {
-	logger, _ := newDebark()
+	logger, _ := newDebark(zap.DebugLevel)
 	for _, l := range append(levels, zap.PanicLevel, zap.FatalLevel) {
 		logger.SetLevel(l)
 		assert.Equal(t, l, logger.Level())
@@ -101,8 +101,7 @@ func TestDebark_Levels(t *testing.T) {
 }
 
 func TestDebark_Check(t *testing.T) {
-	logger, buf := newDebark()
-	logger.SetLevel(zap.DebugLevel)
+	logger, buf := newDebark(zap.DebugLevel)
 	for _, l := range append(levels, zap.PanicLevel, zap.FatalLevel) {
 		require.Equal(t, 0, buf.Len(), "buffer must be clean for %v", l)
 		lc := logger.Check(l, "msg")
@@ -133,8 +132,7 @@ func TestDebark_Check(t *testing.T) {
 }
 
 func TestDebark_LeveledLogging(t *testing.T) {
-	logger, buf := newDebark()
-	logger.SetLevel(zap.DebugLevel)
+	logger, buf := newDebark(zap.DebugLevel)
 	for _, l := range levels {
 		require.Equal(t, 0, buf.Len(), "buffer not zero")
 		logger.Log(l, "ohai")
@@ -155,8 +153,7 @@ func TestDebark_LeveledLogging(t *testing.T) {
 }
 
 func TestDebark_Methods(t *testing.T) {
-	logger, buf := newDebark()
-	logger.SetLevel(zap.DebugLevel)
+	logger, buf := newDebark(zap.DebugLevel)
 
 	funcs := []func(string, ...zap.Field){
 		logger.Debug,
@@ -186,12 +183,12 @@ func TestDebark_Methods(t *testing.T) {
 }
 
 func TestDebark_Stubs(t *testing.T) {
-	logger, _ := newDebark()
+	logger, _ := newDebark(zap.DebugLevel)
 	assert.NotPanics(t, func() { logger.DFatal("msg") })
 }
 
 func TestDebark_zapToBarkFields(t *testing.T) {
-	logger, _ := newDebark()
+	logger, _ := newDebark(zap.DebugLevel)
 	fields := []zap.Field{
 		zap.Bool("a", true),
 		zap.Float64("b", float64(0.1)),

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -176,7 +176,7 @@ func TestSamplerCheckPanicFatal(t *testing.T) {
 
 		assert.Nil(t, sampler.Check(zap.DebugLevel, "foo"), "Expected a nil CheckedMessage at disabled log levels.")
 		for i := 0; i < 5; i++ {
-			if cm := sampler.Check(level, "sample"); assert.True(t, cm.OK(), "expected fatal level to always be OK") {
+			if cm := sampler.Check(level, "sample"); assert.True(t, cm.OK(), "expected %v level to always be OK", level) {
 				cm.Write(zap.Int("iter", i))
 			}
 		}


### PR DESCRIPTION
Made while working on #166's "drop SetLevel big rock":
- shifting the level change test to test the "consequence" of level change, rather than the implementation
- pass level to all test fixture constructors, so that they can survive the fall of "SetLevel"