### PR TITLE
Refactor sampler checking

### DIFF
--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -66,6 +66,11 @@ func (c *counters) Reset(key string) {
 // sampler will emit the first N logs in each bucket and every Mth log
 // therafter. Sampling loggers are safe for concurrent use.
 //
+// Panic and Fatal logging are NOT sampled, and will always call the underlying
+// logger to panic() or terminate the process. HOWEVER Log-ing at PanicLevel or
+// FatalLevel, if it happens is sampled and will call the underlying logger Log
+// method, which should NOT panic() or terminate.
+//
 // Per-message counts are shared between parent and child loggers, which allows
 // applications to more easily control global I/O load.
 func Sample(zl zap.Logger, tick time.Duration, first, thereafter int) zap.Logger {

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -144,15 +144,11 @@ func (s *sampler) Error(msg string, fields ...zap.Field) {
 }
 
 func (s *sampler) Panic(msg string, fields ...zap.Field) {
-	if s.check(zap.PanicLevel, msg) {
-		s.Logger.Panic(msg, fields...)
-	}
+	s.Logger.Panic(msg, fields...)
 }
 
 func (s *sampler) Fatal(msg string, fields ...zap.Field) {
-	if s.check(zap.FatalLevel, msg) {
-		s.Logger.Fatal(msg, fields...)
-	}
+	s.Logger.Fatal(msg, fields...)
 }
 
 func (s *sampler) DFatal(msg string, fields ...zap.Field) {
@@ -162,12 +158,6 @@ func (s *sampler) DFatal(msg string, fields ...zap.Field) {
 }
 
 func (s *sampler) check(lvl zap.Level, msg string) bool {
-	switch lvl {
-	case zap.PanicLevel, zap.FatalLevel:
-		// Ignore sampling for Panic and Fatal, since it should always
-		// cause a panic or exit.
-		return true
-	}
 	if s.Logger.Check(lvl, msg) == nil {
 		return false
 	}

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -98,10 +98,10 @@ func (s *sampler) With(fields ...zap.Field) zap.Logger {
 }
 
 func (s *sampler) Check(lvl zap.Level, msg string) *zap.CheckedMessage {
-	if !s.check(lvl, msg) {
-		return nil
+	if s.check(lvl, msg) {
+		return zap.NewCheckedMessage(s.Logger, lvl, msg)
 	}
-	return zap.NewCheckedMessage(s.Logger, lvl, msg)
+	return nil
 }
 
 func (s *sampler) Log(lvl zap.Level, msg string, fields ...zap.Field) {

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -162,6 +162,10 @@ func (s *sampler) check(lvl zap.Level, msg string) bool {
 	if s.Logger.Check(lvl, msg) == nil {
 		return false
 	}
+	return s.sampled(lvl, msg)
+}
+
+func (s *sampler) sampled(lvl zap.Level, msg string) bool {
 	n := s.counts.Inc(msg)
 	if n <= s.first {
 		return true

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -108,38 +108,38 @@ func (s *sampler) Check(lvl zap.Level, msg string) *zap.CheckedMessage {
 	case zap.PanicLevel, zap.FatalLevel:
 		return cm
 	}
-	if s.sampled(lvl, msg) {
+	if s.sampled(msg) {
 		return cm
 	}
 	return nil
 }
 
 func (s *sampler) Log(lvl zap.Level, msg string, fields ...zap.Field) {
-	if s.Logger.Check(lvl, msg) != nil && s.sampled(lvl, msg) {
+	if s.Logger.Check(lvl, msg) != nil && s.sampled(msg) {
 		s.Logger.Log(lvl, msg, fields...)
 	}
 }
 
 func (s *sampler) Debug(msg string, fields ...zap.Field) {
-	if s.Logger.Check(zap.DebugLevel, msg) != nil && s.sampled(zap.DebugLevel, msg) {
+	if s.Logger.Check(zap.DebugLevel, msg) != nil && s.sampled(msg) {
 		s.Logger.Debug(msg, fields...)
 	}
 }
 
 func (s *sampler) Info(msg string, fields ...zap.Field) {
-	if s.Logger.Check(zap.InfoLevel, msg) != nil && s.sampled(zap.InfoLevel, msg) {
+	if s.Logger.Check(zap.InfoLevel, msg) != nil && s.sampled(msg) {
 		s.Logger.Info(msg, fields...)
 	}
 }
 
 func (s *sampler) Warn(msg string, fields ...zap.Field) {
-	if s.Logger.Check(zap.WarnLevel, msg) != nil && s.sampled(zap.WarnLevel, msg) {
+	if s.Logger.Check(zap.WarnLevel, msg) != nil && s.sampled(msg) {
 		s.Logger.Warn(msg, fields...)
 	}
 }
 
 func (s *sampler) Error(msg string, fields ...zap.Field) {
-	if s.Logger.Check(zap.ErrorLevel, msg) != nil && s.sampled(zap.ErrorLevel, msg) {
+	if s.Logger.Check(zap.ErrorLevel, msg) != nil && s.sampled(msg) {
 		s.Logger.Error(msg, fields...)
 	}
 }
@@ -153,12 +153,12 @@ func (s *sampler) Fatal(msg string, fields ...zap.Field) {
 }
 
 func (s *sampler) DFatal(msg string, fields ...zap.Field) {
-	if s.Logger.Check(zap.ErrorLevel, msg) != nil && s.sampled(zap.ErrorLevel, msg) {
+	if s.Logger.Check(zap.ErrorLevel, msg) != nil && s.sampled(msg) {
 		s.Logger.DFatal(msg, fields...)
 	}
 }
 
-func (s *sampler) sampled(lvl zap.Level, msg string) bool {
+func (s *sampler) sampled(msg string) bool {
 	n := s.counts.Inc(msg)
 	if n <= s.first {
 		return true

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -114,31 +114,31 @@ func (s *sampler) Check(lvl zap.Level, msg string) *zap.CheckedMessage {
 }
 
 func (s *sampler) Log(lvl zap.Level, msg string, fields ...zap.Field) {
-	if s.check(lvl, msg) {
+	if s.Logger.Check(lvl, msg) != nil && s.sampled(lvl, msg) {
 		s.Logger.Log(lvl, msg, fields...)
 	}
 }
 
 func (s *sampler) Debug(msg string, fields ...zap.Field) {
-	if s.check(zap.DebugLevel, msg) {
+	if s.Logger.Check(zap.DebugLevel, msg) != nil && s.sampled(zap.DebugLevel, msg) {
 		s.Logger.Debug(msg, fields...)
 	}
 }
 
 func (s *sampler) Info(msg string, fields ...zap.Field) {
-	if s.check(zap.InfoLevel, msg) {
+	if s.Logger.Check(zap.InfoLevel, msg) != nil && s.sampled(zap.InfoLevel, msg) {
 		s.Logger.Info(msg, fields...)
 	}
 }
 
 func (s *sampler) Warn(msg string, fields ...zap.Field) {
-	if s.check(zap.WarnLevel, msg) {
+	if s.Logger.Check(zap.WarnLevel, msg) != nil && s.sampled(zap.WarnLevel, msg) {
 		s.Logger.Warn(msg, fields...)
 	}
 }
 
 func (s *sampler) Error(msg string, fields ...zap.Field) {
-	if s.check(zap.ErrorLevel, msg) {
+	if s.Logger.Check(zap.ErrorLevel, msg) != nil && s.sampled(zap.ErrorLevel, msg) {
 		s.Logger.Error(msg, fields...)
 	}
 }
@@ -152,16 +152,9 @@ func (s *sampler) Fatal(msg string, fields ...zap.Field) {
 }
 
 func (s *sampler) DFatal(msg string, fields ...zap.Field) {
-	if s.check(zap.ErrorLevel, msg) {
+	if s.Logger.Check(zap.ErrorLevel, msg) != nil && s.sampled(zap.ErrorLevel, msg) {
 		s.Logger.DFatal(msg, fields...)
 	}
-}
-
-func (s *sampler) check(lvl zap.Level, msg string) bool {
-	if s.Logger.Check(lvl, msg) == nil {
-		return false
-	}
-	return s.sampled(lvl, msg)
 }
 
 func (s *sampler) sampled(lvl zap.Level, msg string) bool {

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -159,7 +159,7 @@ func (s *sampler) check(lvl zap.Level, msg string) bool {
 		// cause a panic or exit.
 		return true
 	}
-	if lvl < s.Level() {
+	if s.Logger.Check(lvl, msg) == nil {
 		return false
 	}
 	n := s.counts.Inc(msg)

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -99,18 +99,14 @@ func (s *sampler) With(fields ...zap.Field) zap.Logger {
 
 func (s *sampler) Check(lvl zap.Level, msg string) *zap.CheckedMessage {
 	cm := s.Logger.Check(lvl, msg)
-	if cm == nil {
-		return nil
-	}
 	switch lvl {
 	case zap.PanicLevel, zap.FatalLevel:
-		break
-	default:
-		if !s.sampled(lvl, msg) {
-			return nil
-		}
+		return cm
 	}
-	return cm
+	if s.sampled(lvl, msg) {
+		return cm
+	}
+	return nil
 }
 
 func (s *sampler) Log(lvl zap.Level, msg string, fields ...zap.Field) {

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -107,11 +107,12 @@ func (s *sampler) Check(lvl zap.Level, msg string) *zap.CheckedMessage {
 	switch lvl {
 	case zap.PanicLevel, zap.FatalLevel:
 		return cm
+	default:
+		if !cm.OK() || s.sampled(msg) {
+			return cm
+		}
+		return nil
 	}
-	if s.sampled(msg) {
-		return cm
-	}
-	return nil
 }
 
 func (s *sampler) Log(lvl zap.Level, msg string, fields ...zap.Field) {

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -120,7 +120,7 @@ func (s *sampler) Log(lvl zap.Level, msg string, fields ...zap.Field) {
 	case zap.PanicLevel, zap.FatalLevel:
 		s.Logger.Log(lvl, msg, fields...)
 	default:
-		if s.Logger.Check(lvl, msg) != nil && s.sampled(msg) {
+		if s.Logger.Check(lvl, msg).OK() && s.sampled(msg) {
 			s.Logger.Log(lvl, msg, fields...)
 		}
 	}

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -120,8 +120,8 @@ func (s *sampler) Log(lvl zap.Level, msg string, fields ...zap.Field) {
 	case zap.PanicLevel, zap.FatalLevel:
 		s.Logger.Log(lvl, msg, fields...)
 	default:
-		if s.Logger.Check(lvl, msg).OK() && s.sampled(msg) {
-			s.Logger.Log(lvl, msg, fields...)
+		if cm := s.Logger.Check(lvl, msg); cm.OK() && s.sampled(msg) {
+			cm.Write(fields...)
 		}
 	}
 }

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -144,14 +144,6 @@ func (s *sampler) Error(msg string, fields ...zap.Field) {
 	}
 }
 
-func (s *sampler) Panic(msg string, fields ...zap.Field) {
-	s.Logger.Panic(msg, fields...)
-}
-
-func (s *sampler) Fatal(msg string, fields ...zap.Field) {
-	s.Logger.Fatal(msg, fields...)
-}
-
 func (s *sampler) DFatal(msg string, fields ...zap.Field) {
 	if s.Logger.Check(zap.ErrorLevel, msg) != nil && s.sampled(msg) {
 		s.Logger.DFatal(msg, fields...)

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -116,8 +116,13 @@ func (s *sampler) Check(lvl zap.Level, msg string) *zap.CheckedMessage {
 }
 
 func (s *sampler) Log(lvl zap.Level, msg string, fields ...zap.Field) {
-	if s.Logger.Check(lvl, msg) != nil && s.sampled(msg) {
+	switch lvl {
+	case zap.PanicLevel, zap.FatalLevel:
 		s.Logger.Log(lvl, msg, fields...)
+	default:
+		if s.Logger.Check(lvl, msg) != nil && s.sampled(msg) {
+			s.Logger.Log(lvl, msg, fields...)
+		}
 	}
 }
 


### PR DESCRIPTION
Another towards the main point of #166:
- call underlying `Logger.Check`, rather than rely on level logic
- explicate the "always panic/fatal" logic
- return any underlying logger CheckedMessage, so that it would work right for #161 back a compound one
