### PR TITLE
Improve internal error handling

### DIFF
--- a/hook_test.go
+++ b/hook_test.go
@@ -47,7 +47,7 @@ func TestHookAddCallerFail(t *testing.T) {
 
 	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), ErrorOutput(errBuf), AddCaller())
 	logger.Info("Failure.")
-	assert.Equal(t, "failed to get caller\n", errBuf.String(), "Didn't find expected failure message.")
+	assert.Equal(t, "hook error: failed to get caller\n", errBuf.String(), "Didn't find expected failure message.")
 	assert.Contains(t, buf.String(), `"msg":"Failure."`, "Expected original message to survive failures in runtime.Caller.")
 }
 

--- a/hook_test.go
+++ b/hook_test.go
@@ -47,7 +47,7 @@ func TestHookAddCallerFail(t *testing.T) {
 
 	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), ErrorOutput(errBuf), AddCaller())
 	logger.Info("Failure.")
-	assert.Equal(t, "hook error: failed to get caller\n", errBuf.String(), "Didn't find expected failure message.")
+	assert.Regexp(t, `hook error: failed to get caller`, errBuf.String(), "Didn't find expected failure message.")
 	assert.Contains(t, buf.String(), `"msg":"Failure."`, "Expected original message to survive failures in runtime.Caller.")
 }
 

--- a/logger.go
+++ b/logger.go
@@ -142,12 +142,12 @@ func (log *logger) log(lvl Level, msg string, fields []Field) {
 	entry := newEntry(lvl, msg, temp)
 	for _, hook := range log.Hooks {
 		if err := hook(entry); err != nil {
-			log.internalError(err.Error())
+			log.internalError("hook", err)
 		}
 	}
 
 	if err := temp.WriteEntry(log.Output, entry.Message, entry.Level, entry.Time); err != nil {
-		log.internalError(err.Error())
+		log.internalError("encoder", err)
 	}
 	temp.Free()
 	entry.free()
@@ -158,7 +158,7 @@ func (log *logger) log(lvl Level, msg string, fields []Field) {
 	}
 }
 
-func (log *logger) internalError(msg string) {
-	fmt.Fprintln(log.ErrorOutput, msg)
+func (log *logger) internalError(cause string, err error) {
+	fmt.Fprintf(log.ErrorOutput, "%s error: %v\n", cause, err)
 	log.ErrorOutput.Sync()
 }

--- a/logger.go
+++ b/logger.go
@@ -21,7 +21,6 @@
 package zap
 
 import (
-	"fmt"
 	"os"
 )
 
@@ -142,12 +141,12 @@ func (log *logger) log(lvl Level, msg string, fields []Field) {
 	entry := newEntry(lvl, msg, temp)
 	for _, hook := range log.Hooks {
 		if err := hook(entry); err != nil {
-			log.internalError("hook", err)
+			log.InternalError("hook", err)
 		}
 	}
 
 	if err := temp.WriteEntry(log.Output, entry.Message, entry.Level, entry.Time); err != nil {
-		log.internalError("encoder", err)
+		log.InternalError("encoder", err)
 	}
 	temp.Free()
 	entry.free()
@@ -156,9 +155,4 @@ func (log *logger) log(lvl Level, msg string, fields []Field) {
 		// Sync on Panic and Fatal, since they may crash the program.
 		log.Output.Sync()
 	}
-}
-
-func (log *logger) internalError(cause string, err error) {
-	fmt.Fprintf(log.ErrorOutput, "%s error: %v\n", cause, err)
-	log.ErrorOutput.Sync()
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -372,7 +372,7 @@ func TestJSONLoggerWriteEntryFailure(t *testing.T) {
 
 	logger.Info("foo")
 	// Should log the error.
-	assert.Equal(t, "encoder error: failed", errBuf.Stripped(), "Expected to log the error to the error output.")
+	assert.Regexp(t, `encoder error: failed`, errBuf.Stripped(), "Expected to log the error to the error output.")
 	assert.True(t, errSink.Called(), "Expected logging an internal error to call Sync the error sink.")
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -372,7 +372,7 @@ func TestJSONLoggerWriteEntryFailure(t *testing.T) {
 
 	logger.Info("foo")
 	// Should log the error.
-	assert.Equal(t, "failed", errBuf.Stripped(), "Expected to log the error to the error output.")
+	assert.Equal(t, "encoder error: failed", errBuf.Stripped(), "Expected to log the error to the error output.")
 	assert.True(t, errSink.Called(), "Expected logging an internal error to call Sync the error sink.")
 }
 

--- a/meta.go
+++ b/meta.go
@@ -100,6 +100,6 @@ func (m Meta) Check(log Logger, lvl Level, msg string) *CheckedMessage {
 // InternalError prints an internal error message to the configured
 // ErrorOutput
 func (m Meta) InternalError(cause string, err error) {
-	fmt.Fprintf(m.ErrorOutput, "%s error: %v\n", cause, err)
+	fmt.Fprintf(m.ErrorOutput, "%v %s error: %v\n", _timeNow().UTC(), cause, err)
 	m.ErrorOutput.Sync()
 }

--- a/meta.go
+++ b/meta.go
@@ -98,7 +98,8 @@ func (m Meta) Check(log Logger, lvl Level, msg string) *CheckedMessage {
 }
 
 // InternalError prints an internal error message to the configured
-// ErrorOutput
+// ErrorOutput. This method should only be used to report internal logger
+// problems and should not be used to report user-caused problems.
 func (m Meta) InternalError(cause string, err error) {
 	fmt.Fprintf(m.ErrorOutput, "%v %s error: %v\n", _timeNow().UTC(), cause, err)
 	m.ErrorOutput.Sync()

--- a/meta.go
+++ b/meta.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/uber-go/atomic"
@@ -94,4 +95,11 @@ func (m Meta) Check(log Logger, lvl Level, msg string) *CheckedMessage {
 		}
 	}
 	return NewCheckedMessage(log, lvl, msg)
+}
+
+// InternalError prints an internal error message to the configured
+// ErrorOutput
+func (m Meta) InternalError(cause string, err error) {
+	fmt.Fprintf(m.ErrorOutput, "%s error: %v\n", cause, err)
+	m.ErrorOutput.Sync()
 }


### PR DESCRIPTION
- add timestamp to error output
- tag with "cause" (e.g. "hook" vs "encoder")
- move method to Meta so that other implementation can use it