### PR TITLE
WIP: Add Caller/Callers fields

### DIFF
--- a/field.go
+++ b/field.go
@@ -24,6 +24,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
+	"runtime"
+	"strconv"
 	"time"
 )
 
@@ -155,6 +157,64 @@ func Stack() Field {
 	field := String("stacktrace", takeStacktrace(bs, false))
 	enc.Free()
 	return field
+}
+
+// Callers constrcuts a Field that stores a structured object detailing its
+// caller's call stack (up to 32 entries from it at least) under the key
+// "callers". It is spiritually similar to Stack, but should be more efficient
+// since it is lazy and shouldn't incur any allocations while marshaling.
+//
+// The skip argument is relative to Callers's caller, with 0 identifying the
+// calling function (the log site), 1 identifying its caller, and so on.
+//
+// The marshaled object is a "fake array" with keys "0", "1", "2", etc. Each
+// key's value is an object with "pc", "file", and "line" fields. The callers object may be empty
+func Callers(skip int) Field {
+	var pcs [32]uintptr
+	n := runtime.Callers(skip+2, pcs[:])
+	return Marshaler("callers", LogMarshalerFunc(func(kv KeyValue) error {
+		i := 0
+		frames := runtime.CallersFrames(pcs[:n])
+		fr, more := frames.Next()
+		for {
+			if err := kv.AddMarshaler(strconv.Itoa(i), LogMarshalerFunc(func(kv KeyValue) error {
+				kv.AddUintptr("pc", fr.PC)
+				kv.AddString("file", fr.File)
+				kv.AddInt("line", fr.Line)
+				return nil
+			})); err != nil {
+				return err
+			}
+			if !more {
+				break
+			}
+			fr, more = frames.Next()
+			i++
+		}
+		return nil
+	}))
+}
+
+// Caller constrcuts a Field that stores a structured object its
+// caller under the key "caller". It is spiritually similar to AddCaller,
+// except on a per log-site basis. It should be relatively efficient since it
+// is lazy and incurs no marshaling allocations.
+//
+// The skip argument is relative to Caller's caller, with 0 identifying the
+// calling function (the log site), 1 identifying its caller, and so on.
+//
+// The marshaled object has "pc", "file", and "line" fields, unless a caller
+// couldn't be resolved.
+func Caller(skip int) Field {
+	pc, file, line, ok := runtime.Caller(skip + 2)
+	return Marshaler("caller", LogMarshalerFunc(func(kv KeyValue) error {
+		if ok {
+			kv.AddUintptr("pc", pc)
+			kv.AddString("file", file)
+			kv.AddInt("line", line)
+		}
+		return nil
+	}))
 }
 
 // Duration constructs a Field with the given key and value. It represents

--- a/field_test.go
+++ b/field_test.go
@@ -66,6 +66,15 @@ func assertNotEqualFieldJSON(t testing.TB, expected string, field Field) {
 		"Unexpected JSON output after applying field %+v.", field)
 }
 
+func assertFieldJSONRegEx(t testing.TB, expected string, field Field) {
+	enc := newJSONEncoder()
+	defer enc.Free()
+
+	field.AddTo(enc)
+	assert.Regexp(t, expected, string(enc.bytes),
+		"Unexpected JSON output after applying field %+v.", field)
+}
+
 func assertCanBeReused(t testing.TB, field Field) {
 	var wg sync.WaitGroup
 
@@ -214,6 +223,16 @@ func TestStackField(t *testing.T) {
 
 	require.True(t, strings.HasPrefix(output, `"stacktrace":`), "Stacktrace added under an unexpected key.")
 	assert.Contains(t, output[13:], "zap.TestStackField", "Expected stacktrace to contain caller.")
+}
+
+func TestCaller(t *testing.T) {
+	// Caller() makes an assupmtion that it is called within zap's hook mechanism.
+	// This is not true for this test, so pass -1 to log this function as the caller.
+	c, _ := Caller(-1)
+	assertFieldJSONRegEx(t, "\"caller\":{\"pc\":[0-9]+,\"file\":\".+field_test.go\",\"line\":[0-9]+}", c)
+
+	c2, _ := Caller(-1)
+	assertCanBeReused(t, c2)
 }
 
 func TestUnknownField(t *testing.T) {

--- a/field_test.go
+++ b/field_test.go
@@ -228,10 +228,22 @@ func TestStackField(t *testing.T) {
 func TestCaller(t *testing.T) {
 	// Caller() makes an assupmtion that it is called within zap's hook mechanism.
 	// This is not true for this test, so pass -1 to log this function as the caller.
-	c, _ := Caller(-1)
+	c, ok := Caller(-1)
+	assert.NoError(t, ok, "Caller should not return an error ")
 	assertFieldJSONRegEx(t, "\"caller\":{\"pc\":[0-9]+,\"file\":\".+field_test.go\",\"line\":[0-9]+}", c)
 
-	c2, _ := Caller(-1)
+	c2, ok := Caller(-1)
+	assert.NoError(t, ok, "Caller should not return an error ")
+	assertCanBeReused(t, c2)
+}
+
+func TestCallers(t *testing.T) {
+	// Caller() makes an assupmtion that it is called within zap's hook mechanism.
+	// This is not true for this test, so pass 0 to log this function as the caller.
+	c := Callers(0)
+	assertFieldJSONRegEx(t, "\"callers\":{\"0\":{\"pc\":[0-9]+,\"file\":\".+field_test.go\",\"line\":[0-9]+},", c)
+
+	c2 := Callers(0)
 	assertCanBeReused(t, c2)
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,18 @@
 hash: 8aeb29a35adb31f8b46a792ae1b304c2c55f2d10bfe0ca1a4b8ac5330e22decc
-updated: 2016-11-09T16:14:48.657534669+09:00
+updated: 2016-12-01T19:29:31.346246616-08:00
 imports:
 - name: github.com/cactus/go-statsd-client
-  version: d8eabe07bc70ff9ba6a56836cde99d1ea3d005f7
+  version: 95cb85a8d6b2d1ccfce95fa58d1ca3445779d8af
   subpackages:
   - statsd
 - name: github.com/Sirupsen/logrus
-  version: 1445b7a38228c041834afc69231b7966b9943397
+  version: 08a8a7c27e3d058a8989316a850daad1c10bf4ab
 - name: github.com/uber-common/bark
-  version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
+  version: d52ffa061726911f47fcd3d9e8b9b55f22794772
 - name: github.com/uber-go/atomic
-  version: 9e99152552a6ce13fa3b2ce4a9c4fb117cca4506
+  version: 0c9e689d64f004564b79d9a663634756df322902
 - name: golang.org/x/sys
-  version: 9a2e24c3733eddc63871eda99f253e2db29bd3b9
+  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
   subpackages:
   - unix
 testImports:
@@ -21,23 +21,23 @@ testImports:
   subpackages:
   - handlers/json
 - name: github.com/axw/gocov
-  version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b
+  version: c77561ca0c0cb1ed5d4ce4a912a75f5532566422
   subpackages:
   - gocov
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/go-kit/kit
-  version: 9f5c614cd1e70102f80b644edbc760805ebf16d5
+  version: c369f674159e02f22ca276d8503027af2bc27246
   subpackages:
   - log
 - name: github.com/go-logfmt/logfmt
-  version: d4327190ff838312623b09bfeb50d7c93c8d9c1d
+  version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
 - name: github.com/go-stack/stack
   version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
 - name: github.com/golang/lint
-  version: 3390df4df2787994aea98de825b964ac7944b817
+  version: 206c0f020eba0f7fbcfbc467a5eb808037df2ed6
   subpackages:
   - golint
 - name: github.com/kr/logfmt
@@ -45,22 +45,22 @@ testImports:
 - name: github.com/mattn/go-colorable
   version: d228849504861217f796da67fae4f6e347643f15
 - name: github.com/mattn/go-isatty
-  version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
+  version: 30a891c33c7cde7b02a981314b4228ec99380cca
 - name: github.com/mattn/goveralls
   version: a63d65fe590e2c830e60ad260cde6755ce3482a5
 - name: github.com/pborman/uuid
-  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+  version: c55201b036063326c5b1b89ccfe45a184973d073
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
+  version: 6cb3b85ef5a0efef77caef88363ec4d4b5c0976d
   subpackages:
   - assert
   - require
 - name: golang.org/x/tools
-  version: 44b4c5d044d148f4248b0188ff5ea3e57cfedbc5
+  version: e04df2157ae7263e17159baabadc99fb03fc7514
   subpackages:
   - cover
 - name: gopkg.in/inconshreveable/log15.v2

--- a/hook.go
+++ b/hook.go
@@ -37,7 +37,7 @@ var (
 //
 // Hooks implement the Option interface.
 type Hook interface {
-	hook(*Entry) error
+	Hook(*Entry) error
 }
 
 // AddCaller configures the Logger to annotate each log with
@@ -90,7 +90,7 @@ func SetCallersSkip(callerSkip int, lvl Level) Option {
 ////////////////////
 
 // Hook adds caller information as a field with "caller" key
-func (h *addCallerHook) hook(e *Entry) error {
+func (h *addCallerHook) Hook(e *Entry) error {
 	if e == nil {
 		return errHookNilEntry
 	}
@@ -120,7 +120,7 @@ type addCallerHook struct {
 ////////////////////
 
 // Hook adds callers information as a field with "callers" key
-func (h *addCallersHook) hook(e *Entry) error {
+func (h *addCallersHook) Hook(e *Entry) error {
 	if e == nil {
 		return errHookNilEntry
 	}
@@ -146,7 +146,7 @@ type addCallersHook struct {
 ////////////////////
 
 // Hook adds stack trace information as a field with "stacktrace" key
-func (h *addStacksHook) hook(e *Entry) error {
+func (h *addStacksHook) Hook(e *Entry) error {
 	if e == nil {
 		return errHookNilEntry
 	}

--- a/hook.go
+++ b/hook.go
@@ -71,9 +71,15 @@ func AddCallerWithSkip(callerSkip int) Option {
 	})
 }
 
-// AddCallersWithSkip records the caller's call stack for all messages at or above a given level.
-// The callerskip option helps select the target caller.  Using a value of _callerSkip will select
+// AddCallers records the caller's call stack for all messages at or above a given level.
+// This uses _callerSkip for the caller skip, which will select
 // the target caller as the caller of the leveled logger method.
+func AddCallers(lvl Level) Option {
+	return AddCallersWithSkip(_callersSkip, lvl)
+}
+
+// AddCallersWithSkip records the caller's call stack for all messages at or above a given level.
+// The callerskip option helps select the target caller.
 func AddCallersWithSkip(callerSkip int, lvl Level) Option {
 	return Hook(func(e *Entry) error {
 		if e == nil {

--- a/hook_test.go
+++ b/hook_test.go
@@ -118,7 +118,7 @@ func TestHooksNilEntry(t *testing.T) {
 	}
 	for _, tt := range tests {
 		assert.NotPanics(t, func() {
-			assert.Equal(t, errHookNilEntry, tt.hook.hook(nil), "Expected an error running hook %s on a nil message.", tt.name)
+			assert.Equal(t, errHookNilEntry, tt.hook.Hook(nil), "Expected an error running hook %s on a nil message.", tt.name)
 		}, "Unexpected panic running hook %s on a nil message.", tt.name)
 	}
 }

--- a/hook_test.go
+++ b/hook_test.go
@@ -56,6 +56,24 @@ func TestHookAddCallerFail(t *testing.T) {
 	assert.Contains(t, buf.String(), `"msg":"Failure."`, "Expected original message to survive failures in runtime.Caller.")
 }
 
+func TestHookAddCallers(t *testing.T) {
+	buf := &testBuffer{}
+	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), AddCallers(InfoLevel))
+
+	logger.Info("Callers.")
+	output := buf.String()
+	require.Contains(t, output, "zap/hook_test.go", "Expected to find test file in callers.")
+	assert.Contains(t, output, `"callers":`, "Callers added under an unexpected key.")
+
+	buf.Reset()
+	logger.Warn("Callers.")
+	assert.Contains(t, buf.String(), `"callers":`, "Expected to include callers at Warn level.")
+
+	buf.Reset()
+	logger.Debug("No callers.")
+	assert.NotContains(t, buf.String(), "Unexpected stacktrace at Debug level.")
+}
+
 func TestHookAddCallersWithSkip(t *testing.T) {
 	buf := &testBuffer{}
 	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), AddCallersWithSkip(_callersSkip, InfoLevel))

--- a/hook_test.go
+++ b/hook_test.go
@@ -31,18 +31,18 @@ import (
 func TestHookAddCaller(t *testing.T) {
 	buf := &testBuffer{}
 	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), AddCaller())
-	logger.Info("Callers.")
+	logger.Info("Caller.")
 
-	re := regexp.MustCompile(`"msg":"Callers\.","caller":{"pc":\d+,"file":".+hook_test.go","line":\d+}`)
+	re := regexp.MustCompile(`"msg":"Caller\.","caller":{"pc":\d+,"file":".+hook_test.go","line":\d+}`)
 	assert.Regexp(t, re, buf.Stripped(), "Expected to find package name and file name in output.")
 }
 
 func TestHookAddCallerWithSkip(t *testing.T) {
 	buf := &testBuffer{}
-	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), AddCallerWithSkip(_callerSkip))
-	logger.Info("Callers.")
+	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), AddCaller(), SetCallerSkip(_callerSkip))
+	logger.Info("Caller.")
 
-	re := regexp.MustCompile(`"msg":"Callers\.","caller":{"pc":\d+,"file":".+hook_test.go","line":\d+}`)
+	re := regexp.MustCompile(`"msg":"Caller\.","caller":{"pc":\d+,"file":".+hook_test.go","line":\d+}`)
 	assert.Regexp(t, re, buf.Stripped(), "Expected to find package name and file name in output.")
 }
 
@@ -50,7 +50,7 @@ func TestHookAddCallerFail(t *testing.T) {
 	buf := &testBuffer{}
 	errBuf := &testBuffer{}
 
-	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), ErrorOutput(errBuf), AddCallerWithSkip(1e3))
+	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), ErrorOutput(errBuf), AddCaller(), SetCallerSkip(1e3))
 	logger.Info("Failure.")
 	assert.Regexp(t, `hook error: failed to get caller`, errBuf.String(), "Didn't find expected failure message.")
 	assert.Contains(t, buf.String(), `"msg":"Failure."`, "Expected original message to survive failures in runtime.Caller.")
@@ -76,12 +76,10 @@ func TestHookAddCallers(t *testing.T) {
 
 func TestHookAddCallersWithSkip(t *testing.T) {
 	buf := &testBuffer{}
-	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), AddCallersWithSkip(_callersSkip, InfoLevel))
+	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), AddCallers(InfoLevel), SetCallersSkip(_callersSkip, WarnLevel))
 
 	logger.Info("Callers.")
-	output := buf.String()
-	require.Contains(t, output, "zap/hook_test.go", "Expected to find test file in callers.")
-	assert.Contains(t, output, `"callers":`, "Callers added under an unexpected key.")
+	assert.NotContains(t, buf.String(), "Unexpected stacktrace at Info level.")
 
 	buf.Reset()
 	logger.Warn("Callers.")
@@ -120,7 +118,7 @@ func TestHooksNilEntry(t *testing.T) {
 	}
 	for _, tt := range tests {
 		assert.NotPanics(t, func() {
-			assert.Equal(t, errHookNilEntry, tt.hook(nil), "Expected an error running hook %s on a nil message.", tt.name)
+			assert.Equal(t, errHookNilEntry, tt.hook.hook(nil), "Expected an error running hook %s on a nil message.", tt.name)
 		}, "Unexpected panic running hook %s on a nil message.", tt.name)
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -132,8 +132,8 @@ func (log *logger) log(lvl Level, msg string, fields []Field) {
 	addFields(temp, fields)
 
 	entry := newEntry(lvl, msg, temp)
-	for _, hook := range log.Hooks {
-		if err := hook(entry); err != nil {
+	for _, h := range log.Hooks {
+		if err := h.hook(entry); err != nil {
 			log.InternalError("hook", err)
 		}
 	}

--- a/logger.go
+++ b/logger.go
@@ -133,7 +133,7 @@ func (log *logger) log(lvl Level, msg string, fields []Field) {
 
 	entry := newEntry(lvl, msg, temp)
 	for _, h := range log.Hooks {
-		if err := h.hook(entry); err != nil {
+		if err := h.Hook(entry); err != nil {
 			log.InternalError("hook", err)
 		}
 	}


### PR DESCRIPTION
This PR is essentially a proposal-as-prototype-code, rather than than proposal-as-issue; how about:
- replacing `zap.Stack` with `zap.Callers`
- simplifying the `zap.AddCaller` hook to just add a `zap.Caller` field, rather than mutate msg...
- ...oh and also let the user pass a skip offset to `zap.AddCaller` so that it can get it right under logger wrappers

Other questions include:
- what if we added proper array support, rather than the hacked object? (see also #136)
- maybe we should have explicit PC(s) marshaling support in the the KeyValue interface itself...
- ...this would let the text encoder recover a more human friendly stacktrace-esque form
- ...maybe the Error field should also always (modulo an Option?) add a callers field?