### PR TITLE
Indirect level checking

### DIFF
--- a/level.go
+++ b/level.go
@@ -33,6 +33,20 @@ var errMarshalNilLevel = errors.New("can't marshal a nil *Level to text")
 // New to override the default logging priority.
 type Level int32
 
+// LevelEnabler decides whether a given logging level is enabled when logging a
+// message.
+//
+// Enablers are intended to be used to implement deterministic filters;
+// concerns like sampling are better implemented as a Logger implementation.
+//
+// Each concrete Level value implements a static LevelEnabler which returns
+// true for itself and all higher logging levels. For example WarnLevel.Enabled()
+// will return true for WarnLevel, ErrorLevel, PanicLevel, and FatalLevel, but
+// return false for InfoLevel and DebugLevel.
+type LevelEnabler interface {
+	Enabled(Level) bool
+}
+
 const (
 	// DebugLevel logs are typically voluminous, and are usually disabled in
 	// production.
@@ -104,4 +118,9 @@ func (l *Level) UnmarshalText(text []byte) error {
 		return fmt.Errorf("unrecognized level: %v", string(text))
 	}
 	return nil
+}
+
+// Enabled return true if the given level is at or above this level.
+func (l Level) Enabled(lvl Level) bool {
+	return lvl >= l
 }

--- a/meta.go
+++ b/meta.go
@@ -22,8 +22,7 @@ package zap
 
 import (
 	"os"
-
-	"github.com/uber-go/atomic"
+	"sync"
 )
 
 // Meta is implementation-agnostic state management for Loggers. Most Logger
@@ -38,18 +37,21 @@ type Meta struct {
 	Output      WriteSyncer
 	ErrorOutput WriteSyncer
 
-	lvl *atomic.Int32
+	enabLock *sync.RWMutex
+	enab     *LevelEnabler
 }
 
 // MakeMeta returns a new meta struct with sensible defaults: logging at
 // InfoLevel, development mode off, and writing to standard error and standard
 // out.
 func MakeMeta(enc Encoder, options ...Option) Meta {
+	enb := LevelEnabler(InfoLevel)
 	m := Meta{
-		lvl:         atomic.NewInt32(int32(InfoLevel)),
 		Encoder:     enc,
 		Output:      newLockedWriteSyncer(os.Stdout),
 		ErrorOutput: newLockedWriteSyncer(os.Stderr),
+		enabLock:    &sync.RWMutex{},
+		enab:        &enb,
 	}
 	for _, opt := range options {
 		opt.apply(&m)
@@ -57,15 +59,24 @@ func MakeMeta(enc Encoder, options ...Option) Meta {
 	return m
 }
 
-// Level returns the minimum enabled log level. It's safe to call concurrently.
+// Level returns the minimum enabled log level, if simple monotonic level
+// enabling is being used; otherwise it returns FatalLevel+1.
 func (m Meta) Level() Level {
-	return Level(m.lvl.Load())
+	m.enabLock.RLock()
+	if lvl, ok := (*m.enab).(Level); ok {
+		m.enabLock.RUnlock()
+		return lvl
+	}
+	m.enabLock.RUnlock()
+	return FatalLevel + 1
 }
 
-// SetLevel atomically alters the the logging level for this Meta and all its
-// clones.
+// SetLevel atomically alters the level enabler so that all logs of a given
+// level and up are enabled.
 func (m Meta) SetLevel(lvl Level) {
-	m.lvl.Store(int32(lvl))
+	m.enabLock.Lock()
+	*m.enab = lvl
+	m.enabLock.Unlock()
 }
 
 // Clone creates a copy of the meta struct. It deep-copies the encoder, but not
@@ -77,7 +88,10 @@ func (m Meta) Clone() Meta {
 
 // Enabled returns true if logging a message at a particular level is enabled.
 func (m Meta) Enabled(lvl Level) bool {
-	return lvl >= m.Level()
+	m.enabLock.RLock()
+	e := (*m.enab).Enabled(lvl)
+	m.enabLock.RUnlock()
+	return e
 }
 
 // Check returns a CheckedMessage logging the given message is Enabled, nil


### PR DESCRIPTION
Makes each level value a static `LevelEnabler`.

I had to introduce a lock to avoid the race condition, before we introduce `{Atomic,Dynamic}Level` in #173.  If that's too distasteful, we can just jump to reviewing #173 instead.