### PR TITLE
WIP: Dynamiclevel instead of SetLevel

### DIFF
--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -37,9 +37,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHandler() (Logger, http.Handler) {
-	logger, _ := spy.New()
-	return logger, NewHTTPHandler(logger)
+func newHandler() (AtomicLevel, Logger, http.Handler) {
+	lvl := DynamicLevel()
+	logger, _ := spy.New(lvl)
+	return lvl, logger, NewHTTPHandler(lvl)
 }
 
 func assertCodeOK(t testing.TB, code int) {
@@ -86,44 +87,44 @@ func makeRequest(t testing.TB, method string, handler http.Handler, reader io.Re
 }
 
 func TestHTTPHandlerGetLevel(t *testing.T) {
-	logger, handler := newHandler()
+	lvl, _, handler := newHandler()
 	code, body := makeRequest(t, "GET", handler, nil)
 	assertCodeOK(t, code)
-	assertResponse(t, logger.Level(), body)
+	assertResponse(t, lvl.Level(), body)
 }
 
 func TestHTTPHandlerPutLevel(t *testing.T) {
-	logger, handler := newHandler()
+	lvl, _, handler := newHandler()
 
 	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{"level":"warn"}`))
 
 	assertCodeOK(t, code)
-	assertResponse(t, logger.Level(), body)
+	assertResponse(t, lvl.Level(), body)
 }
 
 func TestHTTPHandlerPutUnrecognizedLevel(t *testing.T) {
-	_, handler := newHandler()
+	_, _, handler := newHandler()
 	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{"level":"unrecognized-level"}`))
 	assertCodeBadRequest(t, code)
 	assertJSONError(t, body)
 }
 
 func TestHTTPHandlerNotJSON(t *testing.T) {
-	_, handler := newHandler()
+	_, _, handler := newHandler()
 	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{`))
 	assertCodeBadRequest(t, code)
 	assertJSONError(t, body)
 }
 
 func TestHTTPHandlerNoLevelSpecified(t *testing.T) {
-	_, handler := newHandler()
+	_, _, handler := newHandler()
 	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{}`))
 	assertCodeBadRequest(t, code)
 	assertJSONError(t, body)
 }
 
 func TestHTTPHandlerMethodNotAllowed(t *testing.T) {
-	_, handler := newHandler()
+	_, _, handler := newHandler()
 	code, body := makeRequest(t, "POST", handler, strings.NewReader(`{`))
 	assertCodeMethodNotAllowed(t, code)
 	assertJSONError(t, body)

--- a/level.go
+++ b/level.go
@@ -33,6 +33,20 @@ var errMarshalNilLevel = errors.New("can't marshal a nil *Level to text")
 // New to override the default logging priority.
 type Level int32
 
+// LevelEnabler decides whether a given logging level is enabled when logging a
+// message.
+//
+// Enablers are intended to be used to implement deterministic filters;
+// concerns like sampling are better implemented as a Logger implementation.
+//
+// Each concrete Level value implements a static LevelEnabler which returns
+// true for itself and all higher logging levels. For example WarnLevel.Enabled()
+// will return true for WarnLevel, ErrorLevel, PanicLevel, and FatalLevel, but
+// return false for InfoLevel and DebugLevel.
+type LevelEnabler interface {
+	Enabled(Level) bool
+}
+
 const (
 	// DebugLevel logs are typically voluminous, and are usually disabled in
 	// production.
@@ -104,4 +118,9 @@ func (l *Level) UnmarshalText(text []byte) error {
 		return fmt.Errorf("unrecognized level: %v", string(text))
 	}
 	return nil
+}
+
+// Enabled return true if the given level is at or above this level.
+func (l Level) Enabled(lvl Level) bool {
+	return lvl >= l
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -353,8 +353,7 @@ func TestJSONLoggerDFatal(t *testing.T) {
 }
 
 func TestJSONLoggerNoOpsDisabledLevels(t *testing.T) {
-	withJSONLogger(t, nil, func(logger Logger, buf *testBuffer) {
-		logger.SetLevel(WarnLevel)
+	withJSONLogger(t, opts(WarnLevel), func(logger Logger, buf *testBuffer) {
 		logger.Info("silence!")
 		assert.Equal(t, []string{}, buf.Lines(), "Expected logging at a disabled level to produce no output.")
 	})

--- a/logger_test.go
+++ b/logger_test.go
@@ -74,44 +74,42 @@ func withJSONLogger(t testing.TB, opts []Option, f func(Logger, *testBuffer)) {
 	assert.Empty(t, errSink.String(), "Expected error sink to be empty.")
 }
 
-func TestJSONLoggerSetLevel(t *testing.T) {
-	withJSONLogger(t, nil, func(logger Logger, _ *testBuffer) {
-		assert.Equal(t, DebugLevel, logger.Level(), "Unexpected initial level.")
-		logger.SetLevel(ErrorLevel)
-		assert.Equal(t, ErrorLevel, logger.Level(), "Unexpected level after SetLevel.")
-	})
+func TestDynamicLevel(t *testing.T) {
+	lvl := DynamicLevel()
+	assert.Equal(t, InfoLevel, lvl.Level(), "Unexpected initial level.")
+	lvl.SetLevel(ErrorLevel)
+	assert.Equal(t, ErrorLevel, lvl.Level(), "Unexpected level after SetLevel.")
 }
 
-func TestJSONLoggerConcurrentLevelMutation(t *testing.T) {
+func TestDynamicLevel_concurrentMutation(t *testing.T) {
+	lvl := DynamicLevel()
 	// Trigger races for non-atomic level mutations.
-	logger := New(newJSONEncoder())
-
 	proceed := make(chan struct{})
 	wg := &sync.WaitGroup{}
 	runConcurrently(10, 100, wg, func() {
 		<-proceed
-		logger.Level()
+		lvl.Level()
 	})
 	runConcurrently(10, 100, wg, func() {
 		<-proceed
-		logger.SetLevel(WarnLevel)
+		lvl.SetLevel(WarnLevel)
 	})
 	close(proceed)
 	wg.Wait()
 }
 
-func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
-	// Test that changing a logger's level also changes the level of all
-	// ancestors and descendants.
-	withJSONLogger(t, opts(InfoLevel), func(grandparent Logger, buf *testBuffer) {
+func TestJSONLogger_DynamicLevel(t *testing.T) {
+	// Test that the DynamicLevel applys to all ancestors and descendants.
+	dl := DynamicLevel()
+	withJSONLogger(t, opts(dl), func(grandparent Logger, buf *testBuffer) {
 		parent := grandparent.With(Int("generation", 2))
 		child := parent.With(Int("generation", 3))
 		all := []Logger{grandparent, parent, child}
 
-		assert.Equal(t, InfoLevel, parent.Level(), "expected initial InfoLevel")
+		assert.Equal(t, InfoLevel, dl.Level(), "expected initial InfoLevel")
 
 		for round, lvl := range []Level{InfoLevel, DebugLevel, WarnLevel} {
-			parent.SetLevel(lvl)
+			dl.SetLevel(lvl)
 			for loggerI, log := range all {
 				log.Debug("@debug", Int("round", round), Int("logger", loggerI))
 			}

--- a/meta.go
+++ b/meta.go
@@ -22,8 +22,7 @@ package zap
 
 import (
 	"os"
-
-	"github.com/uber-go/atomic"
+	"sync"
 )
 
 // Meta is implementation-agnostic state management for Loggers. Most Logger
@@ -38,18 +37,21 @@ type Meta struct {
 	Output      WriteSyncer
 	ErrorOutput WriteSyncer
 
-	lvl *atomic.Int32
+	enabLock *sync.RWMutex
+	enab     *LevelEnabler
 }
 
 // MakeMeta returns a new meta struct with sensible defaults: logging at
 // InfoLevel, development mode off, and writing to standard error and standard
 // out.
 func MakeMeta(enc Encoder, options ...Option) Meta {
+	enb := LevelEnabler(InfoLevel)
 	m := Meta{
-		lvl:         atomic.NewInt32(int32(InfoLevel)),
 		Encoder:     enc,
 		Output:      newLockedWriteSyncer(os.Stdout),
 		ErrorOutput: newLockedWriteSyncer(os.Stderr),
+		enabLock:    &sync.RWMutex{},
+		enab:        &enb,
 	}
 	for _, opt := range options {
 		opt.apply(&m)
@@ -57,15 +59,24 @@ func MakeMeta(enc Encoder, options ...Option) Meta {
 	return m
 }
 
-// Level returns the minimum enabled log level. It's safe to call concurrently.
+// Level returns the minimum enabled log level, if simple monotonic level
+// enabling is being used; otherwise it returns FatalLevel+1.
 func (m Meta) Level() Level {
-	return Level(m.lvl.Load())
+	m.enabLock.RLock()
+	if lvl, ok := (*m.enab).(Level); ok {
+		m.enabLock.RUnlock()
+		return lvl
+	}
+	m.enabLock.RUnlock()
+	return FatalLevel + 1
 }
 
-// SetLevel atomically alters the the logging level for this Meta and all its
-// clones.
+// SetLevel atomically alters the level enabler so that all logs of a given
+// level and up are enabled.
 func (m Meta) SetLevel(lvl Level) {
-	m.lvl.Store(int32(lvl))
+	m.enabLock.Lock()
+	*m.enab = lvl
+	m.enabLock.Unlock()
 }
 
 // Clone creates a copy of the meta struct. It deep-copies the encoder, but not
@@ -77,7 +88,10 @@ func (m Meta) Clone() Meta {
 
 // Enabled returns true if logging a message at a particular level is enabled.
 func (m Meta) Enabled(lvl Level) bool {
-	return lvl >= m.Level()
+	m.enabLock.RLock()
+	e := (*m.enab).Enabled(lvl)
+	m.enabLock.RUnlock()
+	return e
 }
 
 // Check returns a CheckedMessage logging the given message is Enabled, nil

--- a/options.go
+++ b/options.go
@@ -33,9 +33,8 @@ func (f optionFunc) apply(m *Meta) {
 }
 
 // This allows any Level to be used as an option.
-func (l Level) apply(m *Meta) {
-	m.SetLevel(l)
-}
+func (l Level) apply(m *Meta)         { m.LevelEnabler = l }
+func (lvl AtomicLevel) apply(m *Meta) { m.LevelEnabler = lvl }
 
 // Fields sets the initial fields for the logger.
 func Fields(fields ...Field) Option {

--- a/zbark/debark_test.go
+++ b/zbark/debark_test.go
@@ -111,14 +111,14 @@ func TestDebark_Check(t *testing.T) {
 		buf.Reset()
 	}
 
-	logger.SetLevel(zap.PanicLevel)
+	logger, buf = newDebark(zap.PanicLevel)
 	for _, l := range levels {
 		assert.Nil(t, logger.Check(l, "msg"))
 	}
 
 	// We should still panic even if the level isn't enough to log.
+	logger, buf = newDebark(zap.FatalLevel)
 	assert.Panics(t, func() {
-		logger.SetLevel(zap.FatalLevel)
 		logger.Check(zap.PanicLevel, "panic!").Write()
 	})
 }
@@ -132,14 +132,14 @@ func TestDebark_LeveledLogging(t *testing.T) {
 		buf.Reset()
 	}
 
-	logger.SetLevel(zap.FatalLevel)
+	logger, buf = newDebark(zap.FatalLevel)
 	require.Equal(t, 0, buf.Len(), "buffer not zero to begin test")
 	for _, l := range append(levels) {
 		logger.Log(l, "ohai")
 		assert.Equal(t, 0, buf.Len(), "buffer not zero, we should not have logged")
 	}
 
-	logger.SetLevel(zap.DebugLevel)
+	logger, buf = newDebark(zap.DebugLevel)
 	assert.Panics(t, func() { logger.Log(zap.Level(31337), "") })
 	assert.Panics(t, func() { logger.Log(zap.PanicLevel, "") })
 }
@@ -164,7 +164,7 @@ func TestDebark_Methods(t *testing.T) {
 	assert.Panics(t, func() { logger.Panic("foo") })
 	buf.Reset()
 
-	logger.SetLevel(zap.FatalLevel)
+	logger, buf = newDebark(zap.FatalLevel)
 	for i, f := range funcs {
 		f("ohai")
 		if !assert.Equal(t, 0, buf.Len(), "%+v(%d) logged, but shouldn't", f, i) {


### PR DESCRIPTION
WIP prefix of #161 that gets us through most of #166 (only CheckedMessage composition is yet TODO).

PRs to peel out of this one before its ready for proper review:
- [x] rework fatal/panic logic #168 
- ~~decouple sampler checking from level logic #172~~ (turns out that this isn't a strict dependency, but stil good to do towards #166 )
- [x] add `Meta.Enabled`, and  unify `Check` implementations (spy, sampler, logger, zbark) through `Meta` #174
- [ ] rework levels to be "just" an implementation of meta enabled #177
- [ ] replace `Meta.SetLevel` / `Meta.Level` with a `DynamicLevel` implementation of meta enabled