### PR TITLE
WIP: Sentry logger

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,22 @@
-hash: 8aeb29a35adb31f8b46a792ae1b304c2c55f2d10bfe0ca1a4b8ac5330e22decc
-updated: 2016-11-09T16:14:48.657534669+09:00
+hash: 3028dfe3df1463fd20a19a2ac02c361ebfdaddfa4793cfa0cf75899f741282d5
+updated: 2016-11-14T11:46:53.503304274-08:00
 imports:
 - name: github.com/cactus/go-statsd-client
-  version: d8eabe07bc70ff9ba6a56836cde99d1ea3d005f7
+  version: 95cb85a8d6b2d1ccfce95fa58d1ca3445779d8af
   subpackages:
   - statsd
+- name: github.com/getsentry/raven-go
+  version: e39495fea085e98d1281fac0ff4d6eb8dc56f86d
+- name: github.com/pkg/errors
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/Sirupsen/logrus
-  version: 1445b7a38228c041834afc69231b7966b9943397
+  version: 08a8a7c27e3d058a8989316a850daad1c10bf4ab
 - name: github.com/uber-common/bark
-  version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
+  version: d52ffa061726911f47fcd3d9e8b9b55f22794772
 - name: github.com/uber-go/atomic
-  version: 9e99152552a6ce13fa3b2ce4a9c4fb117cca4506
+  version: 0c9e689d64f004564b79d9a663634756df322902
 - name: golang.org/x/sys
-  version: 9a2e24c3733eddc63871eda99f253e2db29bd3b9
+  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
   subpackages:
   - unix
 testImports:
@@ -25,7 +29,7 @@ testImports:
   subpackages:
   - gocov
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/go-kit/kit
@@ -47,20 +51,20 @@ testImports:
 - name: github.com/mattn/go-isatty
   version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
 - name: github.com/mattn/goveralls
-  version: a63d65fe590e2c830e60ad260cde6755ce3482a5
+  version: edf7508a2bcb40ec1160e94518c983c2fc169f02
 - name: github.com/pborman/uuid
-  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+  version: 3d4f2ba23642d3cfd06bd4b54cf03d99d95c0f1b
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - require
 - name: golang.org/x/tools
-  version: 44b4c5d044d148f4248b0188ff5ea3e57cfedbc5
+  version: 3fe2afc9e626f32e91aff6eddb78b14743446865
   subpackages:
   - cover
 - name: gopkg.in/inconshreveable/log15.v2

--- a/glide.lock
+++ b/glide.lock
@@ -6,7 +6,7 @@ imports:
   subpackages:
   - statsd
 - name: github.com/getsentry/raven-go
-  version: e39495fea085e98d1281fac0ff4d6eb8dc56f86d
+  version: 3f7439d3e74d88e21d196ba20eb61a5a958bc118
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/Sirupsen/logrus

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
 hash: 3028dfe3df1463fd20a19a2ac02c361ebfdaddfa4793cfa0cf75899f741282d5
-updated: 2016-11-14T11:46:53.503304274-08:00
+updated: 2016-12-01T12:49:47.876258376-08:00
 imports:
 - name: github.com/cactus/go-statsd-client
   version: 95cb85a8d6b2d1ccfce95fa58d1ca3445779d8af
   subpackages:
   - statsd
+- name: github.com/certifi/gocertifi
+  version: a61bf5eafa3aee233ec8043e9da052447e5463dd
 - name: github.com/getsentry/raven-go
   version: 3f7439d3e74d88e21d196ba20eb61a5a958bc118
 - name: github.com/pkg/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,8 @@ license: MIT
 import:
 - package: github.com/uber-common/bark
 - package: github.com/uber-go/atomic
+- package: github.com/getsentry/raven-go
+- package: github.com/pkg/errors
 testImport:
 - package: github.com/Sirupsen/logrus
 - package: github.com/apex/log
@@ -21,7 +23,6 @@ testImport:
 - package: golang.org/x/tools
   subpackages:
   - cover
-- package: golang.org/x/tools/cover
 - package: github.com/golang/lint
   subpackages:
   - golint

--- a/sentry/capturer.go
+++ b/sentry/capturer.go
@@ -22,7 +22,7 @@ package sentry
 
 import raven "github.com/getsentry/raven-go"
 
-// Capturer knows what to do with a Sentry packet
+// Capturer knows what to do with a Sentry packet.
 //
 // Allows for a variety of implementations of how to send Sentry packets.
 // For more performance sensisitve systems, it might make sense to batch
@@ -39,12 +39,12 @@ func (m *memCapturer) Capture(p *raven.Packet) {
 	m.packets = append(m.packets, p)
 }
 
-// NonBlockingCapturer does not wait for the result of Sentry packet sending
+// NonBlockingCapturer does not wait for the result of Sentry packet sending.
 type NonBlockingCapturer struct {
 	*raven.Client
 }
 
-// Capture will fire off a packet without checking the error channel
+// Capture will fire off a packet without checking the error channel.
 func (s *NonBlockingCapturer) Capture(p *raven.Packet) {
 	s.Client.Capture(p, nil)
 }

--- a/sentry/capturer.go
+++ b/sentry/capturer.go
@@ -23,28 +23,25 @@ package sentry
 import raven "github.com/getsentry/raven-go"
 
 // Capturer knows what to do with a Sentry packet.
-//
-// Allows for a variety of implementations of how to send Sentry packets.
-// For more performance sensitive systems, it might make sense to batch
-// rather than opening up a connection on each send.
 type Capturer interface {
-	Capture(p *raven.Packet)
+	Capture(p *raven.Packet) error
 }
 
 type memCapturer struct {
 	packets []*raven.Packet
 }
 
-func (m *memCapturer) Capture(p *raven.Packet) {
+func (m *memCapturer) Capture(p *raven.Packet) error {
 	m.packets = append(m.packets, p)
+	return nil
 }
 
-// NonBlockingCapturer does not wait for the result of Sentry packet sending.
-type NonBlockingCapturer struct {
+type nonBlockingCapturer struct {
 	*raven.Client
 }
 
 // Capture will fire off a packet without checking the error channel.
-func (s *NonBlockingCapturer) Capture(p *raven.Packet) {
+func (s *nonBlockingCapturer) Capture(p *raven.Packet) error {
 	s.Client.Capture(p, nil)
+	return nil
 }

--- a/sentry/capturer.go
+++ b/sentry/capturer.go
@@ -25,11 +25,14 @@ import raven "github.com/getsentry/raven-go"
 // Capturer knows what to do with a Sentry packet.
 type Capturer interface {
 	Capture(p *raven.Packet) error
+	Close()
 }
 
 type memCapturer struct {
 	packets []*raven.Packet
 }
+
+func (m *memCapturer) Close() {}
 
 func (m *memCapturer) Capture(p *raven.Packet) error {
 	m.packets = append(m.packets, p)
@@ -40,8 +43,12 @@ type nonBlockingCapturer struct {
 	*raven.Client
 }
 
+func (nb *nonBlockingCapturer) Close() {
+	nb.Client.Close()
+}
+
 // Capture will fire off a packet without checking the error channel.
-func (s *nonBlockingCapturer) Capture(p *raven.Packet) error {
-	s.Client.Capture(p, nil)
+func (nb *nonBlockingCapturer) Capture(p *raven.Packet) error {
+	nb.Client.Capture(p, nil)
 	return nil
 }

--- a/sentry/capturer.go
+++ b/sentry/capturer.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE
+
+package sentry
+
+import raven "github.com/getsentry/raven-go"
+
+// Capturer knows what to do with a Sentry packet
+//
+// Allows for a variety of implementations of how to send Sentry packets.
+// For more performance sensisitve systems, it might make sense to batch
+// rather than opening op a connection on each send.
+type Capturer interface {
+	Capture(p *raven.Packet)
+}
+
+type memCapturer struct {
+	packets []*raven.Packet
+}
+
+func (m *memCapturer) Capture(p *raven.Packet) {
+	m.packets = append(m.packets, p)
+}
+
+// NonBlockingCapturer does not wait for the result of Sentry packet sending
+type NonBlockingCapturer struct {
+	*raven.Client
+}
+
+// Capture will fire off a packet without checking the error channel
+func (s *NonBlockingCapturer) Capture(p *raven.Packet) {
+	s.Client.Capture(p, nil)
+}

--- a/sentry/capturer.go
+++ b/sentry/capturer.go
@@ -25,8 +25,8 @@ import raven "github.com/getsentry/raven-go"
 // Capturer knows what to do with a Sentry packet.
 //
 // Allows for a variety of implementations of how to send Sentry packets.
-// For more performance sensisitve systems, it might make sense to batch
-// rather than opening op a connection on each send.
+// For more performance sensitive systems, it might make sense to batch
+// rather than opening up a connection on each send.
 type Capturer interface {
 	Capture(p *raven.Packet)
 }

--- a/sentry/doc.go
+++ b/sentry/doc.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package sentry provides a logger which will automatically send events to sentry
+// over a certain set threshold
+package sentry

--- a/sentry/doc.go
+++ b/sentry/doc.go
@@ -18,6 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package sentry provides a logger which will automatically send events to sentry
-// over a certain set threshold
+// Package sentry provides a logger which will automatically send events
+// to sentry over a certain log level threshold.
 package sentry

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -81,24 +81,14 @@ func New(dsn string, options ...Option) (*Logger, error) {
 		option(l)
 	}
 
-	// Default to live sentry packet capturer
-	if l.Capturer == nil {
-		client, err := raven.New(dsn)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to create sentry client")
-		}
-
-		l.Capturer = &NonBlockingCapturer{Client: client}
+	client, err := raven.New(dsn)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create sentry client")
 	}
+
+	l.Capturer = &nonBlockingCapturer{Client: client}
 
 	return l, nil
-}
-
-// WithCapturer allows to specify which packet capturer should be used.
-func WithCapturer(c Capturer) Option {
-	return func(l *Logger) {
-		l.Capturer = c
-	}
 }
 
 // MinLevel provides a minimum level threshold, above which Sentry packtes will be triggered

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -24,10 +24,11 @@ import (
 	"os"
 	"time"
 
-	raven "github.com/getsentry/raven-go"
-	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
 	"github.com/uber-go/zap/zwrap"
+
+	raven "github.com/getsentry/raven-go"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -98,7 +98,7 @@ func WithCapturer(c Capturer) Option {
 	}
 }
 
-// MinLevel provides a slice of levels for which sentry packaet should be sent.
+// MinLevel provides a minimum level threshold, above which Sentry packtes will be triggered
 func MinLevel(level zap.Level) Option {
 	return func(l *Logger) {
 		l.minLevel = level

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -30,18 +30,20 @@ import (
 	"github.com/uber-go/zap/zwrap"
 )
 
-var (
+const (
 	_platform          = "go"
 	_traceContextLines = 3
 	_traceSkipFrames   = 3
-	_zapToRavenMap     = map[zap.Level]raven.Severity{
-		zap.InfoLevel:  raven.INFO,
-		zap.WarnLevel:  raven.WARNING,
-		zap.ErrorLevel: raven.ERROR,
-		zap.PanicLevel: raven.ERROR,
-		zap.FatalLevel: raven.FATAL,
-	}
 )
+
+var _zapToRavenMap = map[zap.Level]raven.Severity{
+	zap.DebugLevel: raven.INFO,
+	zap.InfoLevel:  raven.INFO,
+	zap.WarnLevel:  raven.WARNING,
+	zap.ErrorLevel: raven.ERROR,
+	zap.PanicLevel: raven.FATAL,
+	zap.FatalLevel: raven.FATAL,
+}
 
 // Logger automatically sends logs above a certain threshold to Sentry.
 type Logger struct {

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -53,7 +53,7 @@ type Logger struct {
 	// Minimum level threshold for sending a Sentry event
 	minLevel zap.Level
 
-	// Cotrols if stack trace should be automatically generated, and how many frames to skip
+	// Controls if stack trace should be automatically generated, and how many frames to skip
 	traceEnabled      bool
 	traceSkipFrames   int
 	traceContextLines int
@@ -172,7 +172,7 @@ func (l *Logger) DFatal(msg string, fields ...zap.Field) {}
 
 // With returns Sentry logger with additional context.
 func (l *Logger) With(fields ...zap.Field) zap.Logger {
-	// Consider pre-allocing the whole new resulting map, but that may be even more expensive
+	// Consider pre-allocating the whole new resulting map, but that may be even more expensive
 	for _, f := range fields {
 		f.AddTo(l.extra)
 	}

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -43,7 +43,7 @@ var (
 	}
 )
 
-// Logger automatically sends logs above a certain threshold to Sentry
+// Logger automatically sends logs above a certain threshold to Sentry.
 type Logger struct {
 	zap.Meta
 	Capturer
@@ -61,10 +61,10 @@ type Logger struct {
 	extra zwrap.KeyValueMap
 }
 
-// Option pattern for logger creation
+// Option pattern for logger creation.
 type Option func(l *Logger)
 
-// New Sentry logger
+// New Sentry logger.
 func New(dsn string, options ...Option) (*Logger, error) {
 	l := &Logger{
 		minLevel:          zap.ErrorLevel,
@@ -91,31 +91,31 @@ func New(dsn string, options ...Option) (*Logger, error) {
 	return l, nil
 }
 
-// WithCapturer allows to specify which packet capturer should be used
-func WithCapturer(c Capturer) func(l *Logger) {
+// WithCapturer allows to specify which packet capturer should be used.
+func WithCapturer(c Capturer) Option {
 	return func(l *Logger) {
 		l.Capturer = c
 	}
 }
 
-// WithMinLevel provides a slice of levels for which sentry packaet should be sent
-func WithMinLevel(level zap.Level) func(l *Logger) {
+// MinLevel provides a slice of levels for which sentry packaet should be sent.
+func MinLevel(level zap.Level) Option {
 	return func(l *Logger) {
 		l.minLevel = level
 	}
 }
 
-// WithTraceEnabled allows to change wether (the somewhat expensive) stack trace generation
-// takes place
-func WithTraceEnabled(enabled bool) func(l *Logger) {
+// TraceEnabled allows to change wether (the somewhat expensive, relatively)
+// stack trace generation takes place.
+func TraceEnabled(enabled bool) Option {
 	return func(l *Logger) {
 		l.traceEnabled = enabled
 	}
 }
 
-// WithTraceCfg allows to change the number of skipped frames, number of context lines and
-// list of go prefixes that are considered "in-app", i.e. "github.com/uber-go/zap"
-func WithTraceCfg(skip, context int, prefixes []string) func(l *Logger) {
+// TraceCfg allows to change the number of skipped frames, number of context lines and
+// list of go prefixes that are considered "in-app", i.e. "github.com/uber-go/zap".
+func TraceCfg(skip, context int, prefixes []string) Option {
 	return func(l *Logger) {
 		l.traceSkipFrames = skip
 		l.traceContextLines = context
@@ -123,50 +123,50 @@ func WithTraceCfg(skip, context int, prefixes []string) func(l *Logger) {
 	}
 }
 
-// WithExtra stores additional information for each Sentry event
-func WithExtra(extra map[string]interface{}) func(l *Logger) {
+// Extra stores additional information for each Sentry event.
+func Extra(extra map[string]interface{}) Option {
 	return func(l *Logger) {
 		l.extra = extra
 	}
 }
 
-// Log sends Sentry information provided minimum threshold is met
+// Log sends Sentry information provided minimum threshold is met.
 func (l *Logger) Log(lvl zap.Level, msg string, fields ...zap.Field) {
 	l.log(lvl, msg, fields)
 }
 
-// Debug is a nop
+// Debug is a nop.
 func (l *Logger) Debug(msg string, fields ...zap.Field) {}
 
-// Info sends Sentry information provided minimum threshold is met
+// Info sends Sentry information provided minimum threshold is met.
 func (l *Logger) Info(msg string, fields ...zap.Field) {
 	l.log(zap.InfoLevel, msg, fields)
 }
 
-// Warn sends Sentry information provided minimum threshold is met
+// Warn sends Sentry information provided minimum threshold is met.
 func (l *Logger) Warn(msg string, fields ...zap.Field) {
 	l.log(zap.WarnLevel, msg, fields)
 }
 
-// Error sends Sentry information provided minimum threshold is met
+// Error sends Sentry information provided minimum threshold is met.
 func (l *Logger) Error(msg string, fields ...zap.Field) {
 	l.log(zap.ErrorLevel, msg, fields)
 }
 
-// Panic sends Sentry information provided minimum threshold is met
+// Panic sends Sentry information provided minimum threshold is met.
 func (l *Logger) Panic(msg string, fields ...zap.Field) {
 	l.log(zap.PanicLevel, msg, fields)
 }
 
-// Fatal sends Sentry information provided minimum threshold is met
+// Fatal sends Sentry information provided minimum threshold is met.
 func (l *Logger) Fatal(msg string, fields ...zap.Field) {
 	l.log(zap.FatalLevel, msg, fields)
 }
 
-// DFatal is a nop
+// DFatal is a nop.
 func (l *Logger) DFatal(msg string, fields ...zap.Field) {}
 
-// With returns Sentry logger with additional context
+// With returns Sentry logger with additional context.
 func (l *Logger) With(fields ...zap.Field) zap.Logger {
 	// Consider pre-allocing the whole new resulting map, but that may be even more expensive
 	for _, f := range fields {
@@ -175,7 +175,7 @@ func (l *Logger) With(fields ...zap.Field) zap.Logger {
 	return l
 }
 
-// Notify sentry if the log level meets minimum threshold
+// Notify sentry if the log level meets minimum threshold.
 func (l *Logger) log(lvl zap.Level, msg string, fields []zap.Field) {
 	if lvl >= l.minLevel {
 		// append all the fields from the current log message to the stored ones
@@ -203,7 +203,7 @@ func (l *Logger) log(lvl zap.Level, msg string, fields []zap.Field) {
 	}
 }
 
-// Check returns a CheckedMessage logging the given message is Enabled, nil otherwise
+// Check returns a CheckedMessage logging the given message is Enabled, nil otherwise.
 func (l *Logger) Check(lvl zap.Level, msg string) *zap.CheckedMessage {
 	if lvl >= l.minLevel {
 		return zap.NewCheckedMessage(l, lvl, msg)

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sentry
+
+import (
+	"time"
+
+	raven "github.com/getsentry/raven-go"
+	"github.com/pkg/errors"
+	"github.com/uber-go/zap"
+	"github.com/uber-go/zap/zwrap"
+)
+
+var (
+	_platform          = "go"
+	_traceContextLines = 3
+	_traceSkipFrames   = 3
+	_zapToRavenMap     = map[zap.Level]raven.Severity{
+		zap.DebugLevel: raven.DEBUG,
+		zap.InfoLevel:  raven.INFO,
+		zap.WarnLevel:  raven.WARNING,
+		zap.ErrorLevel: raven.ERROR,
+		zap.PanicLevel: raven.ERROR,
+		zap.FatalLevel: raven.FATAL,
+	}
+)
+
+// Logger automatically sends logs above a certain threshold to Sentry
+type Logger struct {
+	zap.Meta
+	Capturer
+
+	// Minimum level threshold for sending a Sentry event
+	minLevel zap.Level
+
+	// Cotrols if stack trace should be automatically generated, and how many frames to skip
+	traceEnabled      bool
+	traceSkipFrames   int
+	traceContextLines int
+	traceAppPrefixes  []string
+
+	// Additional information that should be attached to each packet, i.e. customerUUID
+	extra zwrap.KeyValueMap
+}
+
+// Option pattern for logger creation
+type Option func(l *Logger)
+
+// New Sentry logger
+func New(dsn string, options ...Option) (*Logger, error) {
+	l := &Logger{
+		minLevel:          zap.ErrorLevel,
+		traceEnabled:      true,
+		traceSkipFrames:   _traceSkipFrames,
+		traceContextLines: _traceContextLines,
+		extra:             zwrap.KeyValueMap{},
+	}
+
+	for _, option := range options {
+		option(l)
+	}
+
+	// Default to live sentry packet capturer
+	if l.Capturer == nil {
+		client, err := raven.New(dsn)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create sentry client")
+		}
+
+		l.Capturer = &NonBlockingCapturer{Client: client}
+	}
+
+	return l, nil
+}
+
+// WithCapturer allows to specify which packet capturer should be used
+func WithCapturer(c Capturer) func(l *Logger) {
+	return func(l *Logger) {
+		l.Capturer = c
+	}
+}
+
+// WithMinLevel provides a slice of levels for which sentry packaet should be sent
+func WithMinLevel(level zap.Level) func(l *Logger) {
+	return func(l *Logger) {
+		l.minLevel = level
+	}
+}
+
+// WithTraceEnabled allows to change wether (the somewhat expensive) stack trace generation
+// takes place
+func WithTraceEnabled(enabled bool) func(l *Logger) {
+	return func(l *Logger) {
+		l.traceEnabled = enabled
+	}
+}
+
+// WithTraceCfg allows to change the number of skipped frames, number of context lines and
+// list of go prefixes that are considered "in-app", i.e. "github.com/uber-go/zap"
+func WithTraceCfg(skip, context int, prefixes []string) func(l *Logger) {
+	return func(l *Logger) {
+		l.traceSkipFrames = skip
+		l.traceContextLines = context
+		l.traceAppPrefixes = prefixes
+	}
+}
+
+// WithExtra stores additional information for each Sentry event
+func WithExtra(extra map[string]interface{}) func(l *Logger) {
+	return func(l *Logger) {
+		l.extra = extra
+	}
+}
+
+// Log sends Sentry information provided minimum threshold is met
+func (l *Logger) Log(lvl zap.Level, msg string, fields ...zap.Field) {
+	l.log(lvl, msg, fields)
+}
+
+// Debug is a nop
+func (l *Logger) Debug(msg string, fields ...zap.Field) {}
+
+// Info sends Sentry information provided minimum threshold is met
+func (l *Logger) Info(msg string, fields ...zap.Field) {
+	l.log(zap.InfoLevel, msg, fields)
+}
+
+// Warn sends Sentry information provided minimum threshold is met
+func (l *Logger) Warn(msg string, fields ...zap.Field) {
+	l.log(zap.WarnLevel, msg, fields)
+}
+
+// Error sends Sentry information provided minimum threshold is met
+func (l *Logger) Error(msg string, fields ...zap.Field) {
+	l.log(zap.ErrorLevel, msg, fields)
+}
+
+// Panic sends Sentry information provided minimum threshold is met
+func (l *Logger) Panic(msg string, fields ...zap.Field) {
+	l.log(zap.PanicLevel, msg, fields)
+}
+
+// Fatal sends Sentry information provided minimum threshold is met
+func (l *Logger) Fatal(msg string, fields ...zap.Field) {
+	l.log(zap.FatalLevel, msg, fields)
+}
+
+// DFatal is a nop
+func (l *Logger) DFatal(msg string, fields ...zap.Field) {}
+
+// With returns Sentry logger with additional context
+func (l *Logger) With(fields ...zap.Field) zap.Logger {
+	// Consider pre-allocing the whole new resulting map, but that may be even more expensive
+	for _, f := range fields {
+		f.AddTo(l.extra)
+	}
+	return l
+}
+
+// Notify sentry if the log level meets minimum threshold
+func (l *Logger) log(lvl zap.Level, msg string, fields []zap.Field) {
+	if lvl >= l.minLevel {
+		// append all the fields from the current log message to the stored ones
+		extra := l.extra
+		for _, f := range fields {
+			f.AddTo(extra)
+		}
+
+		packet := &raven.Packet{
+			Message:   msg,
+			Timestamp: raven.Timestamp(time.Now()),
+			Level:     _zapToRavenMap[lvl],
+			Platform:  _platform,
+			Extra:     extra,
+		}
+
+		if l.traceEnabled {
+			trace := raven.NewStacktrace(l.traceSkipFrames, l.traceContextLines, l.traceAppPrefixes)
+			if trace != nil {
+				packet.Interfaces = append(packet.Interfaces, trace)
+			}
+		}
+
+		l.Capture(packet)
+	}
+}
+
+// Check returns a CheckedMessage logging the given message is Enabled, nil otherwise
+func (l *Logger) Check(lvl zap.Level, msg string) *zap.CheckedMessage {
+	if lvl >= l.minLevel {
+		return zap.NewCheckedMessage(l, lvl, msg)
+	}
+	return nil
+}

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -21,6 +21,7 @@
 package sentry
 
 import (
+	"os"
 	"time"
 
 	raven "github.com/getsentry/raven-go"
@@ -153,14 +154,16 @@ func (l *Logger) Error(msg string, fields ...zap.Field) {
 	l.log(zap.ErrorLevel, msg, fields)
 }
 
-// Panic sends Sentry information provided minimum threshold is met.
+// Panic sends Sentry information provided minimum threshold is met, then panics.
 func (l *Logger) Panic(msg string, fields ...zap.Field) {
 	l.log(zap.PanicLevel, msg, fields)
+	panic(msg)
 }
 
-// Fatal sends Sentry information provided minimum threshold is met.
+// Fatal sends Sentry information provided minimum threshold is met, then exits.
 func (l *Logger) Fatal(msg string, fields ...zap.Field) {
 	l.log(zap.FatalLevel, msg, fields)
+	os.Exit(1)
 }
 
 // DFatal is a nop.

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -35,7 +35,6 @@ var (
 	_traceContextLines = 3
 	_traceSkipFrames   = 3
 	_zapToRavenMap     = map[zap.Level]raven.Severity{
-		zap.DebugLevel: raven.DEBUG,
 		zap.InfoLevel:  raven.INFO,
 		zap.WarnLevel:  raven.WARNING,
 		zap.ErrorLevel: raven.ERROR,

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -34,7 +34,7 @@ import (
 const (
 	_platform          = "go"
 	_traceContextLines = 3
-	_traceSkipFrames   = 3
+	_traceSkipFrames   = 2
 )
 
 var _zapToRavenMap = map[zap.Level]raven.Severity{
@@ -91,27 +91,41 @@ func New(dsn string, options ...Option) (*Logger, error) {
 	return l, nil
 }
 
-// MinLevel provides a minimum level threshold, above which Sentry packets will be triggered
+// MinLevel provides a minimum level threshold.
+// All log messages above the set level are sent to Sentry.
 func MinLevel(level zap.Level) Option {
 	return func(l *Logger) {
 		l.minLevel = level
 	}
 }
 
-// DisableTraces allows to turn off Stacktrace for sentry packets
+// DisableTraces allows to turn off Stacktrace for sentry packets.
 func DisableTraces() Option {
 	return func(l *Logger) {
 		l.traceEnabled = false
 	}
 }
 
-// TraceCfg allows to change the number of skipped frames, number of context lines and
-// list of go prefixes that are considered "in-app", i.e. "github.com/uber-go/zap".
-func TraceCfg(skip, context int, prefixes []string) Option {
+// TraceContextLines sets how many lines of code (in on direction) are sent
+// with the Sentry packet.
+func TraceContextLines(lines int) Option {
+	return func(l *Logger) {
+		l.traceContextLines = lines
+	}
+}
+
+// TraceAppPrefixes sets a list of go import prefixes that are considered "in app".
+func TraceAppPrefixes(prefixes []string) Option {
+	return func(l *Logger) {
+		l.traceAppPrefixes = prefixes
+	}
+}
+
+// TraceSkipFrames sets how many stacktrace frames to skip when sending a
+// sentry packet. This is very useful when helper functions are involved.
+func TraceSkipFrames(skip int) Option {
 	return func(l *Logger) {
 		l.traceSkipFrames = skip
-		l.traceContextLines = context
-		l.traceAppPrefixes = prefixes
 	}
 }
 

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -160,13 +160,12 @@ func (l *Logger) Fatal(msg string, fields ...zap.Field) {
 	os.Exit(1)
 }
 
-// DFatal either Fatals in development or Errors in production, as well as sending a packet.
-func (l *Logger) DFatal(msg string, fields ...zap.Field) {
+// DPanic logs the message and then panics if in development mode
+func (l *Logger) DPanic(msg string, fields ...zap.Field) {
+	l.log(zap.DPanicLevel, msg, fields)
 	if l.Development {
-		l.Fatal(msg, fields...)
-		return
+		panic(msg)
 	}
-	l.Error(msg, fields...)
 }
 
 // With returns Sentry logger with additional context.

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -98,11 +98,10 @@ func MinLevel(level zap.Level) Option {
 	}
 }
 
-// TraceEnabled allows to change wether (the somewhat expensive, relatively)
-// stack trace generation takes place.
-func TraceEnabled(enabled bool) Option {
+// DisableTraces allows to turn off Stacktrace for sentry packets
+func DisableTraces() Option {
 	return func(l *Logger) {
-		l.traceEnabled = enabled
+		l.traceEnabled = false
 	}
 }
 

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -91,7 +91,7 @@ func New(dsn string, options ...Option) (*Logger, error) {
 	return l, nil
 }
 
-// MinLevel provides a minimum level threshold, above which Sentry packtes will be triggered
+// MinLevel provides a minimum level threshold, above which Sentry packets will be triggered
 func MinLevel(level zap.Level) Option {
 	return func(l *Logger) {
 		l.minLevel = level

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -35,7 +35,7 @@ type fakeClient raven.Client
 func TestBadDSN(t *testing.T) {
 	_, err := New("123http://whoops")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "dsn missing public", "failed to create sentry client")
+	assert.Contains(t, err.Error(), "failed to create sentry client")
 }
 
 func TestEmptyDSN(t *testing.T) {

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -73,6 +73,16 @@ func TestWith(t *testing.T) {
 	assert.Equal(t, l.extra, expected)
 }
 
+func TestWithDoesNotMutate(t *testing.T) {
+	l1, err := New("", Extra(map[string]interface{}{
+		"someInt": 123,
+	}))
+	assert.NoError(t, err)
+
+	var _ = l1.With(zap.Float64("someFloat", float64(10))).(*Logger)
+	assert.Equal(t, zwrap.KeyValueMap{"someInt": 123}, l1.extra)
+}
+
 func TestWithTraceDisabled(t *testing.T) {
 	_, ps := capturePackets(func(l *Logger) {
 		l.Error("some error message", zap.String("foo", "bar"))

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -94,15 +94,13 @@ func TestTraceCfg(t *testing.T) {
 
 func TestLevels(t *testing.T) {
 	_, ps := capturePackets(func(l *Logger) {
-		l.Log(zap.ErrorLevel, "direct call with error")
+		l.Log(zap.DebugLevel, "direct call at Debug level")
 		l.Info("info")
 		l.Warn("warn")
 		l.Error("error")
-		l.Panic("panic")
-		l.Fatal("fatal")
-	}, MinLevel(zap.FatalLevel))
+	}, MinLevel(zap.WarnLevel))
 
-	assert.Equal(t, len(ps), 1, "Only the fatal packet should be present")
+	assert.Equal(t, len(ps), 2, "only Warn and Error packets should be collected")
 }
 
 func TestMeta(t *testing.T) {

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -132,13 +132,13 @@ func capturePacket(f func(l *Logger), options ...Option) (*Logger, *raven.Packet
 }
 
 func capturePackets(f func(l *Logger), options ...Option) (*Logger, []*raven.Packet) {
-	c := &memCapturer{}
-	options = append(options, WithCapturer(c))
-
 	l, err := New("", options...)
 	if err != nil {
 		panic("Failed to create the logger")
 	}
+
+	c := &memCapturer{}
+	l.Capturer = c
 
 	f(l)
 

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sentry
+
+import (
+	"testing"
+
+	"github.com/uber-go/zap"
+	"github.com/uber-go/zap/zwrap"
+
+	raven "github.com/getsentry/raven-go"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeClient raven.Client
+
+func TestBadDSN(t *testing.T) {
+	_, err := New("123http://whoops")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dsn missing public", "failed to create sentry client")
+}
+
+func TestEmptyDSN(t *testing.T) {
+	l, err := New("")
+	assert.NoError(t, err)
+	assert.NotNil(t, l)
+}
+
+func TestWithLevels(t *testing.T) {
+	l, err := New("", WithMinLevel(zap.InfoLevel))
+	assert.NoError(t, err)
+	assert.NotNil(t, l)
+	assert.Equal(t, l.minLevel, zap.InfoLevel)
+}
+
+func TestExtra(t *testing.T) {
+	extra := zwrap.KeyValueMap{
+		"requestID":         "123h2eor2039423",
+		"someInt":           123,
+		"arrayOfManyThings": []int{1, 2, 3},
+	}
+	l, err := New("", WithExtra(extra))
+	l.Error("error log")
+	assert.NoError(t, err)
+	assert.Equal(t, l.extra, extra)
+}
+
+func TestWith(t *testing.T) {
+	l, err := New("", WithExtra(map[string]interface{}{
+		"someInt": 123,
+	}))
+	expected := zwrap.KeyValueMap{"someInt": 123, "someFloat": float64(10)}
+	l = l.With(zap.Float64("someFloat", float64(10))).(*Logger)
+	assert.NoError(t, err)
+	assert.Equal(t, l.extra, expected)
+}
+
+func TestWithTraceDisabled(t *testing.T) {
+	_, ps := capturePackets(func(l *Logger) {
+		l.Error("some error message", zap.String("foo", "bar"))
+		l.Error("another error message")
+	}, WithTraceEnabled(false))
+
+	for _, p := range ps {
+		assert.Empty(t, p.Interfaces)
+	}
+}
+
+func TestTraceCfg(t *testing.T) {
+	l, err := New("", WithTraceCfg(1, 7, []string{"github.com/uber-go/unicorns"}))
+	assert.NoError(t, err)
+	assert.Equal(t, l.traceSkipFrames, 1)
+	assert.Equal(t, l.traceContextLines, 7)
+	assert.Equal(t, l.traceAppPrefixes, []string{"github.com/uber-go/unicorns"})
+}
+
+func TestLevels(t *testing.T) {
+	_, ps := capturePackets(func(l *Logger) {
+		l.Log(zap.ErrorLevel, "direct call with error")
+		l.Info("info")
+		l.Warn("warn")
+		l.Error("error")
+		l.Panic("panic")
+		l.Fatal("fatal")
+	}, WithMinLevel(zap.FatalLevel))
+
+	assert.Equal(t, len(ps), 1, "Only the fatal packet should be present")
+}
+
+func TestMeta(t *testing.T) {
+	l, _ := New("")
+	assert.Nil(t, l.Check(zap.InfoLevel, "info log"))
+
+	c := l.Check(zap.ErrorLevel, "error message")
+	assert.NotNil(t, c)
+}
+
+func TestErrorCapture(t *testing.T) {
+	_, p := capturePacket(func(l *Logger) {
+		l.Error("some error message", zap.String("foo", "bar"))
+	})
+
+	assert.Equal(t, p.Message, "some error message")
+	assert.Equal(t, p.Extra, map[string]interface{}{"foo": "bar"})
+
+	trace := p.Interfaces[0].(*raven.Stacktrace)
+	assert.NotNil(t, trace.Frames)
+}
+
+func capturePacket(f func(l *Logger), options ...Option) (*Logger, *raven.Packet) {
+	l, ps := capturePackets(f, options...)
+	if len(ps) != 1 {
+		panic("Expected to capture a packet, but didn't")
+	}
+	return l, ps[0]
+}
+
+func capturePackets(f func(l *Logger), options ...Option) (*Logger, []*raven.Packet) {
+	c := &memCapturer{}
+	options = append(options, WithCapturer(c))
+
+	l, err := New("", options...)
+	if err != nil {
+		panic("Failed to create the logger")
+	}
+
+	f(l)
+
+	return l, c.packets
+}

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -58,7 +58,7 @@ func TestExtra(t *testing.T) {
 		"arrayOfManyThings": []int{1, 2, 3},
 	}
 	l, err := New("", Extra(extra))
-	l.Error("error log")
+	l.Error("error log", zap.String("foo", "bar"))
 	assert.NoError(t, err)
 	assert.Equal(t, l.extra, extra)
 }

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -45,7 +45,7 @@ func TestEmptyDSN(t *testing.T) {
 }
 
 func TestWithLevels(t *testing.T) {
-	l, err := New("", WithMinLevel(zap.InfoLevel))
+	l, err := New("", MinLevel(zap.InfoLevel))
 	assert.NoError(t, err)
 	assert.NotNil(t, l)
 	assert.Equal(t, l.minLevel, zap.InfoLevel)
@@ -57,14 +57,14 @@ func TestExtra(t *testing.T) {
 		"someInt":           123,
 		"arrayOfManyThings": []int{1, 2, 3},
 	}
-	l, err := New("", WithExtra(extra))
+	l, err := New("", Extra(extra))
 	l.Error("error log")
 	assert.NoError(t, err)
 	assert.Equal(t, l.extra, extra)
 }
 
 func TestWith(t *testing.T) {
-	l, err := New("", WithExtra(map[string]interface{}{
+	l, err := New("", Extra(map[string]interface{}{
 		"someInt": 123,
 	}))
 	expected := zwrap.KeyValueMap{"someInt": 123, "someFloat": float64(10)}
@@ -77,7 +77,7 @@ func TestWithTraceDisabled(t *testing.T) {
 	_, ps := capturePackets(func(l *Logger) {
 		l.Error("some error message", zap.String("foo", "bar"))
 		l.Error("another error message")
-	}, WithTraceEnabled(false))
+	}, TraceEnabled(false))
 
 	for _, p := range ps {
 		assert.Empty(t, p.Interfaces)
@@ -85,7 +85,7 @@ func TestWithTraceDisabled(t *testing.T) {
 }
 
 func TestTraceCfg(t *testing.T) {
-	l, err := New("", WithTraceCfg(1, 7, []string{"github.com/uber-go/unicorns"}))
+	l, err := New("", TraceCfg(1, 7, []string{"github.com/uber-go/unicorns"}))
 	assert.NoError(t, err)
 	assert.Equal(t, l.traceSkipFrames, 1)
 	assert.Equal(t, l.traceContextLines, 7)
@@ -100,7 +100,7 @@ func TestLevels(t *testing.T) {
 		l.Error("error")
 		l.Panic("panic")
 		l.Fatal("fatal")
-	}, WithMinLevel(zap.FatalLevel))
+	}, MinLevel(zap.FatalLevel))
 
 	assert.Equal(t, len(ps), 1, "Only the fatal packet should be present")
 }

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -103,16 +103,34 @@ func TestWithTraceDisabled(t *testing.T) {
 }
 
 func TestTraceCfg(t *testing.T) {
-	l, err := New("", TraceCfg(1, 7, []string{"github.com/uber-go/unicorns"}))
+	l, err := New(
+		"",
+		TraceSkipFrames(1),
+		TraceContextLines(7),
+		TraceAppPrefixes([]string{"github.com/uber-go/unicorns"}),
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, l.traceSkipFrames, 1)
 	assert.Equal(t, l.traceContextLines, 7)
 	assert.Equal(t, l.traceAppPrefixes, []string{"github.com/uber-go/unicorns"})
 }
 
+func TestPanics(t *testing.T) {
+	l, _ := New("")
+	l.Development = true
+
+	assert.Panics(t, func() {
+		l.Panic("ERMYGAWD")
+	})
+	assert.Panics(t, func() {
+		l.DPanic("ERMYGAWD in Development")
+	})
+}
+
 func TestLevels(t *testing.T) {
 	_, ps := capturePackets(func(l *Logger) {
 		l.Log(zap.DebugLevel, "direct call at Debug level")
+		l.Debug("debug")
 		l.Info("info")
 		l.Warn("warn")
 		l.Error("error")

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -142,7 +142,7 @@ func TestErrorCapture(t *testing.T) {
 }
 
 func TestPacketSending(t *testing.T) {
-	withTestSentry(t, func(dsn string, ch <-chan *raven.Packet) {
+	withTestSentry(func(dsn string, ch <-chan *raven.Packet) {
 		sl, err := New(dsn)
 		defer sl.Close()
 
@@ -180,7 +180,7 @@ func capturePackets(f func(l *Logger), options ...Option) (*Logger, []*raven.Pac
 	return l, c.packets
 }
 
-func withTestSentry(t *testing.T, f func(string, <-chan *raven.Packet)) {
+func withTestSentry(f func(string, <-chan *raven.Packet)) {
 	ch := make(chan *raven.Packet)
 	h := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		defer req.Body.Close()
@@ -198,7 +198,7 @@ func withTestSentry(t *testing.T, f func(string, <-chan *raven.Packet)) {
 		err := d.Decode(p)
 		if err != nil {
 			ch <- nil
-			t.Fatal(err.Error())
+			panic(err.Error())
 		}
 		ch <- p
 	})

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -95,7 +95,7 @@ func TestWithTraceDisabled(t *testing.T) {
 	_, ps := capturePackets(func(l *Logger) {
 		l.Error("some error message", zap.String("foo", "bar"))
 		l.Error("another error message")
-	}, TraceEnabled(false))
+	}, DisableTraces())
 
 	for _, p := range ps {
 		assert.Empty(t, p.Interfaces)


### PR DESCRIPTION
This Sentry Logger can be used in combination with the forthcoming TeeLogger to easily report errors, or other types of logs as well, to Sentry.

It is written in a separate package `zap/sentry`, so the users of zap do not inherit a transitive dependence, but I think that quite a few if the current users might be interested in this Sentry integration.

It allows for somewhat flexible setup about how and when to send sentry packets through `Capturer` interface. Provided with it are two examples: memory one used for testing and a non-blocking one (without checking the outcome of the packet send). If speed is no main concern, another `BlockingCapturer` could be added in the future that will wait on the outcome of the packet send.

TODO: Benchmark?