### PR TITLE
Add SugaredLogger

### DIFF
--- a/benchmarks/zap_sugar_bench_test.go
+++ b/benchmarks/zap_sugar_bench_test.go
@@ -99,7 +99,7 @@ func BenchmarkZapSugarAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapSugarWithAccumulatedContext(b *testing.B) {
-	logger, _ := newSugarLogger().With(fakeSugarFields()...)
+	logger := newSugarLogger().With(fakeSugarFields()...)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/benchmarks/zap_sugar_bench_test.go
+++ b/benchmarks/zap_sugar_bench_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmarks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/uber-go/zap"
+	"github.com/uber-go/zap/zwrap"
+)
+
+func fakeSugarFields() []interface{} {
+	return []interface{}{
+		errExample,
+		"int", 1,
+		"int64", 2,
+		"float", 3.0,
+		"string", "four!",
+		"stringer", zap.DebugLevel,
+		"bool", true,
+		"time", time.Unix(0, 0),
+		"duration", time.Second,
+		"another string", "done!",
+	}
+}
+
+func BenchmarkZapSugarDisabledLevelsWithoutFields(b *testing.B) {
+	logger := zap.NewSugar(zap.New(zap.NewJSONEncoder(), zap.ErrorLevel, zap.DiscardOutput))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Should be discarded.")
+		}
+	})
+}
+
+func BenchmarkZapSugarDisabledLevelsAccumulatedContext(b *testing.B) {
+	context := fakeFields()
+	logger := zap.NewSugar(zap.New(
+		zap.NewJSONEncoder(),
+		zap.ErrorLevel,
+		zap.DiscardOutput,
+		zap.Fields(context...),
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Should be discarded.")
+		}
+	})
+}
+
+func BenchmarkZapSugarDisabledLevelsAddingFields(b *testing.B) {
+	logger := zap.NewSugar(zap.New(
+		zap.NewJSONEncoder(),
+		zap.ErrorLevel,
+		zap.DiscardOutput,
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Should be discarded.", fakeSugarFields()...)
+		}
+	})
+}
+
+func BenchmarkZapSugarAddingFields(b *testing.B) {
+	logger := zap.NewSugar(zap.New(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.DiscardOutput,
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go fast.", fakeSugarFields()...)
+		}
+	})
+}
+
+func BenchmarkZapSugarWithAccumulatedContext(b *testing.B) {
+	logger, _ := zap.NewSugar(zap.New(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.DiscardOutput,
+	)).With(fakeSugarFields()...)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go really fast.")
+		}
+	})
+}
+
+func BenchmarkZapSugarWithoutFields(b *testing.B) {
+	logger := zap.New(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.DiscardOutput,
+	)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go fast.")
+		}
+	})
+}
+
+func BenchmarkZapSugarSampleWithoutFields(b *testing.B) {
+	messages := fakeMessages(1000)
+	base := zap.New(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.DiscardOutput,
+	)
+	logger := zap.NewSugar(zwrap.Sample(base, time.Second, 10, 10000))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			i++
+			logger.Info(messages[i%1000])
+		}
+	})
+}
+
+func BenchmarkZapSugarSampleAddingFields(b *testing.B) {
+	messages := fakeMessages(1000)
+	base := zap.New(
+		zap.NewJSONEncoder(),
+		zap.DebugLevel,
+		zap.DiscardOutput,
+	)
+	logger := zap.NewSugar(zwrap.Sample(base, time.Second, 10, 10000))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			i++
+			logger.Info(messages[i%1000], fakeSugarFields()...)
+		}
+	})
+}

--- a/benchmarks/zap_sugar_bench_test.go
+++ b/benchmarks/zap_sugar_bench_test.go
@@ -20,6 +20,8 @@
 
 package benchmarks
 
+/* FIXME (shah): Update to match new APIs.
+
 import (
 	"testing"
 	"time"
@@ -145,3 +147,4 @@ func BenchmarkZapSugarSampleAddingFields(b *testing.B) {
 		}
 	})
 }
+*/

--- a/benchmarks/zap_sugar_bench_test.go
+++ b/benchmarks/zap_sugar_bench_test.go
@@ -20,14 +20,13 @@
 
 package benchmarks
 
-/* FIXME (shah): Update to match new APIs.
-
 import (
 	"testing"
 	"time"
 
-	"github.com/uber-go/zap"
-	"github.com/uber-go/zap/zwrap"
+	"go.uber.org/zap"
+	"go.uber.org/zap/testutils"
+	"go.uber.org/zap/zapcore"
 )
 
 func fakeSugarFields() []interface{} {
@@ -45,18 +44,12 @@ func fakeSugarFields() []interface{} {
 	}
 }
 
-var newCoreLoggerDefaults = []zap.Option{
-	zap.ErrorLevel,
-	zap.DiscardOutput,
-}
-
-func newCoreLogger(options ...zap.Option) zap.Logger {
-	options = append(newCoreLoggerDefaults, options...)
-	return zap.New(zap.NewJSONEncoder(), options...)
-}
-
-func newSugarLogger(options ...zap.Option) zap.Sugar {
-	return zap.NewSugar(newCoreLogger(options...))
+func newSugarLogger(options ...zap.Option) *zap.SugaredLogger {
+	return zap.Sugar(zap.New(zapcore.WriterFacility(
+		benchEncoder(),
+		&testutils.Discarder{},
+		zap.ErrorLevel,
+	)))
 }
 
 func BenchmarkZapSugarDisabledLevelsWithoutFields(b *testing.B) {
@@ -119,32 +112,3 @@ func BenchmarkZapSugarWithoutFields(b *testing.B) {
 		}
 	})
 }
-
-func BenchmarkZapSugarSampleWithoutFields(b *testing.B) {
-	messages := fakeMessages(1000)
-	core := newCoreLogger()
-	logger := zap.NewSugar(zwrap.Sample(core, time.Second, 10, 10000))
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		i := 0
-		for pb.Next() {
-			i++
-			logger.Info(messages[i%1000])
-		}
-	})
-}
-
-func BenchmarkZapSugarSampleAddingFields(b *testing.B) {
-	messages := fakeMessages(1000)
-	core := newCoreLogger()
-	logger := zap.NewSugar(zwrap.Sample(core, time.Second, 10, 10000))
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		i := 0
-		for pb.Next() {
-			i++
-			logger.Info(messages[i%1000], fakeSugarFields()...)
-		}
-	})
-}
-*/

--- a/benchmarks/zap_sugar_bench_test.go
+++ b/benchmarks/zap_sugar_bench_test.go
@@ -78,7 +78,7 @@ func BenchmarkZapSugarDisabledLevelsAddingFields(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			logger.Info("Should be discarded.", fakeSugarFields()...)
+			logger.Infow("Should be discarded.", fakeSugarFields()...)
 		}
 	})
 }
@@ -88,7 +88,7 @@ func BenchmarkZapSugarAddingFields(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			logger.Info("Go fast.", fakeSugarFields()...)
+			logger.Infow("Go fast.", fakeSugarFields()...)
 		}
 	})
 }

--- a/benchmarks/zap_sugar_bench_test.go
+++ b/benchmarks/zap_sugar_bench_test.go
@@ -44,16 +44,16 @@ func fakeSugarFields() []interface{} {
 	}
 }
 
-func newSugarLogger(options ...zap.Option) *zap.SugaredLogger {
+func newSugarLogger(lvl zapcore.Level, options ...zap.Option) *zap.SugaredLogger {
 	return zap.Sugar(zap.New(zapcore.WriterFacility(
 		benchEncoder(),
 		&testutils.Discarder{},
-		zap.ErrorLevel,
-	)))
+		lvl,
+	), options...))
 }
 
 func BenchmarkZapSugarDisabledLevelsWithoutFields(b *testing.B) {
-	logger := newSugarLogger()
+	logger := newSugarLogger(zap.ErrorLevel)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -64,7 +64,7 @@ func BenchmarkZapSugarDisabledLevelsWithoutFields(b *testing.B) {
 
 func BenchmarkZapSugarDisabledLevelsAccumulatedContext(b *testing.B) {
 	context := fakeFields()
-	logger := newSugarLogger(zap.Fields(context...))
+	logger := newSugarLogger(zap.ErrorLevel, zap.Fields(context...))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -74,7 +74,7 @@ func BenchmarkZapSugarDisabledLevelsAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapSugarDisabledLevelsAddingFields(b *testing.B) {
-	logger := newSugarLogger()
+	logger := newSugarLogger(zap.ErrorLevel)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -84,7 +84,7 @@ func BenchmarkZapSugarDisabledLevelsAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapSugarAddingFields(b *testing.B) {
-	logger := newSugarLogger()
+	logger := newSugarLogger(zap.DebugLevel)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -94,7 +94,7 @@ func BenchmarkZapSugarAddingFields(b *testing.B) {
 }
 
 func BenchmarkZapSugarWithAccumulatedContext(b *testing.B) {
-	logger := newSugarLogger().With(fakeSugarFields()...)
+	logger := newSugarLogger(zap.DebugLevel).With(fakeSugarFields()...)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -104,7 +104,7 @@ func BenchmarkZapSugarWithAccumulatedContext(b *testing.B) {
 }
 
 func BenchmarkZapSugarWithoutFields(b *testing.B) {
-	logger := newSugarLogger()
+	logger := newSugarLogger(zap.DebugLevel)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/common_test.go
+++ b/common_test.go
@@ -41,6 +41,10 @@ func withLogger(t testing.TB, e zapcore.LevelEnabler, opts []Option, f func(Logg
 	f(log, &logs)
 }
 
+func withSugar(t testing.TB, e zapcore.LevelEnabler, opts []Option, f func(*SugaredLogger, *zapcore.ObservedLogs)) {
+	withLogger(t, e, opts, func(logger Logger, logs *zapcore.ObservedLogs) { f(Sugar(logger), logs) })
+}
+
 func runConcurrently(goroutines, iterations int, wg *sync.WaitGroup, f func()) {
 	wg.Add(goroutines)
 	for g := 0; g < goroutines; g++ {

--- a/common_test.go
+++ b/common_test.go
@@ -41,8 +41,8 @@ func withLogger(t testing.TB, e zapcore.LevelEnabler, opts []Option, f func(Logg
 	f(log, &logs)
 }
 
-func withSugar(t testing.TB, e zapcore.LevelEnabler, opts []Option, f func(*SugaredLogger, *zapcore.ObservedLogs)) {
-	withLogger(t, e, opts, func(logger Logger, logs *zapcore.ObservedLogs) { f(Sugar(logger), logs) })
+func withSugar(t testing.TB, e zapcore.LevelEnabler, opts []Option, f func(*SugaredLogger, *observer.ObservedLogs)) {
+	withLogger(t, e, opts, func(logger Logger, logs *observer.ObservedLogs) { f(Sugar(logger), logs) })
 }
 
 func runConcurrently(goroutines, iterations int, wg *sync.WaitGroup, f func()) {

--- a/field.go
+++ b/field.go
@@ -201,7 +201,7 @@ func Any(key string, value interface{}) zapcore.Field {
 	case time.Duration:
 		return Duration(key, val)
 	case fmt.Stringer:
-		return String(key, val.String())
+		return Stringer(key, val)
 	default:
 		return Reflect(key, val)
 	}

--- a/field.go
+++ b/field.go
@@ -156,3 +156,53 @@ func Reflect(key string, val interface{}) zapcore.Field {
 func Nest(key string, fields ...zapcore.Field) zapcore.Field {
 	return zapcore.Field{Key: key, Type: zapcore.ObjectMarshalerType, Interface: zapcore.Fields(fields)}
 }
+
+// Any takes a key and an arbitrary value and chooses the best way to represent
+// them as a field, falling back to a reflection-based approach only if
+// necessary.
+func Any(key string, value interface{}) zapcore.Field {
+	switch val := value.(type) {
+	case zapcore.ObjectMarshaler:
+		return Object(key, val)
+	case bool:
+		return Bool(key, val)
+	case float64:
+		return Float64(key, val)
+	case float32:
+		return Float64(key, float64(val))
+	case int:
+		return Int(key, val)
+	case int64:
+		return Int64(key, val)
+	case int32:
+		return Int64(key, int64(val))
+	case int16:
+		return Int64(key, int64(val))
+	case int8:
+		return Int64(key, int64(val))
+	case uint:
+		return Uint(key, val)
+	case uint64:
+		return Uint64(key, val)
+	case uint32:
+		return Uint64(key, uint64(val))
+	case uint16:
+		return Uint64(key, uint64(val))
+	case uint8:
+		return Uint64(key, uint64(val))
+	case uintptr:
+		return Uintptr(key, val)
+	case string:
+		return String(key, val)
+	case error:
+		return String(key, val.Error())
+	case time.Time:
+		return Time(key, val)
+	case time.Duration:
+		return Duration(key, val)
+	case fmt.Stringer:
+		return String(key, val.String())
+	default:
+		return Reflect(key, val)
+	}
+}

--- a/field.go
+++ b/field.go
@@ -164,6 +164,8 @@ func Any(key string, value interface{}) zapcore.Field {
 	switch val := value.(type) {
 	case zapcore.ObjectMarshaler:
 		return Object(key, val)
+	case zapcore.ArrayMarshaler:
+		return Array(key, val)
 	case bool:
 		return Bool(key, val)
 	case float64:
@@ -194,12 +196,12 @@ func Any(key string, value interface{}) zapcore.Field {
 		return Uintptr(key, val)
 	case string:
 		return String(key, val)
-	case error:
-		return String(key, val.Error())
 	case time.Time:
 		return Time(key, val)
 	case time.Duration:
 		return Duration(key, val)
+	case error:
+		return String(key, val.Error())
 	case fmt.Stringer:
 		return Stringer(key, val)
 	default:

--- a/field_test.go
+++ b/field_test.go
@@ -22,16 +22,14 @@ package zap
 
 import (
 	"errors"
+	"math"
 	"net"
 	"sync"
 	"testing"
 	"time"
 
-	"go.uber.org/zap/zapcore"
-
-	"math"
-
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
 )
 
 var (
@@ -100,6 +98,7 @@ func TestFieldConstructors(t *testing.T) {
 		{"Reflect", zapcore.Field{Key: "k", Type: zapcore.ReflectType, Interface: ints}, Reflect("k", ints)},
 		{"Nest", zapcore.Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: nested}, Nest("k", nested...)},
 		{"Any:ObjectMarshaler", Any("k", name), Object("k", name)},
+		{"Any:ArrayMarshaler", Any("k", bools([]bool{true})), Array("k", bools([]bool{true}))},
 		{"Any:Bool", Any("k", true), Bool("k", true)},
 		{"Any:Float64", Any("k", 3.14), Float64("k", 3.14)},
 		// TODO (v1.0): We could use some approximately-equal logic here, but it's

--- a/field_test.go
+++ b/field_test.go
@@ -99,6 +99,30 @@ func TestFieldConstructors(t *testing.T) {
 		{"Object", zapcore.Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: name}, Object("k", name)},
 		{"Reflect", zapcore.Field{Key: "k", Type: zapcore.ReflectType, Interface: ints}, Reflect("k", ints)},
 		{"Nest", zapcore.Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: nested}, Nest("k", nested...)},
+		{"Any:ObjectMarshaler", Any("k", name), Object("k", name)},
+		{"Any:Bool", Any("k", true), Bool("k", true)},
+		{"Any:Float64", Any("k", 3.14), Float64("k", 3.14)},
+		// TODO (v1.0): We could use some approximately-equal logic here, but it's
+		// not worth it to test this one line. Before 1.0, we'll need to support
+		// float32s explicitly, which will make this test pass.
+		// {"Any:Float32", Any("k", float32(3.14)), Float32("k", 3.14)},
+		{"Any:Int", Any("k", 1), Int("k", 1)},
+		{"Any:Int64", Any("k", int64(1)), Int64("k", 1)},
+		{"Any:Int32", Any("k", int32(1)), Int64("k", 1)},
+		{"Any:Int16", Any("k", int16(1)), Int64("k", 1)},
+		{"Any:Int8", Any("k", int8(1)), Int64("k", 1)},
+		{"Any:Uint", Any("k", uint(1)), Uint("k", 1)},
+		{"Any:Uint64", Any("k", uint64(1)), Uint64("k", 1)},
+		{"Any:Uint32", Any("k", uint32(1)), Uint64("k", 1)},
+		{"Any:Uint16", Any("k", uint16(1)), Uint64("k", 1)},
+		{"Any:Uint8", Any("k", uint8(1)), Uint64("k", 1)},
+		{"Any:Uintptr", Any("k", uintptr(1)), Uintptr("k", 1)},
+		{"Any:String", Any("k", "v"), String("k", "v")},
+		{"Any:Error", Any("k", errors.New("v")), String("k", "v")},
+		{"Any:Time", Any("k", time.Unix(0, 0)), Time("k", time.Unix(0, 0))},
+		{"Any:Duration", Any("k", time.Second), Duration("k", time.Second)},
+		{"Any:Stringer", Any("k", addr), Stringer("k", addr)},
+		{"Any:Fallback", Any("k", struct{}{}), Reflect("k", struct{}{})},
 	}
 
 	for _, tt := range tests {

--- a/sugar.go
+++ b/sugar.go
@@ -112,31 +112,33 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 				return nil, errors.New("field name must be string")
 			}
 		} else {
-			switch value := value.(type) {
-			case bool:
-				fields = append(fields, Bool(key, value))
-			case float64:
-				fields = append(fields, Float64(key, value))
-			case int:
-				fields = append(fields, Int(key, value))
-			case int64:
-				fields = append(fields, Int64(key, value))
-			case uint:
-				fields = append(fields, Uint(key, value))
-			case uint64:
-				fields = append(fields, Uint64(key, value))
-			case string:
-				fields = append(fields, String(key, value))
-			case time.Time:
-				fields = append(fields, Time(key, value))
-			case time.Duration:
-				fields = append(fields, Duration(key, value))
-			case fmt.Stringer:
-				fields = append(fields, Stringer(key, value))
+			switch v := value.(type) {
 			case error:
 				return nil, errors.New("error can only be the first argument")
+			case bool:
+				fields = append(fields, Bool(key, v))
+			case float64:
+				fields = append(fields, Float64(key, v))
+			case int:
+				fields = append(fields, Int(key, v))
+			case int64:
+				fields = append(fields, Int64(key, v))
+			case uint:
+				fields = append(fields, Uint(key, v))
+			case uint64:
+				fields = append(fields, Uint64(key, v))
+			case string:
+				fields = append(fields, String(key, v))
+			case time.Time:
+				fields = append(fields, Time(key, v))
+			case time.Duration:
+				fields = append(fields, Duration(key, v))
+			case fmt.Stringer:
+				fields = append(fields, Stringer(key, v))
+			case LogMarshaler:
+				fields = append(fields, Marshaler(key, v))
 			default:
-				return nil, errors.New("invalid argument type")
+				fields = append(fields, Object(key, value))
 			}
 		}
 	}

--- a/sugar.go
+++ b/sugar.go
@@ -192,9 +192,9 @@ func (s *sugar) Fatal(msg string, args ...interface{}) {
 }
 
 func (s *sugar) DFatal(msg string, args ...interface{}) {
-	lvl := ErrorLevel
-	if s.core.(*logger).Development {
-		lvl = FatalLevel
+	fields, err := getSugarFields(args...)
+	if err != nil {
+		s.internalError(err.Error())
 	}
-	s.Log(lvl, msg, args...)
+	s.core.DFatal(msg, fields...)
 }

--- a/sugar.go
+++ b/sugar.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Sugar is a wrapper around core logger whith less verbose API
+type Sugar interface {
+	// Check the minimum enabled log level.
+	Level() Level
+	// Change the level of this logger, as well as all its ancestors and
+	// descendants. This makes it easy to change the log level at runtime
+	// without restarting your application.
+	SetLevel(Level)
+
+	// Create a child logger, and optionally add some context to that logger.
+	With(...interface{}) (Sugar, error)
+
+	// Log a message at the given level. Messages include any context that's
+	// accumulated on the logger, as well as any fields added at the log site.
+	Log(Level, string, ...interface{}) error
+	Debug(string, ...interface{}) error
+	Info(string, ...interface{}) error
+	Warn(string, ...interface{}) error
+	Error(string, ...interface{}) error
+	Panic(string, ...interface{}) error
+	Fatal(string, ...interface{}) error
+	// If the logger is in development mode (via the Development option), DFatal
+	// logs at the Fatal level. Otherwise, it logs at the Error level.
+	DFatal(string, ...interface{}) error
+}
+
+type sugar struct {
+	core Logger
+}
+
+// NewSugar is a constructor for Sugar
+func NewSugar(core Logger) Sugar {
+	return &sugar{core}
+}
+
+func (s *sugar) Level() Level {
+	return s.core.Level()
+}
+
+func (s *sugar) SetLevel(lvl Level) {
+	s.core.SetLevel(lvl)
+}
+
+func (s *sugar) With(args ...interface{}) (Sugar, error) {
+	fields, err := getSugarFields(args...)
+	if err != nil {
+		return nil, err
+	}
+	return NewSugar(s.core.With(fields...)), nil
+}
+
+func getSugarFields(args ...interface{}) ([]Field, error) {
+	if (len(args) % 2) != 0 {
+		return nil, errors.New("invalid number of arguments")
+	}
+	var (
+		fields []Field
+		ii     int
+		key    string
+		value  interface{}
+	)
+	for ii, value = range args {
+		if (ii % 2) == 0 {
+			switch value.(type) {
+			case string:
+				key = value.(string)
+			default:
+				return nil, errors.New("field name must be string")
+			}
+		} else {
+			switch value.(type) {
+			case bool:
+				fields = append(fields, Bool(key, value.(bool)))
+			case float64:
+				fields = append(fields, Float64(key, value.(float64)))
+			case int:
+				fields = append(fields, Int(key, value.(int)))
+			case int64:
+				fields = append(fields, Int64(key, value.(int64)))
+			case uint:
+				fields = append(fields, Uint(key, value.(uint)))
+			case uint64:
+				fields = append(fields, Uint64(key, value.(uint64)))
+			case string:
+				fields = append(fields, String(key, value.(string)))
+			case time.Time:
+				fields = append(fields, Time(key, value.(time.Time)))
+			case time.Duration:
+				fields = append(fields, Duration(key, value.(time.Duration)))
+			case fmt.Stringer:
+				fields = append(fields, Stringer(key, value.(fmt.Stringer)))
+			default:
+				return nil, errors.New("invalid argument type")
+			}
+		}
+	}
+	return fields, nil
+}
+
+// Log ...
+func (s *sugar) Log(lvl Level, msg string, args ...interface{}) error {
+	fields, err := getSugarFields(args...)
+	if err != nil {
+		return err
+	}
+	s.core.Log(lvl, msg, fields...)
+	return nil
+}
+
+func (s *sugar) Debug(msg string, args ...interface{}) error {
+	return s.Log(DebugLevel, msg, args...)
+}
+
+func (s *sugar) Info(msg string, args ...interface{}) error {
+	return s.Log(InfoLevel, msg, args...)
+}
+
+func (s *sugar) Warn(msg string, args ...interface{}) error {
+	return s.Log(WarnLevel, msg, args...)
+}
+
+func (s *sugar) Error(msg string, args ...interface{}) error {
+	return s.Log(ErrorLevel, msg, args...)
+}
+
+func (s *sugar) Panic(msg string, args ...interface{}) error {
+	return s.Log(PanicLevel, msg, args...)
+}
+
+func (s *sugar) Fatal(msg string, args ...interface{}) error {
+	return s.Log(FatalLevel, msg, args...)
+}
+
+func (s *sugar) DFatal(msg string, args ...interface{}) error {
+	fields, err := getSugarFields(args...)
+	if err != nil {
+		return err
+	}
+	s.core.DFatal(msg, fields...)
+	return nil
+}

--- a/sugar.go
+++ b/sugar.go
@@ -112,27 +112,27 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 				return nil, errors.New("field name must be string")
 			}
 		} else {
-			switch value.(type) {
+			switch value := value.(type) {
 			case bool:
-				fields = append(fields, Bool(key, value.(bool)))
+				fields = append(fields, Bool(key, value))
 			case float64:
-				fields = append(fields, Float64(key, value.(float64)))
+				fields = append(fields, Float64(key, value))
 			case int:
-				fields = append(fields, Int(key, value.(int)))
+				fields = append(fields, Int(key, value))
 			case int64:
-				fields = append(fields, Int64(key, value.(int64)))
+				fields = append(fields, Int64(key, value))
 			case uint:
-				fields = append(fields, Uint(key, value.(uint)))
+				fields = append(fields, Uint(key, value))
 			case uint64:
-				fields = append(fields, Uint64(key, value.(uint64)))
+				fields = append(fields, Uint64(key, value))
 			case string:
-				fields = append(fields, String(key, value.(string)))
+				fields = append(fields, String(key, value))
 			case time.Time:
-				fields = append(fields, Time(key, value.(time.Time)))
+				fields = append(fields, Time(key, value))
 			case time.Duration:
-				fields = append(fields, Duration(key, value.(time.Duration)))
+				fields = append(fields, Duration(key, value))
 			case fmt.Stringer:
-				fields = append(fields, Stringer(key, value.(fmt.Stringer)))
+				fields = append(fields, Stringer(key, value))
 			case error:
 				return nil, errors.New("error can only be the first argument")
 			default:

--- a/sugar.go
+++ b/sugar.go
@@ -80,12 +80,12 @@ func (s *sugar) With(args ...interface{}) (Sugar, error) {
 func getSugarFields(args ...interface{}) ([]Field, error) {
 	var (
 		noErrArgs []interface{}
-		fields    []Field
 
 		ii    int
 		key   string
 		value interface{}
 	)
+	fields := make([]Field, 0, len(args)/2)
 
 	if len(args) == 0 {
 		return fields, nil

--- a/sugar.go
+++ b/sugar.go
@@ -21,180 +21,209 @@
 package zap
 
 import (
-	"errors"
 	"fmt"
 	"time"
 )
 
-// Sugar is a wrapper around core logger with less verbose API
-type Sugar interface {
-	// Level returns the minimum enabled log level
-	Level() Level
-
-	// SetLevel changes the level of this logger, as well as all its ancestors
-	// and descendants. This makes it easy to change the log level at runtime
-	// without restarting your application.
-	SetLevel(Level)
-
-	// With creates a child logger, and optionally add some context to that
-	// logger
-	With(...interface{}) Sugar
-
-	// Log a message at the given level. Messages include any context that's
-	// accumulated on the logger, as well as any fields added at the log site.
-	Log(Level, string, ...interface{})
-	Debug(string, ...interface{})
-	Info(string, ...interface{})
-	Warn(string, ...interface{})
-	Error(string, ...interface{})
-	Panic(string, ...interface{})
-	Fatal(string, ...interface{})
-
-	// DFatal logs at the Fatal level if the logger is in development mode (via
-	// the Development option), otherwise it logs at the Error level.
-	DFatal(string, ...interface{})
-}
-
-type sugar struct {
+// A SugaredLogger wraps the core Logger functionality in a slower, but less
+// verbose, API.
+type SugaredLogger struct {
 	core Logger
 }
 
-func (s *sugar) internalError(msg string) {
-	s.core.(*logger).internalError(msg)
+// Sugar converts a Logger to a SugaredLogger.
+func Sugar(core Logger) *SugaredLogger {
+	return &SugaredLogger{core}
 }
 
-// NewSugar is a constructor for Sugar
-func NewSugar(core Logger) Sugar {
-	return &sugar{core}
+// Desugar unwraps a SugaredLogger, exposing the original Logger.
+func Desugar(s *SugaredLogger) Logger {
+	return s.core
 }
 
-func (s *sugar) Level() Level {
-	return s.core.Level()
+// With adds a variadic number of key-value pairs to the logging context.
+// Even-indexed arguments are treated as keys, and are converted to strings
+// (with fmt.Sprint) if necessary. The keys are then zipped with the
+// odd-indexed values into typed fields, falling back to a reflection-based
+// encoder if necessary.
+//
+// For example,
+//   sugaredLogger.With(
+//     "hello", "world",
+//     "failure", errors.New("oh no"),
+//     "count", 42,
+//     "user", User{name: "alice"},
+//  )
+// is the equivalent of
+//   coreLogger.With(
+//     String("hello", "world"),
+//     String("failure", "oh no"),
+//     Int("count", 42),
+//     Object("user", User{name: "alice"}),
+//   )
+func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
+	return &SugaredLogger{core: s.core.With(sweetenFields(args, s.core)...)}
 }
 
-func (s *sugar) SetLevel(lvl Level) {
-	s.core.SetLevel(lvl)
+// WithStack adds a complete stack trace to the logger's context, using the key
+// "stacktrace".
+func (s *SugaredLogger) WithStack() *SugaredLogger {
+	return &SugaredLogger{core: s.core.With(Stack())}
 }
 
-func (s *sugar) With(args ...interface{}) Sugar {
-	fields, err := getSugarFields(args...)
-	if err != nil {
-		s.internalError(err.Error())
-	}
-	return NewSugar(s.core.With(fields...))
+// Debug logs a message and some key-value pairs at DebugLevel. Keys and values
+// are treated as they are in the With method.
+func (s *SugaredLogger) Debug(msg interface{}, keysAndValues ...interface{}) {
+	s.core.Debug(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
 }
 
-func getSugarFields(args ...interface{}) ([]Field, error) {
-	var (
-		noErrArgs []interface{}
+// Debugf uses fmt.Sprintf to construct a dynamic message and logs it at
+// DebugLevel. It doesn't add to the message's structured context.
+func (s *SugaredLogger) Debugf(template string, args ...interface{}) {
+	s.Debug(fmt.Sprintf(template, args...))
+}
 
-		ii    int
-		key   string
-		value interface{}
-	)
-	fields := make([]Field, 0, len(args)/2)
+// Info logs a message and some key-value pairs at InfoLevel. Keys and values
+// are treated as they are in the With method.
+func (s *SugaredLogger) Info(msg interface{}, keysAndValues ...interface{}) {
+	s.core.Info(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+}
 
+// Infof uses fmt.Sprintf to construct a dynamic message and logs it at
+// InfoLevel. It doesn't add to the message's structured context.
+func (s *SugaredLogger) Infof(template string, args ...interface{}) {
+	s.Info(fmt.Sprintf(template, args...))
+}
+
+// Warn logs a message and some key-value pairs at WarnLevel. Keys and values
+// are treated as they are in the With method.
+func (s *SugaredLogger) Warn(msg interface{}, keysAndValues ...interface{}) {
+	s.core.Warn(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+}
+
+// Warnf uses fmt.Sprintf to construct a dynamic message and logs it at
+// WarnLevel. It doesn't add to the message's structured context.
+func (s *SugaredLogger) Warnf(template string, args ...interface{}) {
+	s.Warn(fmt.Sprintf(template, args...))
+}
+
+// Error logs a message and some key-value pairs at ErrorLevel. Keys and values
+// are treated as they are in the With method.
+func (s *SugaredLogger) Error(msg interface{}, keysAndValues ...interface{}) {
+	s.core.Error(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+}
+
+// Errorf uses fmt.Sprintf to construct a dynamic message and logs it at
+// ErrorLevel. It doesn't add to the message's structured context.
+func (s *SugaredLogger) Errorf(template string, args ...interface{}) {
+	s.Error(fmt.Sprintf(template, args...))
+}
+
+// Panic logs a message and some key-value pairs at PanicLevel, then panics.
+// Keys and values are treated as they are in the With method.
+func (s *SugaredLogger) Panic(msg interface{}, keysAndValues ...interface{}) {
+	s.core.Panic(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+}
+
+// Panicf uses fmt.Sprintf to construct a dynamic message and logs it at
+// PanicLevel, then panics. It doesn't add to the message's structured context.
+func (s *SugaredLogger) Panicf(template string, args ...interface{}) {
+	s.Panic(fmt.Sprintf(template, args...))
+}
+
+// Fatal logs a message and some key-value pairs at FatalLevel, then calls
+// os.Exit(1). Keys and values are treated as they are in the With method.
+func (s *SugaredLogger) Fatal(msg interface{}, keysAndValues ...interface{}) {
+	s.core.Fatal(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+}
+
+// Fatalf uses fmt.Sprintf to construct a dynamic message and logs it at
+// FatalLevel, then calls os.Exit(1). It doesn't add to the message's
+// structured context.
+func (s *SugaredLogger) Fatalf(template string, args ...interface{}) {
+	s.Fatal(fmt.Sprintf(template, args...))
+}
+
+// DFatal logs a message and some key-value pairs using the underlying logger's
+// DFatal method. Keys and values are treated as they are in the With
+// method. (See Logger.DFatal for details.)
+func (s *SugaredLogger) DFatal(msg interface{}, keysAndValues ...interface{}) {
+	s.core.DFatal(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+}
+
+// DFatalf uses fmt.Sprintf to construct a dynamic message, which is passed to
+// the underlying Logger's DFatal method. (See Logger.DFatal for details.) It
+// doesn't add to the message's structured context.
+func (s *SugaredLogger) DFatalf(template string, args ...interface{}) {
+	s.DFatal(fmt.Sprintf(template, args...))
+}
+
+func sweetenFields(args []interface{}, errLogger Logger) []Field {
 	if len(args) == 0 {
-		return fields, nil
+		return nil
+	}
+	if len(args)%2 == 1 {
+		errLogger.DFatal(
+			"Passed an odd number of keys and values to SugaredLogger, ignoring last.",
+			Object("ignored", args[len(args)-1]),
+		)
 	}
 
-	switch err := args[0].(type) {
-	case error:
-		fields = append(fields, Error(err))
-		noErrArgs = args[1:]
-	default:
-		noErrArgs = args
-	}
+	fields := make([]Field, len(args)/2)
+	for i := range fields {
+		key := sweetenMsg(args[2*i])
 
-	if (len(noErrArgs) % 2) != 0 {
-		return nil, errors.New("invalid number of arguments")
-	}
-
-	for ii, value = range noErrArgs {
-		if (ii % 2) == 0 {
-			switch value.(type) {
-			case string:
-				key = value.(string)
-			default:
-				return nil, errors.New("field name must be string")
-			}
-		} else {
-			// TODO: Add LogMarshaler support, it once been here, but
-			//       had to be removed because type switch won't catch
-			//       this intarface properly for some mystical reason.
-			switch v := value.(type) {
-			case error:
-				return nil, errors.New("error can only be the first argument")
-			case bool:
-				fields = append(fields, Bool(key, v))
-			case float64:
-				fields = append(fields, Float64(key, v))
-			case int:
-				fields = append(fields, Int(key, v))
-			case int64:
-				fields = append(fields, Int64(key, v))
-			case uint:
-				fields = append(fields, Uint(key, v))
-			case uint64:
-				fields = append(fields, Uint64(key, v))
-			case string:
-				fields = append(fields, String(key, v))
-			case time.Time:
-				fields = append(fields, Time(key, v))
-			case time.Duration:
-				fields = append(fields, Duration(key, v))
-			case fmt.Stringer:
-				fields = append(fields, Stringer(key, v))
-			default:
-				fields = append(fields, Object(key, value))
-			}
+		switch val := args[2*i+1].(type) {
+		case LogMarshaler:
+			fields[i] = Marshaler(key, val)
+		case bool:
+			fields[i] = Bool(key, val)
+		case float64:
+			fields[i] = Float64(key, val)
+		case float32:
+			fields[i] = Float64(key, float64(val))
+		case int:
+			fields[i] = Int(key, val)
+		case int64:
+			fields[i] = Int64(key, val)
+		case int32:
+			fields[i] = Int64(key, int64(val))
+		case int16:
+			fields[i] = Int64(key, int64(val))
+		case int8:
+			fields[i] = Int64(key, int64(val))
+		case uint:
+			fields[i] = Uint(key, val)
+		case uint64:
+			fields[i] = Uint64(key, val)
+		case uint32:
+			fields[i] = Uint64(key, uint64(val))
+		case uint16:
+			fields[i] = Uint64(key, uint64(val))
+		case uint8:
+			fields[i] = Uint64(key, uint64(val))
+		case uintptr:
+			fields[i] = Uintptr(key, val)
+		case string:
+			fields[i] = String(key, val)
+		case time.Time:
+			fields[i] = Time(key, val)
+		case time.Duration:
+			fields[i] = Duration(key, val)
+		case error:
+			fields[i] = String(key, val.Error())
+		case fmt.Stringer:
+			fields[i] = String(key, val.String())
+		default:
+			fields[i] = Object(key, val)
 		}
 	}
-	return fields, nil
+	return fields
 }
 
-func (s *sugar) Log(lvl Level, msg string, args ...interface{}) {
-	var (
-		fields []Field
-		err    error
-	)
-	if cm := s.core.Check(lvl, msg); cm.OK() {
-		fields, err = getSugarFields(args...)
-		if err != nil {
-			s.internalError(err.Error())
-		}
-		cm.Write(fields...)
+func sweetenMsg(msg interface{}) string {
+	if m, ok := msg.(string); ok {
+		return m
 	}
-}
-
-func (s *sugar) Debug(msg string, args ...interface{}) {
-	s.Log(DebugLevel, msg, args...)
-}
-
-func (s *sugar) Info(msg string, args ...interface{}) {
-	s.Log(InfoLevel, msg, args...)
-}
-
-func (s *sugar) Warn(msg string, args ...interface{}) {
-	s.Log(WarnLevel, msg, args...)
-}
-
-func (s *sugar) Error(msg string, args ...interface{}) {
-	s.Log(ErrorLevel, msg, args...)
-}
-
-func (s *sugar) Panic(msg string, args ...interface{}) {
-	s.Log(PanicLevel, msg, args...)
-}
-
-func (s *sugar) Fatal(msg string, args ...interface{}) {
-	s.Log(FatalLevel, msg, args...)
-}
-
-func (s *sugar) DFatal(msg string, args ...interface{}) {
-	fields, err := getSugarFields(args...)
-	if err != nil {
-		s.internalError(err.Error())
-	}
-	s.core.DFatal(msg, fields...)
+	return fmt.Sprint(msg)
 }

--- a/sugar.go
+++ b/sugar.go
@@ -112,6 +112,9 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 				return nil, errors.New("field name must be string")
 			}
 		} else {
+			// TODO: Add LogMarshaler support, it once been here, but
+			//       had to be removed because type switch won't catch
+			//       this intarface properly for some mystical reason.
 			switch v := value.(type) {
 			case error:
 				return nil, errors.New("error can only be the first argument")
@@ -135,8 +138,6 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 				fields = append(fields, Duration(key, v))
 			case fmt.Stringer:
 				fields = append(fields, Stringer(key, v))
-			case LogMarshaler:
-				fields = append(fields, Marshaler(key, v))
 			default:
 				fields = append(fields, Object(key, value))
 			}

--- a/sugar.go
+++ b/sugar.go
@@ -145,11 +145,13 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 
 // Log ...
 func (s *sugar) Log(lvl Level, msg string, args ...interface{}) error {
-	fields, err := getSugarFields(args...)
-	if err != nil {
-		return err
+	if cm := s.core.Check(lvl, msg); cm.OK() {
+		fields, err := getSugarFields(args...)
+		if err != nil {
+			return err
+		}
+		cm.Write(fields...)
 	}
-	s.core.Log(lvl, msg, fields...)
 	return nil
 }
 
@@ -178,10 +180,9 @@ func (s *sugar) Fatal(msg string, args ...interface{}) error {
 }
 
 func (s *sugar) DFatal(msg string, args ...interface{}) error {
-	fields, err := getSugarFields(args...)
-	if err != nil {
-		return err
+	lvl := ErrorLevel
+	if s.core.(*logger).Development {
+		lvl = FatalLevel
 	}
-	s.core.DFatal(msg, fields...)
-	return nil
+	return s.Log(lvl, msg, args...)
 }

--- a/sugar.go
+++ b/sugar.go
@@ -28,14 +28,16 @@ import (
 
 // Sugar is a wrapper around core logger with less verbose API
 type Sugar interface {
-	// Check the minimum enabled log level.
+	// Level returns the minimum enabled log level
 	Level() Level
-	// Change the level of this logger, as well as all its ancestors and
-	// descendants. This makes it easy to change the log level at runtime
+
+	// SetLevel changes the level of this logger, as well as all its ancestors
+	// and descendants. This makes it easy to change the log level at runtime
 	// without restarting your application.
 	SetLevel(Level)
 
-	// Create a child logger, and optionally add some context to that logger.
+	// With creates a child logger, and optionally add some context to that
+	// logger
 	With(...interface{}) (Sugar, error)
 
 	// Log a message at the given level. Messages include any context that's
@@ -47,8 +49,9 @@ type Sugar interface {
 	Error(string, ...interface{})
 	Panic(string, ...interface{})
 	Fatal(string, ...interface{})
-	// If the logger is in development mode (via the Development option), DFatal
-	// logs at the Fatal level. Otherwise, it logs at the Error level.
+
+	// DFatal logs at the Fatal level if the logger is in development mode (via
+	// the Development option), otherwise it logs at the Error level.
 	DFatal(string, ...interface{})
 }
 
@@ -146,7 +149,6 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 	return fields, nil
 }
 
-// Log ...
 func (s *sugar) Log(lvl Level, msg string, args ...interface{}) {
 	var (
 		fields []Field

--- a/sugar.go
+++ b/sugar.go
@@ -26,7 +26,7 @@ import (
 	"time"
 )
 
-// Sugar is a wrapper around core logger whith less verbose API
+// Sugar is a wrapper around core logger with less verbose API
 type Sugar interface {
 	// Check the minimum enabled log level.
 	Level() Level

--- a/sugar.go
+++ b/sugar.go
@@ -40,16 +40,16 @@ type Sugar interface {
 
 	// Log a message at the given level. Messages include any context that's
 	// accumulated on the logger, as well as any fields added at the log site.
-	Log(Level, string, ...interface{}) error
-	Debug(string, ...interface{}) error
-	Info(string, ...interface{}) error
-	Warn(string, ...interface{}) error
-	Error(string, ...interface{}) error
-	Panic(string, ...interface{}) error
-	Fatal(string, ...interface{}) error
+	Log(Level, string, ...interface{})
+	Debug(string, ...interface{})
+	Info(string, ...interface{})
+	Warn(string, ...interface{})
+	Error(string, ...interface{})
+	Panic(string, ...interface{})
+	Fatal(string, ...interface{})
 	// If the logger is in development mode (via the Development option), DFatal
 	// logs at the Fatal level. Otherwise, it logs at the Error level.
-	DFatal(string, ...interface{}) error
+	DFatal(string, ...interface{})
 }
 
 type sugar struct {
@@ -91,9 +91,9 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 		return fields, nil
 	}
 
-	switch args[0].(type) {
+	switch err := args[0].(type) {
 	case error:
-		fields = append(fields, Error(args[0].(error)))
+		fields = append(fields, Error(err))
 		noErrArgs = args[1:]
 	default:
 		noErrArgs = args
@@ -144,45 +144,48 @@ func getSugarFields(args ...interface{}) ([]Field, error) {
 }
 
 // Log ...
-func (s *sugar) Log(lvl Level, msg string, args ...interface{}) error {
+func (s *sugar) Log(lvl Level, msg string, args ...interface{}) {
+	var (
+		fields []Field
+		err    error
+	)
 	if cm := s.core.Check(lvl, msg); cm.OK() {
-		fields, err := getSugarFields(args...)
+		fields, err = getSugarFields(args...)
 		if err != nil {
-			return err
+			fields = []Field{Error(err)}
 		}
 		cm.Write(fields...)
 	}
-	return nil
 }
 
-func (s *sugar) Debug(msg string, args ...interface{}) error {
-	return s.Log(DebugLevel, msg, args...)
+func (s *sugar) Debug(msg string, args ...interface{}) {
+	s.Log(DebugLevel, msg, args...)
 }
 
-func (s *sugar) Info(msg string, args ...interface{}) error {
-	return s.Log(InfoLevel, msg, args...)
+func (s *sugar) Info(msg string, args ...interface{}) {
+	s.Log(InfoLevel, msg, args...)
 }
 
-func (s *sugar) Warn(msg string, args ...interface{}) error {
-	return s.Log(WarnLevel, msg, args...)
+func (s *sugar) Warn(msg string, args ...interface{}) {
+	s.Log(WarnLevel, msg, args...)
 }
 
-func (s *sugar) Error(msg string, args ...interface{}) error {
-	return s.Log(ErrorLevel, msg, args...)
+func (s *sugar) Error(msg string, args ...interface{}) {
+	s.Log(ErrorLevel, msg, args...)
 }
 
-func (s *sugar) Panic(msg string, args ...interface{}) error {
-	return s.Log(PanicLevel, msg, args...)
+func (s *sugar) Panic(msg string, args ...interface{}) {
+	s.Log(PanicLevel, msg, args...)
 }
 
-func (s *sugar) Fatal(msg string, args ...interface{}) error {
-	return s.Log(FatalLevel, msg, args...)
+func (s *sugar) Fatal(msg string, args ...interface{}) {
+	s.Log(FatalLevel, msg, args...)
 }
 
-func (s *sugar) DFatal(msg string, args ...interface{}) error {
+func (s *sugar) DFatal(msg string, args ...interface{}) {
 	lvl := ErrorLevel
 	if s.core.(*logger).Development {
 		lvl = FatalLevel
 	}
-	return s.Log(lvl, msg, args...)
+	s.Log(lvl, msg, args...)
 }

--- a/sugar.go
+++ b/sugar.go
@@ -77,12 +77,6 @@ func (s *sugar) With(args ...interface{}) (Sugar, error) {
 	return NewSugar(s.core.With(fields...)), nil
 }
 
-const (
-	expectFirst = iota
-	expectString
-	expectValue
-)
-
 func getSugarFields(args ...interface{}) ([]Field, error) {
 	var (
 		noErrArgs []interface{}

--- a/sugar.go
+++ b/sugar.go
@@ -66,127 +66,99 @@ func Desugar(s *SugaredLogger) Logger {
 //     Object("user", User{name: "alice"}),
 //   )
 func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
-	return s.WithFields(s.sweetenFields(args)...)
-}
-
-// WithFields adds structured fields to the logger's context, just like the
-// standard Logger's With method.
-func (s *SugaredLogger) WithFields(fs ...zapcore.Field) *SugaredLogger {
-	return &SugaredLogger{core: s.core.With(fs...)}
+	return &SugaredLogger{core: s.core.With(s.sweetenFields(args)...)}
 }
 
 // Debug logs a message and some key-value pairs at DebugLevel. Keys and values
 // are treated as they are in the With method.
 func (s *SugaredLogger) Debug(msg interface{}, keysAndValues ...interface{}) {
-	if ce := s.core.Check(DebugLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(s.sweetenFields(keysAndValues)...)
-	}
+	s.log(DebugLevel, sweetenMsg(msg), keysAndValues)
 }
 
 // Debugf uses fmt.Sprintf to construct a dynamic message and logs it at
 // DebugLevel. It doesn't add to the message's structured context.
 func (s *SugaredLogger) Debugf(template string, args ...interface{}) {
-	if ce := s.core.Check(DebugLevel, fmt.Sprintf(template, args...)); ce != nil {
-		ce.Write()
-	}
+	s.log(DebugLevel, fmt.Sprintf(template, args...), nil)
 }
 
 // Info logs a message and some key-value pairs at InfoLevel. Keys and values
 // are treated as they are in the With method.
 func (s *SugaredLogger) Info(msg interface{}, keysAndValues ...interface{}) {
-	if ce := s.core.Check(InfoLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(s.sweetenFields(keysAndValues)...)
-	}
+	s.log(InfoLevel, sweetenMsg(msg), keysAndValues)
 }
 
 // Infof uses fmt.Sprintf to construct a dynamic message and logs it at
 // InfoLevel. It doesn't add to the message's structured context.
 func (s *SugaredLogger) Infof(template string, args ...interface{}) {
-	if ce := s.core.Check(InfoLevel, fmt.Sprintf(template, args...)); ce != nil {
-		ce.Write()
-	}
+	s.log(InfoLevel, fmt.Sprintf(template, args...), nil)
 }
 
 // Warn logs a message and some key-value pairs at WarnLevel. Keys and values
 // are treated as they are in the With method.
 func (s *SugaredLogger) Warn(msg interface{}, keysAndValues ...interface{}) {
-	if ce := s.core.Check(WarnLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(s.sweetenFields(keysAndValues)...)
-	}
+	s.log(WarnLevel, sweetenMsg(msg), keysAndValues)
 }
 
 // Warnf uses fmt.Sprintf to construct a dynamic message and logs it at
 // WarnLevel. It doesn't add to the message's structured context.
 func (s *SugaredLogger) Warnf(template string, args ...interface{}) {
-	if ce := s.core.Check(WarnLevel, fmt.Sprintf(template, args...)); ce != nil {
-		ce.Write()
-	}
+	s.log(WarnLevel, fmt.Sprintf(template, args...), nil)
 }
 
 // Error logs a message and some key-value pairs at ErrorLevel. Keys and values
 // are treated as they are in the With method.
 func (s *SugaredLogger) Error(msg interface{}, keysAndValues ...interface{}) {
-	if ce := s.core.Check(ErrorLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(s.sweetenFields(keysAndValues)...)
-	}
+	s.log(ErrorLevel, sweetenMsg(msg), keysAndValues)
 }
 
 // Errorf uses fmt.Sprintf to construct a dynamic message and logs it at
 // ErrorLevel. It doesn't add to the message's structured context.
 func (s *SugaredLogger) Errorf(template string, args ...interface{}) {
-	if ce := s.core.Check(ErrorLevel, fmt.Sprintf(template, args...)); ce != nil {
-		ce.Write()
-	}
+	s.log(ErrorLevel, fmt.Sprintf(template, args...), nil)
 }
 
 // DPanic logs a message and some key-value pairs using the underlying logger's
 // DPanic method. Keys and values are treated as they are in the With
 // method. (See Logger.DPanic for details.)
 func (s *SugaredLogger) DPanic(msg interface{}, keysAndValues ...interface{}) {
-	if ce := s.core.Check(DPanicLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(s.sweetenFields(keysAndValues)...)
-	}
+	s.log(DPanicLevel, sweetenMsg(msg), keysAndValues)
 }
 
 // DPanicf uses fmt.Sprintf to construct a dynamic message, which is passed to
 // the underlying Logger's DPanic method. (See Logger.DPanic for details.) It
 // doesn't add to the message's structured context.
 func (s *SugaredLogger) DPanicf(template string, args ...interface{}) {
-	if ce := s.core.Check(DPanicLevel, fmt.Sprintf(template, args...)); ce != nil {
-		ce.Write()
-	}
+	s.log(DPanicLevel, fmt.Sprintf(template, args...), nil)
 }
 
 // Panic logs a message and some key-value pairs at PanicLevel, then panics.
 // Keys and values are treated as they are in the With method.
 func (s *SugaredLogger) Panic(msg interface{}, keysAndValues ...interface{}) {
-	if ce := s.core.Check(PanicLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(s.sweetenFields(keysAndValues)...)
-	}
+	s.log(PanicLevel, sweetenMsg(msg), keysAndValues)
 }
 
 // Panicf uses fmt.Sprintf to construct a dynamic message and logs it at
 // PanicLevel, then panics. It doesn't add to the message's structured context.
 func (s *SugaredLogger) Panicf(template string, args ...interface{}) {
-	if ce := s.core.Check(PanicLevel, fmt.Sprintf(template, args...)); ce != nil {
-		ce.Write()
-	}
+	s.log(PanicLevel, fmt.Sprintf(template, args...), nil)
 }
 
 // Fatal logs a message and some key-value pairs at FatalLevel, then calls
 // os.Exit(1). Keys and values are treated as they are in the With method.
 func (s *SugaredLogger) Fatal(msg interface{}, keysAndValues ...interface{}) {
-	if ce := s.core.Check(FatalLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(s.sweetenFields(keysAndValues)...)
-	}
+	s.log(FatalLevel, sweetenMsg(msg), keysAndValues)
 }
 
 // Fatalf uses fmt.Sprintf to construct a dynamic message and logs it at
 // FatalLevel, then calls os.Exit(1). It doesn't add to the message's
 // structured context.
 func (s *SugaredLogger) Fatalf(template string, args ...interface{}) {
-	if ce := s.core.Check(FatalLevel, fmt.Sprintf(template, args...)); ce != nil {
-		ce.Write()
+	s.log(FatalLevel, fmt.Sprintf(template, args...), nil)
+}
+
+func (s *SugaredLogger) log(lvl zapcore.Level, msg string, context []interface{}) {
+	if ce := s.core.Check(lvl, msg); ce != nil {
+		ce.Write(s.sweetenFields(context)...)
 	}
 }
 

--- a/sugar.go
+++ b/sugar.go
@@ -22,8 +22,11 @@ package zap
 
 import (
 	"fmt"
-	"time"
+
+	"go.uber.org/zap/zapcore"
 )
+
+const oddNumberErrMsg = "Passed an odd number of keys and values to SugaredLogger, ignoring last."
 
 // A SugaredLogger wraps the core Logger functionality in a slower, but less
 // verbose, API.
@@ -33,19 +36,20 @@ type SugaredLogger struct {
 
 // Sugar converts a Logger to a SugaredLogger.
 func Sugar(core Logger) *SugaredLogger {
+	// TODO: increment caller skip.
 	return &SugaredLogger{core}
 }
 
 // Desugar unwraps a SugaredLogger, exposing the original Logger.
 func Desugar(s *SugaredLogger) Logger {
+	// TODO: decrement caller skip.
 	return s.core
 }
 
 // With adds a variadic number of key-value pairs to the logging context.
 // Even-indexed arguments are treated as keys, and are converted to strings
 // (with fmt.Sprint) if necessary. The keys are then zipped with the
-// odd-indexed values into typed fields, falling back to a reflection-based
-// encoder if necessary.
+// odd-indexed values into typed fields using the Any field constructor.
 //
 // For example,
 //   sugaredLogger.With(
@@ -65,165 +69,146 @@ func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
 	return &SugaredLogger{core: s.core.With(sweetenFields(args, s.core)...)}
 }
 
-// WithStack adds a complete stack trace to the logger's context, using the key
-// "stacktrace".
-func (s *SugaredLogger) WithStack() *SugaredLogger {
-	return &SugaredLogger{core: s.core.With(Stack())}
+// WithFields adds structured fields to the logger's context, just like the
+// standard Logger's With method.
+func (s *SugaredLogger) WithFields(fs ...zapcore.Field) *SugaredLogger {
+	return &SugaredLogger{core: s.core.With(fs...)}
 }
 
 // Debug logs a message and some key-value pairs at DebugLevel. Keys and values
 // are treated as they are in the With method.
 func (s *SugaredLogger) Debug(msg interface{}, keysAndValues ...interface{}) {
-	s.core.Debug(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+	if ce := s.core.Check(DebugLevel, sweetenMsg(msg)); ce != nil {
+		ce.Write(sweetenFields(keysAndValues, s.core)...)
+	}
 }
 
 // Debugf uses fmt.Sprintf to construct a dynamic message and logs it at
 // DebugLevel. It doesn't add to the message's structured context.
 func (s *SugaredLogger) Debugf(template string, args ...interface{}) {
-	s.Debug(fmt.Sprintf(template, args...))
+	if ce := s.core.Check(DebugLevel, fmt.Sprintf(template, args...)); ce != nil {
+		ce.Write()
+	}
 }
 
 // Info logs a message and some key-value pairs at InfoLevel. Keys and values
 // are treated as they are in the With method.
 func (s *SugaredLogger) Info(msg interface{}, keysAndValues ...interface{}) {
-	s.core.Info(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+	if ce := s.core.Check(InfoLevel, sweetenMsg(msg)); ce != nil {
+		ce.Write(sweetenFields(keysAndValues, s.core)...)
+	}
 }
 
 // Infof uses fmt.Sprintf to construct a dynamic message and logs it at
 // InfoLevel. It doesn't add to the message's structured context.
 func (s *SugaredLogger) Infof(template string, args ...interface{}) {
-	s.Info(fmt.Sprintf(template, args...))
+	if ce := s.core.Check(InfoLevel, fmt.Sprintf(template, args...)); ce != nil {
+		ce.Write()
+	}
 }
 
 // Warn logs a message and some key-value pairs at WarnLevel. Keys and values
 // are treated as they are in the With method.
 func (s *SugaredLogger) Warn(msg interface{}, keysAndValues ...interface{}) {
-	s.core.Warn(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+	if ce := s.core.Check(WarnLevel, sweetenMsg(msg)); ce != nil {
+		ce.Write(sweetenFields(keysAndValues, s.core)...)
+	}
 }
 
 // Warnf uses fmt.Sprintf to construct a dynamic message and logs it at
 // WarnLevel. It doesn't add to the message's structured context.
 func (s *SugaredLogger) Warnf(template string, args ...interface{}) {
-	s.Warn(fmt.Sprintf(template, args...))
+	if ce := s.core.Check(WarnLevel, fmt.Sprintf(template, args...)); ce != nil {
+		ce.Write()
+	}
 }
 
 // Error logs a message and some key-value pairs at ErrorLevel. Keys and values
 // are treated as they are in the With method.
 func (s *SugaredLogger) Error(msg interface{}, keysAndValues ...interface{}) {
-	s.core.Error(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+	if ce := s.core.Check(ErrorLevel, sweetenMsg(msg)); ce != nil {
+		ce.Write(sweetenFields(keysAndValues, s.core)...)
+	}
 }
 
 // Errorf uses fmt.Sprintf to construct a dynamic message and logs it at
 // ErrorLevel. It doesn't add to the message's structured context.
 func (s *SugaredLogger) Errorf(template string, args ...interface{}) {
-	s.Error(fmt.Sprintf(template, args...))
+	if ce := s.core.Check(ErrorLevel, fmt.Sprintf(template, args...)); ce != nil {
+		ce.Write()
+	}
+}
+
+// DPanic logs a message and some key-value pairs using the underlying logger's
+// DPanic method. Keys and values are treated as they are in the With
+// method. (See Logger.DPanic for details.)
+func (s *SugaredLogger) DPanic(msg interface{}, keysAndValues ...interface{}) {
+	if ce := s.core.Check(DPanicLevel, sweetenMsg(msg)); ce != nil {
+		ce.Write(sweetenFields(keysAndValues, s.core)...)
+	}
+}
+
+// DPanicf uses fmt.Sprintf to construct a dynamic message, which is passed to
+// the underlying Logger's DPanic method. (See Logger.DPanic for details.) It
+// doesn't add to the message's structured context.
+func (s *SugaredLogger) DPanicf(template string, args ...interface{}) {
+	if ce := s.core.Check(DPanicLevel, fmt.Sprintf(template, args...)); ce != nil {
+		ce.Write()
+	}
 }
 
 // Panic logs a message and some key-value pairs at PanicLevel, then panics.
 // Keys and values are treated as they are in the With method.
 func (s *SugaredLogger) Panic(msg interface{}, keysAndValues ...interface{}) {
-	s.core.Panic(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+	if ce := s.core.Check(PanicLevel, sweetenMsg(msg)); ce != nil {
+		ce.Write(sweetenFields(keysAndValues, s.core)...)
+	}
 }
 
 // Panicf uses fmt.Sprintf to construct a dynamic message and logs it at
 // PanicLevel, then panics. It doesn't add to the message's structured context.
 func (s *SugaredLogger) Panicf(template string, args ...interface{}) {
-	s.Panic(fmt.Sprintf(template, args...))
+	if ce := s.core.Check(PanicLevel, fmt.Sprintf(template, args...)); ce != nil {
+		ce.Write()
+	}
 }
 
 // Fatal logs a message and some key-value pairs at FatalLevel, then calls
 // os.Exit(1). Keys and values are treated as they are in the With method.
 func (s *SugaredLogger) Fatal(msg interface{}, keysAndValues ...interface{}) {
-	s.core.Fatal(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
+	if ce := s.core.Check(FatalLevel, sweetenMsg(msg)); ce != nil {
+		ce.Write(sweetenFields(keysAndValues, s.core)...)
+	}
 }
 
 // Fatalf uses fmt.Sprintf to construct a dynamic message and logs it at
 // FatalLevel, then calls os.Exit(1). It doesn't add to the message's
 // structured context.
 func (s *SugaredLogger) Fatalf(template string, args ...interface{}) {
-	s.Fatal(fmt.Sprintf(template, args...))
+	if ce := s.core.Check(FatalLevel, fmt.Sprintf(template, args...)); ce != nil {
+		ce.Write()
+	}
 }
 
-// DFatal logs a message and some key-value pairs using the underlying logger's
-// DFatal method. Keys and values are treated as they are in the With
-// method. (See Logger.DFatal for details.)
-func (s *SugaredLogger) DFatal(msg interface{}, keysAndValues ...interface{}) {
-	s.core.DFatal(sweetenMsg(msg), sweetenFields(keysAndValues, s.core)...)
-}
-
-// DFatalf uses fmt.Sprintf to construct a dynamic message, which is passed to
-// the underlying Logger's DFatal method. (See Logger.DFatal for details.) It
-// doesn't add to the message's structured context.
-func (s *SugaredLogger) DFatalf(template string, args ...interface{}) {
-	s.DFatal(fmt.Sprintf(template, args...))
-}
-
-func sweetenFields(args []interface{}, errLogger Logger) []Field {
+func sweetenFields(args []interface{}, errLogger Logger) []zapcore.Field {
 	if len(args) == 0 {
 		return nil
 	}
 	if len(args)%2 == 1 {
-		errLogger.DFatal(
-			"Passed an odd number of keys and values to SugaredLogger, ignoring last.",
-			Object("ignored", args[len(args)-1]),
-		)
+		errLogger.DPanic(oddNumberErrMsg, Any("ignored", args[len(args)-1]))
 	}
 
-	fields := make([]Field, len(args)/2)
+	fields := make([]zapcore.Field, len(args)/2)
 	for i := range fields {
 		key := sweetenMsg(args[2*i])
-
-		switch val := args[2*i+1].(type) {
-		case LogMarshaler:
-			fields[i] = Marshaler(key, val)
-		case bool:
-			fields[i] = Bool(key, val)
-		case float64:
-			fields[i] = Float64(key, val)
-		case float32:
-			fields[i] = Float64(key, float64(val))
-		case int:
-			fields[i] = Int(key, val)
-		case int64:
-			fields[i] = Int64(key, val)
-		case int32:
-			fields[i] = Int64(key, int64(val))
-		case int16:
-			fields[i] = Int64(key, int64(val))
-		case int8:
-			fields[i] = Int64(key, int64(val))
-		case uint:
-			fields[i] = Uint(key, val)
-		case uint64:
-			fields[i] = Uint64(key, val)
-		case uint32:
-			fields[i] = Uint64(key, uint64(val))
-		case uint16:
-			fields[i] = Uint64(key, uint64(val))
-		case uint8:
-			fields[i] = Uint64(key, uint64(val))
-		case uintptr:
-			fields[i] = Uintptr(key, val)
-		case string:
-			fields[i] = String(key, val)
-		case time.Time:
-			fields[i] = Time(key, val)
-		case time.Duration:
-			fields[i] = Duration(key, val)
-		case error:
-			fields[i] = String(key, val.Error())
-		case fmt.Stringer:
-			fields[i] = String(key, val.String())
-		default:
-			fields[i] = Object(key, val)
-		}
+		fields[i] = Any(key, args[2*i+1])
 	}
 	return fields
 }
 
 func sweetenMsg(msg interface{}) string {
-	if m, ok := msg.(string); ok {
-		return m
+	if str, ok := msg.(string); ok {
+		return str
 	}
 	return fmt.Sprint(msg)
 }

--- a/sugar.go
+++ b/sugar.go
@@ -66,7 +66,7 @@ func Desugar(s *SugaredLogger) Logger {
 //     Object("user", User{name: "alice"}),
 //   )
 func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
-	return &SugaredLogger{core: s.core.With(sweetenFields(args, s.core)...)}
+	return s.WithFields(sweetenFields(args, s.core)...)
 }
 
 // WithFields adds structured fields to the logger's context, just like the

--- a/sugar.go
+++ b/sugar.go
@@ -26,7 +26,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const oddNumberErrMsg = "Passed an odd number of keys and values to SugaredLogger, ignoring last."
+const _oddNumberErrMsg = "Passed an odd number of keys and values to SugaredLogger, ignoring last."
 
 // A SugaredLogger wraps the core Logger functionality in a slower, but less
 // verbose, API.
@@ -66,7 +66,7 @@ func Desugar(s *SugaredLogger) Logger {
 //     Object("user", User{name: "alice"}),
 //   )
 func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
-	return s.WithFields(sweetenFields(args, s.core)...)
+	return s.WithFields(s.sweetenFields(args)...)
 }
 
 // WithFields adds structured fields to the logger's context, just like the
@@ -79,7 +79,7 @@ func (s *SugaredLogger) WithFields(fs ...zapcore.Field) *SugaredLogger {
 // are treated as they are in the With method.
 func (s *SugaredLogger) Debug(msg interface{}, keysAndValues ...interface{}) {
 	if ce := s.core.Check(DebugLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(sweetenFields(keysAndValues, s.core)...)
+		ce.Write(s.sweetenFields(keysAndValues)...)
 	}
 }
 
@@ -95,7 +95,7 @@ func (s *SugaredLogger) Debugf(template string, args ...interface{}) {
 // are treated as they are in the With method.
 func (s *SugaredLogger) Info(msg interface{}, keysAndValues ...interface{}) {
 	if ce := s.core.Check(InfoLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(sweetenFields(keysAndValues, s.core)...)
+		ce.Write(s.sweetenFields(keysAndValues)...)
 	}
 }
 
@@ -111,7 +111,7 @@ func (s *SugaredLogger) Infof(template string, args ...interface{}) {
 // are treated as they are in the With method.
 func (s *SugaredLogger) Warn(msg interface{}, keysAndValues ...interface{}) {
 	if ce := s.core.Check(WarnLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(sweetenFields(keysAndValues, s.core)...)
+		ce.Write(s.sweetenFields(keysAndValues)...)
 	}
 }
 
@@ -127,7 +127,7 @@ func (s *SugaredLogger) Warnf(template string, args ...interface{}) {
 // are treated as they are in the With method.
 func (s *SugaredLogger) Error(msg interface{}, keysAndValues ...interface{}) {
 	if ce := s.core.Check(ErrorLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(sweetenFields(keysAndValues, s.core)...)
+		ce.Write(s.sweetenFields(keysAndValues)...)
 	}
 }
 
@@ -144,7 +144,7 @@ func (s *SugaredLogger) Errorf(template string, args ...interface{}) {
 // method. (See Logger.DPanic for details.)
 func (s *SugaredLogger) DPanic(msg interface{}, keysAndValues ...interface{}) {
 	if ce := s.core.Check(DPanicLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(sweetenFields(keysAndValues, s.core)...)
+		ce.Write(s.sweetenFields(keysAndValues)...)
 	}
 }
 
@@ -161,7 +161,7 @@ func (s *SugaredLogger) DPanicf(template string, args ...interface{}) {
 // Keys and values are treated as they are in the With method.
 func (s *SugaredLogger) Panic(msg interface{}, keysAndValues ...interface{}) {
 	if ce := s.core.Check(PanicLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(sweetenFields(keysAndValues, s.core)...)
+		ce.Write(s.sweetenFields(keysAndValues)...)
 	}
 }
 
@@ -177,7 +177,7 @@ func (s *SugaredLogger) Panicf(template string, args ...interface{}) {
 // os.Exit(1). Keys and values are treated as they are in the With method.
 func (s *SugaredLogger) Fatal(msg interface{}, keysAndValues ...interface{}) {
 	if ce := s.core.Check(FatalLevel, sweetenMsg(msg)); ce != nil {
-		ce.Write(sweetenFields(keysAndValues, s.core)...)
+		ce.Write(s.sweetenFields(keysAndValues)...)
 	}
 }
 
@@ -190,12 +190,12 @@ func (s *SugaredLogger) Fatalf(template string, args ...interface{}) {
 	}
 }
 
-func sweetenFields(args []interface{}, errLogger Logger) []zapcore.Field {
+func (s *SugaredLogger) sweetenFields(args []interface{}) []zapcore.Field {
 	if len(args) == 0 {
 		return nil
 	}
 	if len(args)%2 == 1 {
-		errLogger.DPanic(oddNumberErrMsg, Any("ignored", args[len(args)-1]))
+		s.core.DPanic(_oddNumberErrMsg, Any("ignored", args[len(args)-1]))
 	}
 
 	fields := make([]zapcore.Field, len(args)/2)

--- a/sugar_bench_test.go
+++ b/sugar_bench_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import "testing"
+
+func withBenchedSugar(b *testing.B, f func(Sugar)) {
+	logger := NewSugar(New(
+		NewJSONEncoder(),
+		DebugLevel,
+		DiscardOutput,
+	))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			f(logger)
+		}
+	})
+}
+
+func Benchmark10FieldsSugar(b *testing.B) {
+	withBenchedSugar(b, func(log Sugar) {
+		log.Info("Ten fields, passed at the log site.",
+			"one", 1,
+			"two", 2,
+			"three", 3,
+			"four", 4,
+			"five", 5,
+			"six", 6,
+			"seven", 7,
+			"eight", 8,
+			"nine", 9,
+			"ten", 10,
+		)
+	})
+}

--- a/sugar_bench_test.go
+++ b/sugar_bench_test.go
@@ -22,8 +22,8 @@ package zap
 
 import "testing"
 
-func withBenchedSugar(b *testing.B, f func(Sugar)) {
-	logger := NewSugar(New(
+func withBenchedSugar(b *testing.B, f func(*SugaredLogger)) {
+	logger := Sugar(New(
 		NewJSONEncoder(),
 		DebugLevel,
 		DiscardOutput,
@@ -37,8 +37,8 @@ func withBenchedSugar(b *testing.B, f func(Sugar)) {
 }
 
 func Benchmark10FieldsSugar(b *testing.B) {
-	withBenchedSugar(b, func(log Sugar) {
-		log.Info("Ten fields, passed at the log site.",
+	withBenchedSugar(b, func(logger *SugaredLogger) {
+		logger.Info("Ten fields, passed at the log site.",
 			"one", 1,
 			"two", 2,
 			"three", 3,

--- a/sugar_bench_test.go
+++ b/sugar_bench_test.go
@@ -42,7 +42,7 @@ func withBenchedSugar(b *testing.B, f func(*SugaredLogger)) {
 
 func Benchmark10FieldsSugar(b *testing.B) {
 	withBenchedSugar(b, func(logger *SugaredLogger) {
-		logger.Info("Ten fields, passed at the log site.",
+		logger.Infow("Ten fields, passed at the log site.",
 			"one", 1,
 			"two", 2,
 			"three", 3,

--- a/sugar_bench_test.go
+++ b/sugar_bench_test.go
@@ -20,14 +20,18 @@
 
 package zap
 
-import "testing"
+import (
+	"testing"
+
+	"go.uber.org/zap/testutils"
+	"go.uber.org/zap/zapcore"
+)
 
 func withBenchedSugar(b *testing.B, f func(*SugaredLogger)) {
-	logger := Sugar(New(
-		NewJSONEncoder(),
+	logger := Sugar(New(zapcore.WriterFacility(zapcore.NewJSONEncoder(defaultEncoderConfig()),
+		&testutils.Discarder{},
 		DebugLevel,
-		DiscardOutput,
-	))
+	)))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -46,6 +46,9 @@ func TestSugarGetSugarFields(t *testing.T) {
 	_, err = getSugarFields("test1", nil)
 	assert.Error(t, err, "Should return error on argument of unknown type")
 
+	_, err = getSugarFields("test1", 1, "error", errors.New(""))
+	assert.Error(t, err, "Should return error when error passed as value (special case of unknown type)")
+
 	_, err = getSugarFields(1, 1)
 	assert.Error(t, err, "Should return error on non-string field name")
 

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSugarGetSugarFields(t *testing.T) {
+	// logger := NewSugar(New(NewJSONEncoder()))
+	// assert.Error(t, logger.getFields("test"), )
+
+	var (
+		fields []Field
+		err    error
+	)
+
+	_, err = getSugarFields("test")
+	assert.Error(t, err, "Should return error on invalid number of arguments")
+
+	_, err = getSugarFields("test1", 1, "test2")
+	assert.Error(t, err, "Should return error on invalid number of arguments")
+
+	_, err = getSugarFields("test1", nil)
+	assert.Error(t, err, "Should return error on argument of unknown type")
+
+	_, err = getSugarFields(1, 1)
+	assert.Error(t, err, "Should return error on non-string field name")
+
+	fields, _ = getSugarFields("test", 1)
+	assert.Equal(t, 1, len(fields), "Should return 1 field")
+
+	fields, _ = getSugarFields("test1", 1, "test2", 2)
+	assert.Equal(t, 2, len(fields), "Should return 2 fields")
+}
+
+func withSugarLogger(t testing.TB, opts []Option, f func(Sugar, *testBuffer)) {
+	sink := &testBuffer{}
+	errSink := &testBuffer{}
+
+	allOpts := make([]Option, 0, 3+len(opts))
+	allOpts = append(allOpts, DebugLevel, Output(sink), ErrorOutput(errSink))
+	allOpts = append(allOpts, opts...)
+	logger := New(newJSONEncoder(NoTime()), allOpts...)
+	sugar := NewSugar(logger)
+
+	f(sugar, sink)
+}
+
+func TestSugarLog(t *testing.T) {
+	opts := opts(Fields(Int("foo", 42)))
+	withSugarLogger(t, opts, func(logger Sugar, buf *testBuffer) {
+		logger.Debug("debug message", "a", "b")
+		logger.Info("info message", "c", "d")
+		logger.Warn("warn message", "e", "f")
+		logger.Error("error message", "g", "h")
+		assert.Equal(t, []string{
+			`{"level":"debug","msg":"debug message","foo":42,"a":"b"}`,
+			`{"level":"info","msg":"info message","foo":42,"c":"d"}`,
+			`{"level":"warn","msg":"warn message","foo":42,"e":"f"}`,
+			`{"level":"error","msg":"error message","foo":42,"g":"h"}`,
+		}, buf.Lines(), "Incorrect output from logger")
+	})
+}
+
+func TestSugarWith(t *testing.T) {
+	opts := opts()
+	withSugarLogger(t, opts, func(logger Sugar, buf *testBuffer) {
+		child, _ := logger.With("a", "b")
+		child.Debug("debug message", "c", "d")
+		assert.Equal(t, []string{
+			`{"level":"debug","msg":"debug message","a":"b","c":"d"}`,
+		}, buf.Lines(), "Incorrect output from logger")
+	})
+}

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -145,6 +145,11 @@ func TestSugarDFatal(t *testing.T) {
 		assert.Equal(t, `{"level":"error","msg":"foo"}`, buf.Stripped(), "Unexpected output from dfatal")
 	})
 
+	withSugarLogger(t, nil, func(logger Sugar, buf *testBuffer) {
+		err := logger.DFatal("foo", "a")
+		assert.Error(t, err, "DFatal should fail with invalid arguments")
+	})
+
 	stub := stubExit()
 	defer stub.Unstub()
 	opts := opts(Development())

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -20,53 +20,9 @@
 
 package zap
 
-import (
-	"errors"
-	"testing"
-	"time"
+/* FIXME (shah): Update to match new APIs.
 
-	"github.com/stretchr/testify/assert"
-)
-
-func TestSugarGetSugarFields(t *testing.T) {
-	var (
-		fields []Field
-		err    error
-	)
-
-	_, err = getSugarFields("test")
-	assert.Error(t, err, "Should return error on invalid number of arguments")
-
-	_, err = getSugarFields("test1", 1, "test2")
-	assert.Error(t, err, "Should return error on invalid number of arguments")
-
-	_, err = getSugarFields("test1", 1, "error", errors.New(""))
-	assert.Error(t, err, "Should return error when error passed as value (special case of unknown type)")
-
-	_, err = getSugarFields(1, 1)
-	assert.Error(t, err, "Should return error on non-string field name")
-
-	fields, _ = getSugarFields("test", 1)
-	assert.Len(t, fields, 1, "Should return 1 field")
-
-	fields, _ = getSugarFields("test1", 1, "test2", 2)
-	assert.Len(t, fields, 2, "Should return 2 fields")
-
-	fields, _ = getSugarFields(errors.New("error"), "test1", 1)
-	assert.Len(t, fields, 2, "Should return 2 fields")
-}
-
-func TestSugarLevel(t *testing.T) {
-	assert.Equal(t, DebugLevel, NewSugar(New(NewJSONEncoder(), DebugLevel)).Level())
-	assert.Equal(t, FatalLevel, NewSugar(New(NewJSONEncoder(), FatalLevel)).Level())
-}
-
-func TestSugarSetLevel(t *testing.T) {
-	sugar := NewSugar(New(NewJSONEncoder()))
-	sugar.SetLevel(FatalLevel)
-	assert.Equal(t, FatalLevel, sugar.Level())
-}
-
+// FIXME: add tests for trailing keys in key-value pairs.
 func withSugarLogger(t testing.TB, opts []Option, f func(Sugar, *testBuffer, *testBuffer)) {
 	sink := &testBuffer{}
 	errSink := &testBuffer{}
@@ -224,3 +180,4 @@ func TestSugarWithErrors(t *testing.T) {
 		assert.Equal(t, "invalid number of arguments", err.Stripped(), "Should log invalid number of arguments")
 	})
 }
+*/

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -81,13 +81,13 @@ func withSugarLogger(t testing.TB, opts []Option, f func(Sugar, *testBuffer)) {
 }
 
 type m9e struct {
-	Foo int  `json:"foo"`
-	Bar bool `json:"bar"`
+	foo int
+	bar bool
 }
 
 func (m *m9e) MarshalLog(kv KeyValue) error {
-	kv.AddInt("foo", m.Foo)
-	kv.AddBool("bar", m.Bar)
+	kv.AddInt("foo", m.foo)
+	kv.AddBool("bar", m.bar)
 	return nil
 }
 

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -52,6 +53,9 @@ func TestSugarGetSugarFields(t *testing.T) {
 	assert.Equal(t, 1, len(fields), "Should return 1 field")
 
 	fields, _ = getSugarFields("test1", 1, "test2", 2)
+	assert.Equal(t, 2, len(fields), "Should return 2 fields")
+
+	fields, _ = getSugarFields(errors.New("error"), "test1", 1)
 	assert.Equal(t, 2, len(fields), "Should return 2 fields")
 }
 
@@ -118,6 +122,24 @@ func TestSugarLogTypes(t *testing.T) {
 			`{"level":"debug","msg":"","time":0}`,
 			`{"level":"debug","msg":"","duration":1000000000}`,
 			`{"level":"debug","msg":"","stringer":"debug"}`,
+		}, buf.Lines(), "Incorrect output from logger")
+	})
+}
+
+func TestSugarLogNoArgs(t *testing.T) {
+	withSugarLogger(t, nil, func(logger Sugar, buf *testBuffer) {
+		logger.Debug("no args message")
+		assert.Equal(t, []string{
+			`{"level":"debug","msg":"no args message"}`,
+		}, buf.Lines(), "Incorrect output from logger")
+	})
+}
+
+func TestSugarLogError(t *testing.T) {
+	withSugarLogger(t, nil, func(logger Sugar, buf *testBuffer) {
+		logger.Debug("with error", errors.New("this is a error"))
+		assert.Equal(t, []string{
+			`{"level":"debug","msg":"with error","error":"this is a error"}`,
 		}, buf.Lines(), "Incorrect output from logger")
 	})
 }

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -80,17 +80,6 @@ func withSugarLogger(t testing.TB, opts []Option, f func(Sugar, *testBuffer)) {
 	f(sugar, sink)
 }
 
-type m9e struct {
-	foo int
-	bar bool
-}
-
-func (m *m9e) MarshalLog(kv KeyValue) error {
-	kv.AddInt("foo", m.foo)
-	kv.AddBool("bar", m.bar)
-	return nil
-}
-
 func TestSugarLog(t *testing.T) {
 	opts := opts(Fields(Int("foo", 42)))
 	withSugarLogger(t, opts, func(logger Sugar, buf *testBuffer) {
@@ -120,7 +109,6 @@ func TestSugarLogTypes(t *testing.T) {
 		logger.Debug("", "time", time.Unix(0, 0))
 		logger.Debug("", "duration", time.Second)
 		logger.Debug("", "stringer", DebugLevel)
-		logger.Debug("", "marshaler", m9e{1, true})
 		logger.Debug("", "object", []string{"foo", "bar"})
 		assert.Equal(t, []string{
 			`{"level":"debug","msg":""}`,
@@ -134,7 +122,6 @@ func TestSugarLogTypes(t *testing.T) {
 			`{"level":"debug","msg":"","time":0}`,
 			`{"level":"debug","msg":"","duration":1000000000}`,
 			`{"level":"debug","msg":"","stringer":"debug"}`,
-			`{"level":"debug","msg":"","marshaler":{"foo":1,"bar":true}}`,
 			`{"level":"debug","msg":"","object":["foo","bar"]}`,
 		}, buf.Lines(), "Incorrect output from logger")
 	})

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -169,6 +169,14 @@ func TestSugarDFatal(t *testing.T) {
 	})
 }
 
+func TestSugarDFatalErrors(t *testing.T) {
+	opts := opts()
+	withSugarLogger(t, opts, func(logger Sugar, _ *testBuffer, err *testBuffer) {
+		logger.DFatal("foo", "bar")
+		assert.Equal(t, "invalid number of arguments", err.Stripped(), "Should log invalid number of arguments")
+	})
+}
+
 func TestSugarLogErrors(t *testing.T) {
 	withSugarLogger(t, nil, func(logger Sugar, out *testBuffer, err *testBuffer) {
 		logger.Log(InfoLevel, "foo", "a")

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -186,8 +186,20 @@ func TestSugarDFatal(t *testing.T) {
 }
 
 func TestSugarLogFails(t *testing.T) {
-	sugar := NewSugar(New(NewJSONEncoder()))
-	assert.Error(t, sugar.Log(DebugLevel, "message", "a"), "Should fail with invalid args")
+	withSugarLogger(t, nil, func(logger Sugar, buf *testBuffer) {
+		assert.Error(t, logger.Log(DebugLevel, "message", "a"), "Should fail with invalid args")
+	})
+}
+
+func TestSugarLogDiscards(t *testing.T) {
+	withSugarLogger(t, opts(InfoLevel), func(logger Sugar, buf *testBuffer) {
+		logger.Debug("should be discarded")
+		logger.Debug("should be discarded even with invalid arg count", "bla")
+		logger.Info("should be logged")
+		assert.Equal(t, []string{
+			`{"level":"info","msg":"should be logged"}`,
+		}, buf.Lines(), "")
+	})
 }
 
 func TestSugarWith(t *testing.T) {

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -64,21 +64,6 @@ func TestSugarWith(t *testing.T) {
 	}
 }
 
-func TestSugarWithFields(t *testing.T) {
-	tests := [][]zapcore.Field{
-		{},
-		{String("foo", "bar"), Int("baz", 42)},
-	}
-	for _, fields := range tests {
-		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
-			logger.WithFields(fields...).Info("")
-			output := logs.AllUntimed()
-			assert.Equal(t, 1, len(output), "Expected only one message to be logged.")
-			assert.Equal(t, fields, output[0].Context, "Unexpected message context.")
-		})
-	}
-}
-
 type stringerF func() string
 
 func (f stringerF) String() string { return f() }

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestSugarWith(t *testing.T) {
 	ignored := observer.LoggedEntry{
-		Entry:   zapcore.Entry{Level: DPanicLevel, Message: oddNumberErrMsg},
+		Entry:   zapcore.Entry{Level: DPanicLevel, Message: _oddNumberErrMsg},
 		Context: []zapcore.Field{Any("ignored", "should ignore")},
 	}
 


### PR DESCRIPTION
This PR carries forward the work that @akabos did in #147. Once complete, this will resolve #138.

Relevant benchmarks for logrus, the regular zap logger, and the sugared logger:

```
BenchmarkLogrusAddingFields-4                         	  100000	     10219 ns/op	    5726 B/op	      77 allocs/op
BenchmarkLogrusWithAccumulatedContext-4               	  200000	      7760 ns/op	    3919 B/op	      61 allocs/op
BenchmarkLogrusWithoutFields-4                        	 1000000	      2317 ns/op	    1321 B/op	      25 allocs/op

BenchmarkZapAddingFields-4                            	 1000000	      1287 ns/op	     768 B/op	       4 allocs/op
BenchmarkZapWithAccumulatedContext-4                  	 5000000	       341 ns/op	      64 B/op	       2 allocs/op
BenchmarkZapWithoutFields-4                           	 5000000	       363 ns/op	      64 B/op	       2 allocs/op

BenchmarkZapSugarAddingFields-4                       	  500000	      4160 ns/op	    1443 B/op	      36 allocs/op
BenchmarkZapSugarWithAccumulatedContext-4             	 3000000	       408 ns/op	      80 B/op	       3 allocs/op
BenchmarkZapSugarWithoutFields-4                      	 5000000	       400 ns/op	      80 B/op	       3 allocs/op
```

By these benchmarks, we're doing pretty well - the sugared logger is similar to logrus in developer ergonomics, but is much, much faster and lower-allocation. However, the sugared field-adding API does introduce quite a bit of allocation overhead.
