### PR TITLE
Error handling in output sync and AtomicLevel

### DIFF
--- a/http_handler.go
+++ b/http_handler.go
@@ -40,44 +40,42 @@ func (lvl AtomicLevel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Level *Level `json:"level"`
 	}
 
-	if err := func() error {
-		enc := json.NewEncoder(w)
-		switch r.Method {
+	enc := json.NewEncoder(w)
+	switch r.Method {
 
-		case "GET":
-			current := lvl.Level()
-			return enc.Encode(payload{Level: &current})
-
-		case "PUT":
-			var req payload
-			if errmess := func() string {
-				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-					return fmt.Sprintf("Request body must be well-formed JSON: %v", err)
-				}
-				if req.Level == nil {
-					return "Must specify a logging level."
-				}
-				return ""
-			}(); errmess != "" {
-				w.WriteHeader(http.StatusBadRequest)
-				return enc.Encode(errorResponse{Error: errmess})
-			}
-			lvl.SetLevel(*req.Level)
-			return enc.Encode(req)
-
-		default:
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			return enc.Encode(errorResponse{
-				Error: "Only GET and PUT are supported.",
-			})
+	case "GET":
+		current := lvl.Level()
+		if err := enc.Encode(payload{Level: &current}); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			io.WriteString(w, fmt.Sprintf("AtomicLevel.ServeHTTP internal error: %v", err))
 		}
-	}(); err != nil {
-		// an encoding error; TODO: it would be great if we had an intenal
-		// error reporting mechanism here.
-		w.WriteHeader(http.StatusInternalServerError)
-		// last ditch write to client, ignore any error (likely since an
-		// "encoding error" probably already was a repsonse io error)
-		_, _ = io.WriteString(w, fmt.Sprintf(
-			"AtomicLevel.ServeHTTP internal error: %v", err))
+
+	case "PUT":
+		var req payload
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			enc.Encode(errorResponse{
+				Error: fmt.Sprintf("Request body must be well-formed JSON: %v", err),
+			})
+			return
+		}
+		if req.Level == nil {
+			w.WriteHeader(http.StatusBadRequest)
+			enc.Encode(errorResponse{
+				Error: "Must specify a logging level.",
+			})
+			return
+		}
+		lvl.SetLevel(*req.Level)
+		if err := enc.Encode(req); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			io.WriteString(w, fmt.Sprintf("AtomicLevel.ServeHTTP internal error: %v", err))
+		}
+
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		enc.Encode(errorResponse{
+			Error: "Only GET and PUT are supported.",
+		})
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -146,6 +146,8 @@ func (log *logger) log(lvl Level, msg string, fields []Field) {
 
 	if lvl > ErrorLevel {
 		// Sync on Panic and Fatal, since they may crash the program.
-		log.Output.Sync()
+		if err := log.Output.Sync(); err != nil {
+			log.InternalError("sync", err)
+		}
 	}
 }


### PR DESCRIPTION
- noticed around recent `AtomicLevel.ServeHTTP` work
- the sync error is probably an unlikely edge case, but nice to have
- some of them were overly pedantic, so this just silences the warning