### PR TITLE
Replace Logger.{Level,SetLevel} with DynamicLevel

### DIFF
--- a/http_handler.go
+++ b/http_handler.go
@@ -26,66 +26,51 @@ import (
 	"net/http"
 )
 
-type httpPayload struct {
-	Level *Level `json:"level"`
-}
-
-type errorResponse struct {
-	Error string `json:"error"`
-}
-
-type levelHandler struct {
-	lvl AtomicLevel
-}
-
-// NewHTTPHandler returns an HTTP handler that can atomically change a dynamic
-// logging level at runtime. Keep in mind that changing a dynamic logging level
-// affects not just the logger(s) that it was passed to, but also any
-// sub-loggers that have been or will be created With them.
+// ServeHTTP supports changing logging level with an HTTP request.
 //
 // GET requests return a JSON description of the current logging level. PUT
 // requests change the logging level and expect a payload like:
 //   {"level":"info"}
-func NewHTTPHandler(lvl AtomicLevel) http.Handler {
-	return &levelHandler{lvl: lvl}
-}
+func (lvl AtomicLevel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	type errorResponse struct {
+		Error string `json:"error"`
+	}
+	type payload struct {
+		Level *Level `json:"level"`
+	}
 
-func (h *levelHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	enc := json.NewEncoder(w)
+
 	switch r.Method {
+
 	case "GET":
-		h.getLevel(w, r)
+		current := lvl.Level()
+		enc.Encode(payload{Level: &current})
+
 	case "PUT":
-		h.putLevel(w, r)
+		var req payload
+
+		if errmess := func() string {
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				return fmt.Sprintf("Request body must be well-formed JSON: %v", err)
+			}
+			if req.Level == nil {
+				return "Must specify a logging level."
+			}
+			return ""
+		}(); errmess != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			enc.Encode(errorResponse{Error: errmess})
+			return
+		}
+
+		lvl.SetLevel(*req.Level)
+		enc.Encode(req)
+
 	default:
-		h.error(w, "Only GET and PUT are supported.", http.StatusMethodNotAllowed)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		enc.Encode(errorResponse{
+			Error: "Only GET and PUT are supported.",
+		})
 	}
-}
-
-func (h *levelHandler) getLevel(w http.ResponseWriter, r *http.Request) {
-	current := h.lvl.Level()
-	json.NewEncoder(w).Encode(httpPayload{Level: &current})
-}
-
-func (h *levelHandler) putLevel(w http.ResponseWriter, r *http.Request) {
-	var p httpPayload
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&p); err != nil {
-		h.error(
-			w,
-			fmt.Sprintf("Request body must be well-formed JSON: %v", err),
-			http.StatusBadRequest,
-		)
-		return
-	}
-	if p.Level == nil {
-		h.error(w, "Must specify a logging level.", http.StatusBadRequest)
-		return
-	}
-	h.lvl.SetLevel(*p.Level)
-	json.NewEncoder(w).Encode(p)
-}
-
-func (h *levelHandler) error(w http.ResponseWriter, msg string, status int) {
-	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(errorResponse{Error: msg})
 }

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -37,9 +37,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHandler() (Logger, http.Handler) {
-	logger, _ := spy.New()
-	return logger, NewHTTPHandler(logger)
+func newHandler() (AtomicLevel, Logger, http.Handler) {
+	lvl := DynamicLevel()
+	logger, _ := spy.New(lvl)
+	return lvl, logger, NewHTTPHandler(lvl)
 }
 
 func assertCodeOK(t testing.TB, code int) {
@@ -86,44 +87,44 @@ func makeRequest(t testing.TB, method string, handler http.Handler, reader io.Re
 }
 
 func TestHTTPHandlerGetLevel(t *testing.T) {
-	logger, handler := newHandler()
+	lvl, _, handler := newHandler()
 	code, body := makeRequest(t, "GET", handler, nil)
 	assertCodeOK(t, code)
-	assertResponse(t, logger.Level(), body)
+	assertResponse(t, lvl.Level(), body)
 }
 
 func TestHTTPHandlerPutLevel(t *testing.T) {
-	logger, handler := newHandler()
+	lvl, _, handler := newHandler()
 
 	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{"level":"warn"}`))
 
 	assertCodeOK(t, code)
-	assertResponse(t, logger.Level(), body)
+	assertResponse(t, lvl.Level(), body)
 }
 
 func TestHTTPHandlerPutUnrecognizedLevel(t *testing.T) {
-	_, handler := newHandler()
+	_, _, handler := newHandler()
 	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{"level":"unrecognized-level"}`))
 	assertCodeBadRequest(t, code)
 	assertJSONError(t, body)
 }
 
 func TestHTTPHandlerNotJSON(t *testing.T) {
-	_, handler := newHandler()
+	_, _, handler := newHandler()
 	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{`))
 	assertCodeBadRequest(t, code)
 	assertJSONError(t, body)
 }
 
 func TestHTTPHandlerNoLevelSpecified(t *testing.T) {
-	_, handler := newHandler()
+	_, _, handler := newHandler()
 	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{}`))
 	assertCodeBadRequest(t, code)
 	assertJSONError(t, body)
 }
 
 func TestHTTPHandlerMethodNotAllowed(t *testing.T) {
-	_, handler := newHandler()
+	_, _, handler := newHandler()
 	code, body := makeRequest(t, "POST", handler, strings.NewReader(`{`))
 	assertCodeMethodNotAllowed(t, code)
 	assertJSONError(t, body)

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -37,10 +37,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHandler() (AtomicLevel, Logger, http.Handler) {
+func newHandler() (AtomicLevel, Logger) {
 	lvl := DynamicLevel()
 	logger, _ := spy.New(lvl)
-	return lvl, logger, NewHTTPHandler(lvl)
+	return lvl, logger
 }
 
 func assertCodeOK(t testing.TB, code int) {
@@ -87,45 +87,45 @@ func makeRequest(t testing.TB, method string, handler http.Handler, reader io.Re
 }
 
 func TestHTTPHandlerGetLevel(t *testing.T) {
-	lvl, _, handler := newHandler()
-	code, body := makeRequest(t, "GET", handler, nil)
+	lvl, _ := newHandler()
+	code, body := makeRequest(t, "GET", lvl, nil)
 	assertCodeOK(t, code)
 	assertResponse(t, lvl.Level(), body)
 }
 
 func TestHTTPHandlerPutLevel(t *testing.T) {
-	lvl, _, handler := newHandler()
+	lvl, _ := newHandler()
 
-	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{"level":"warn"}`))
+	code, body := makeRequest(t, "PUT", lvl, strings.NewReader(`{"level":"warn"}`))
 
 	assertCodeOK(t, code)
 	assertResponse(t, lvl.Level(), body)
 }
 
 func TestHTTPHandlerPutUnrecognizedLevel(t *testing.T) {
-	_, _, handler := newHandler()
-	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{"level":"unrecognized-level"}`))
+	lvl, _ := newHandler()
+	code, body := makeRequest(t, "PUT", lvl, strings.NewReader(`{"level":"unrecognized-level"}`))
 	assertCodeBadRequest(t, code)
 	assertJSONError(t, body)
 }
 
 func TestHTTPHandlerNotJSON(t *testing.T) {
-	_, _, handler := newHandler()
-	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{`))
+	lvl, _ := newHandler()
+	code, body := makeRequest(t, "PUT", lvl, strings.NewReader(`{`))
 	assertCodeBadRequest(t, code)
 	assertJSONError(t, body)
 }
 
 func TestHTTPHandlerNoLevelSpecified(t *testing.T) {
-	_, _, handler := newHandler()
-	code, body := makeRequest(t, "PUT", handler, strings.NewReader(`{}`))
+	lvl, _ := newHandler()
+	code, body := makeRequest(t, "PUT", lvl, strings.NewReader(`{}`))
 	assertCodeBadRequest(t, code)
 	assertJSONError(t, body)
 }
 
 func TestHTTPHandlerMethodNotAllowed(t *testing.T) {
-	_, _, handler := newHandler()
-	code, body := makeRequest(t, "POST", handler, strings.NewReader(`{`))
+	lvl, _ := newHandler()
+	code, body := makeRequest(t, "POST", lvl, strings.NewReader(`{`))
 	assertCodeMethodNotAllowed(t, code)
 	assertJSONError(t, body)
 }

--- a/level.go
+++ b/level.go
@@ -33,6 +33,20 @@ var errMarshalNilLevel = errors.New("can't marshal a nil *Level to text")
 // New to override the default logging priority.
 type Level int32
 
+// LevelEnabler decides whether a given logging level is enabled when logging a
+// message.
+//
+// Enablers are intended to be used to implement deterministic filters;
+// concerns like sampling are better implemented as a Logger implementation.
+//
+// Each concrete Level value implements a static LevelEnabler which returns
+// true for itself and all higher logging levels. For example WarnLevel.Enabled()
+// will return true for WarnLevel, ErrorLevel, PanicLevel, and FatalLevel, but
+// return false for InfoLevel and DebugLevel.
+type LevelEnabler interface {
+	Enabled(Level) bool
+}
+
 const (
 	// DebugLevel logs are typically voluminous, and are usually disabled in
 	// production.
@@ -104,4 +118,9 @@ func (l *Level) UnmarshalText(text []byte) error {
 		return fmt.Errorf("unrecognized level: %v", string(text))
 	}
 	return nil
+}
+
+// Enabled return true if the given level is at or above this level.
+func (l Level) Enabled(lvl Level) bool {
+	return lvl >= l
 }

--- a/level.go
+++ b/level.go
@@ -122,7 +122,7 @@ func (l *Level) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// Enabled return true if the given level is at or above this level.
+// Enabled returns true if the given level is at or above this level.
 func (l Level) Enabled(lvl Level) bool {
 	return lvl >= l
 }

--- a/logger.go
+++ b/logger.go
@@ -30,13 +30,6 @@ var _exit = os.Exit
 // A Logger enables leveled, structured logging. All methods are safe for
 // concurrent use.
 type Logger interface {
-	// Check the minimum enabled log level.
-	Level() Level
-	// Change the level of this logger, as well as all its ancestors and
-	// descendants. This makes it easy to change the log level at runtime
-	// without restarting your application.
-	SetLevel(Level)
-
 	// Create a child logger, and optionally add some context to that logger.
 	With(...Field) Logger
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -353,8 +353,7 @@ func TestJSONLoggerDFatal(t *testing.T) {
 }
 
 func TestJSONLoggerNoOpsDisabledLevels(t *testing.T) {
-	withJSONLogger(t, nil, func(logger Logger, buf *testBuffer) {
-		logger.SetLevel(WarnLevel)
+	withJSONLogger(t, opts(WarnLevel), func(logger Logger, buf *testBuffer) {
 		logger.Info("silence!")
 		assert.Equal(t, []string{}, buf.Lines(), "Expected logging at a disabled level to produce no output.")
 	})

--- a/logger_test.go
+++ b/logger_test.go
@@ -74,44 +74,42 @@ func withJSONLogger(t testing.TB, opts []Option, f func(Logger, *testBuffer)) {
 	assert.Empty(t, errSink.String(), "Expected error sink to be empty.")
 }
 
-func TestJSONLoggerSetLevel(t *testing.T) {
-	withJSONLogger(t, nil, func(logger Logger, _ *testBuffer) {
-		assert.Equal(t, DebugLevel, logger.Level(), "Unexpected initial level.")
-		logger.SetLevel(ErrorLevel)
-		assert.Equal(t, ErrorLevel, logger.Level(), "Unexpected level after SetLevel.")
-	})
+func TestDynamicLevel(t *testing.T) {
+	lvl := DynamicLevel()
+	assert.Equal(t, InfoLevel, lvl.Level(), "Unexpected initial level.")
+	lvl.SetLevel(ErrorLevel)
+	assert.Equal(t, ErrorLevel, lvl.Level(), "Unexpected level after SetLevel.")
 }
 
-func TestJSONLoggerConcurrentLevelMutation(t *testing.T) {
+func TestDynamicLevel_concurrentMutation(t *testing.T) {
+	lvl := DynamicLevel()
 	// Trigger races for non-atomic level mutations.
-	logger := New(newJSONEncoder())
-
 	proceed := make(chan struct{})
 	wg := &sync.WaitGroup{}
 	runConcurrently(10, 100, wg, func() {
 		<-proceed
-		logger.Level()
+		lvl.Level()
 	})
 	runConcurrently(10, 100, wg, func() {
 		<-proceed
-		logger.SetLevel(WarnLevel)
+		lvl.SetLevel(WarnLevel)
 	})
 	close(proceed)
 	wg.Wait()
 }
 
-func TestJSONLoggerRuntimeLevelChange(t *testing.T) {
-	// Test that changing a logger's level also changes the level of all
-	// ancestors and descendants.
-	withJSONLogger(t, opts(InfoLevel), func(grandparent Logger, buf *testBuffer) {
+func TestJSONLogger_DynamicLevel(t *testing.T) {
+	// Test that the DynamicLevel applys to all ancestors and descendants.
+	dl := DynamicLevel()
+	withJSONLogger(t, opts(dl), func(grandparent Logger, buf *testBuffer) {
 		parent := grandparent.With(Int("generation", 2))
 		child := parent.With(Int("generation", 3))
 		all := []Logger{grandparent, parent, child}
 
-		assert.Equal(t, InfoLevel, parent.Level(), "expected initial InfoLevel")
+		assert.Equal(t, InfoLevel, dl.Level(), "expected initial InfoLevel")
 
 		for round, lvl := range []Level{InfoLevel, DebugLevel, WarnLevel} {
-			parent.SetLevel(lvl)
+			dl.SetLevel(lvl)
 			for loggerI, log := range all {
 				log.Debug("@debug", Int("round", round), Int("logger", loggerI))
 			}

--- a/meta.go
+++ b/meta.go
@@ -23,7 +23,6 @@ package zap
 import (
 	"fmt"
 	"os"
-	"sync"
 )
 
 // Meta is implementation-agnostic state management for Loggers. Most Logger
@@ -37,22 +36,18 @@ type Meta struct {
 	Hooks       []Hook
 	Output      WriteSyncer
 	ErrorOutput WriteSyncer
-
-	enabLock *sync.RWMutex
-	enab     *LevelEnabler
+	LevelEnabler
 }
 
 // MakeMeta returns a new meta struct with sensible defaults: logging at
 // InfoLevel, development mode off, and writing to standard error and standard
 // out.
 func MakeMeta(enc Encoder, options ...Option) Meta {
-	enb := LevelEnabler(InfoLevel)
 	m := Meta{
-		Encoder:     enc,
-		Output:      newLockedWriteSyncer(os.Stdout),
-		ErrorOutput: newLockedWriteSyncer(os.Stderr),
-		enabLock:    &sync.RWMutex{},
-		enab:        &enb,
+		Encoder:      enc,
+		Output:       newLockedWriteSyncer(os.Stdout),
+		ErrorOutput:  newLockedWriteSyncer(os.Stderr),
+		LevelEnabler: InfoLevel,
 	}
 	for _, opt := range options {
 		opt.apply(&m)
@@ -63,21 +58,16 @@ func MakeMeta(enc Encoder, options ...Option) Meta {
 // Level returns the minimum enabled log level, if simple monotonic level
 // enabling is being used; otherwise it returns FatalLevel+1.
 func (m Meta) Level() Level {
-	m.enabLock.RLock()
-	if lvl, ok := (*m.enab).(Level); ok {
-		m.enabLock.RUnlock()
+	if lvl, ok := m.LevelEnabler.(Level); ok {
 		return lvl
 	}
-	m.enabLock.RUnlock()
 	return FatalLevel + 1
 }
 
 // SetLevel atomically alters the level enabler so that all logs of a given
 // level and up are enabled.
 func (m Meta) SetLevel(lvl Level) {
-	m.enabLock.Lock()
-	*m.enab = lvl
-	m.enabLock.Unlock()
+	m.LevelEnabler = lvl
 }
 
 // Clone creates a copy of the meta struct. It deep-copies the encoder, but not
@@ -89,10 +79,7 @@ func (m Meta) Clone() Meta {
 
 // Enabled returns true if logging a message at a particular level is enabled.
 func (m Meta) Enabled(lvl Level) bool {
-	m.enabLock.RLock()
-	e := (*m.enab).Enabled(lvl)
-	m.enabLock.RUnlock()
-	return e
+	return m.LevelEnabler.Enabled(lvl)
 }
 
 // Check returns a CheckedMessage logging the given message is Enabled, nil

--- a/meta.go
+++ b/meta.go
@@ -23,8 +23,7 @@ package zap
 import (
 	"fmt"
 	"os"
-
-	"github.com/uber-go/atomic"
+	"sync"
 )
 
 // Meta is implementation-agnostic state management for Loggers. Most Logger
@@ -39,18 +38,21 @@ type Meta struct {
 	Output      WriteSyncer
 	ErrorOutput WriteSyncer
 
-	lvl *atomic.Int32
+	enabLock *sync.RWMutex
+	enab     *LevelEnabler
 }
 
 // MakeMeta returns a new meta struct with sensible defaults: logging at
 // InfoLevel, development mode off, and writing to standard error and standard
 // out.
 func MakeMeta(enc Encoder, options ...Option) Meta {
+	enb := LevelEnabler(InfoLevel)
 	m := Meta{
-		lvl:         atomic.NewInt32(int32(InfoLevel)),
 		Encoder:     enc,
 		Output:      newLockedWriteSyncer(os.Stdout),
 		ErrorOutput: newLockedWriteSyncer(os.Stderr),
+		enabLock:    &sync.RWMutex{},
+		enab:        &enb,
 	}
 	for _, opt := range options {
 		opt.apply(&m)
@@ -58,15 +60,24 @@ func MakeMeta(enc Encoder, options ...Option) Meta {
 	return m
 }
 
-// Level returns the minimum enabled log level. It's safe to call concurrently.
+// Level returns the minimum enabled log level, if simple monotonic level
+// enabling is being used; otherwise it returns FatalLevel+1.
 func (m Meta) Level() Level {
-	return Level(m.lvl.Load())
+	m.enabLock.RLock()
+	if lvl, ok := (*m.enab).(Level); ok {
+		m.enabLock.RUnlock()
+		return lvl
+	}
+	m.enabLock.RUnlock()
+	return FatalLevel + 1
 }
 
-// SetLevel atomically alters the the logging level for this Meta and all its
-// clones.
+// SetLevel atomically alters the level enabler so that all logs of a given
+// level and up are enabled.
 func (m Meta) SetLevel(lvl Level) {
-	m.lvl.Store(int32(lvl))
+	m.enabLock.Lock()
+	*m.enab = lvl
+	m.enabLock.Unlock()
 }
 
 // Clone creates a copy of the meta struct. It deep-copies the encoder, but not
@@ -78,7 +89,10 @@ func (m Meta) Clone() Meta {
 
 // Enabled returns true if logging a message at a particular level is enabled.
 func (m Meta) Enabled(lvl Level) bool {
-	return lvl >= m.Level()
+	m.enabLock.RLock()
+	e := (*m.enab).Enabled(lvl)
+	m.enabLock.RUnlock()
+	return e
 }
 
 // Check returns a CheckedMessage logging the given message is Enabled, nil

--- a/meta.go
+++ b/meta.go
@@ -55,21 +55,6 @@ func MakeMeta(enc Encoder, options ...Option) Meta {
 	return m
 }
 
-// Level returns the minimum enabled log level, if simple monotonic level
-// enabling is being used; otherwise it returns FatalLevel+1.
-func (m Meta) Level() Level {
-	if lvl, ok := m.LevelEnabler.(Level); ok {
-		return lvl
-	}
-	return FatalLevel + 1
-}
-
-// SetLevel atomically alters the level enabler so that all logs of a given
-// level and up are enabled.
-func (m Meta) SetLevel(lvl Level) {
-	m.LevelEnabler = lvl
-}
-
 // Clone creates a copy of the meta struct. It deep-copies the encoder, but not
 // the hooks (since they rarely change).
 func (m Meta) Clone() Meta {

--- a/meta.go
+++ b/meta.go
@@ -31,12 +31,13 @@ import (
 // Note that while the level-related fields and methods are safe for concurrent
 // use, the remaining fields are not.
 type Meta struct {
+	LevelEnabler
+
 	Development bool
 	Encoder     Encoder
 	Hooks       []Hook
 	Output      WriteSyncer
 	ErrorOutput WriteSyncer
-	LevelEnabler
 }
 
 // MakeMeta returns a new meta struct with sensible defaults: logging at

--- a/meta.go
+++ b/meta.go
@@ -63,11 +63,6 @@ func (m Meta) Clone() Meta {
 	return m
 }
 
-// Enabled returns true if logging a message at a particular level is enabled.
-func (m Meta) Enabled(lvl Level) bool {
-	return m.LevelEnabler.Enabled(lvl)
-}
-
 // Check returns a CheckedMessage logging the given message is Enabled, nil
 // otherwise.
 func (m Meta) Check(log Logger, lvl Level, msg string) *CheckedMessage {

--- a/options.go
+++ b/options.go
@@ -33,9 +33,8 @@ func (f optionFunc) apply(m *Meta) {
 }
 
 // This allows any Level to be used as an option.
-func (l Level) apply(m *Meta) {
-	m.SetLevel(l)
-}
+func (l Level) apply(m *Meta)         { m.LevelEnabler = l }
+func (lvl AtomicLevel) apply(m *Meta) { m.LevelEnabler = lvl }
 
 // Fields sets the initial fields for the logger.
 func Fields(fields ...Field) Option {

--- a/zbark/debark_test.go
+++ b/zbark/debark_test.go
@@ -111,14 +111,14 @@ func TestDebark_Check(t *testing.T) {
 		buf.Reset()
 	}
 
-	logger.SetLevel(zap.PanicLevel)
+	logger, buf = newDebark(zap.PanicLevel)
 	for _, l := range levels {
 		assert.Nil(t, logger.Check(l, "msg"))
 	}
 
 	// We should still panic even if the level isn't enough to log.
+	logger, buf = newDebark(zap.FatalLevel)
 	assert.Panics(t, func() {
-		logger.SetLevel(zap.FatalLevel)
 		logger.Check(zap.PanicLevel, "panic!").Write()
 	})
 }
@@ -132,14 +132,14 @@ func TestDebark_LeveledLogging(t *testing.T) {
 		buf.Reset()
 	}
 
-	logger.SetLevel(zap.FatalLevel)
+	logger, buf = newDebark(zap.FatalLevel)
 	require.Equal(t, 0, buf.Len(), "buffer not zero to begin test")
 	for _, l := range append(levels) {
 		logger.Log(l, "ohai")
 		assert.Equal(t, 0, buf.Len(), "buffer not zero, we should not have logged")
 	}
 
-	logger.SetLevel(zap.DebugLevel)
+	logger, buf = newDebark(zap.DebugLevel)
 	assert.Panics(t, func() { logger.Log(zap.Level(31337), "") })
 	assert.Panics(t, func() { logger.Log(zap.PanicLevel, "") })
 }
@@ -164,7 +164,7 @@ func TestDebark_Methods(t *testing.T) {
 	assert.Panics(t, func() { logger.Panic("foo") })
 	buf.Reset()
 
-	logger.SetLevel(zap.FatalLevel)
+	logger, buf = newDebark(zap.FatalLevel)
 	for i, f := range funcs {
 		f("ohai")
 		if !assert.Equal(t, 0, buf.Len(), "%+v(%d) logged, but shouldn't", f, i) {


### PR DESCRIPTION
Depends on #172, supercedes #173.

After this PR, the only part of #166 left is the CheckedMessage composition work.