### PR TITLE
Move zap and atomic to go.uber.org and update vendor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.6
   - 1.7
   - tip
+go_import_path: go.uber.org/zap
 env:
   global:
     - GO15VENDOREXPERIMENT=1

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Blazing fast, structured, leveled logging in Go.
 
 ## Installation
-`go get -u github.com/uber-go/zap`
+`go get -u go.uber.org/zap`
 
 ## Structure
 
@@ -90,8 +90,8 @@ Released under the [MIT License](LICENSE.txt).
 benchmarking against slightly older versions of other libraries. Versions are
 pinned in zap's [glide.lock][] file. [↩](#anchor-versions)
 
-[doc-img]: https://godoc.org/github.com/uber-go/zap?status.svg
-[doc]: https://godoc.org/github.com/uber-go/zap
+[doc-img]: https://godoc.org/go.uber.org/zap?status.svg
+[doc]: https://godoc.org/go.uber.org/zap
 [ci-img]: https://travis-ci.org/uber-go/zap.svg?branch=master
 [ci]: https://travis-ci.org/uber-go/zap
 [cov-img]: https://coveralls.io/repos/github/uber-go/zap/badge.svg?branch=master

--- a/benchmarks/logrus_bench_test.go
+++ b/benchmarks/logrus_bench_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber-go/zap"
-	"github.com/uber-go/zap/zbark"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zbark"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/uber-common/bark"

--- a/benchmarks/stdlib_bench_test.go
+++ b/benchmarks/stdlib_bench_test.go
@@ -25,8 +25,8 @@ import (
 	"log"
 	"testing"
 
-	"github.com/uber-go/zap"
-	"github.com/uber-go/zap/zwrap"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zwrap"
 )
 
 func BenchmarkStandardLibraryWithoutFields(b *testing.B) {

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber-go/zap"
-	"github.com/uber-go/zap/zwrap"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zwrap"
 )
 
 var errExample = errors.New("fail")

--- a/checked_message_bench_test.go
+++ b/checked_message_bench_test.go
@@ -23,7 +23,7 @@ package zap
 import (
 	"testing"
 
-	"github.com/uber-go/atomic"
+	"go.uber.org/atomic"
 )
 
 func benchmarkLoggers(levels []Level, options ...Option) []Logger {

--- a/example_test.go
+++ b/example_test.go
@@ -27,7 +27,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 func Example() {

--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,18 @@
-hash: 8aeb29a35adb31f8b46a792ae1b304c2c55f2d10bfe0ca1a4b8ac5330e22decc
-updated: 2016-11-09T16:14:48.657534669+09:00
+hash: 4cc8fc30ee17b2d6c783a0daf74a1140c9cabc209be57a701505660674f212cc
+updated: 2016-12-08T18:23:01.675037107+01:00
 imports:
 - name: github.com/cactus/go-statsd-client
   version: d8eabe07bc70ff9ba6a56836cde99d1ea3d005f7
   subpackages:
   - statsd
 - name: github.com/Sirupsen/logrus
-  version: 1445b7a38228c041834afc69231b7966b9943397
+  version: 881bee4e20a5d11a6a88a5667c6f292072ac1963
 - name: github.com/uber-common/bark
   version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
-- name: github.com/uber-go/atomic
+- name: go.uber.org/atomic
   version: 9e99152552a6ce13fa3b2ce4a9c4fb117cca4506
 - name: golang.org/x/sys
-  version: 9a2e24c3733eddc63871eda99f253e2db29bd3b9
+  version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
   subpackages:
   - unix
 testImports:
@@ -21,23 +21,23 @@ testImports:
   subpackages:
   - handlers/json
 - name: github.com/axw/gocov
-  version: 54b98cfcac0c63fb3f9bd8e7ad241b724d4e985b
+  version: c77561ca0c0cb1ed5d4ce4a912a75f5532566422
   subpackages:
   - gocov
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/go-kit/kit
-  version: 9f5c614cd1e70102f80b644edbc760805ebf16d5
+  version: 0d6c91c61a1b3ac2467facd58a06fe89fd34aa3c
   subpackages:
   - log
 - name: github.com/go-logfmt/logfmt
-  version: d4327190ff838312623b09bfeb50d7c93c8d9c1d
+  version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
 - name: github.com/go-stack/stack
   version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
 - name: github.com/golang/lint
-  version: 3390df4df2787994aea98de825b964ac7944b817
+  version: 206c0f020eba0f7fbcfbc467a5eb808037df2ed6
   subpackages:
   - golint
 - name: github.com/kr/logfmt
@@ -45,22 +45,22 @@ testImports:
 - name: github.com/mattn/go-colorable
   version: d228849504861217f796da67fae4f6e347643f15
 - name: github.com/mattn/go-isatty
-  version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
+  version: 30a891c33c7cde7b02a981314b4228ec99380cca
 - name: github.com/mattn/goveralls
   version: a63d65fe590e2c830e60ad260cde6755ce3482a5
 - name: github.com/pborman/uuid
-  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+  version: 5007efa264d92316c43112bc573e754bc889b7b1
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
+  version: 18a02ba4a312f95da08ff4cfc0055750ce50ae9e
   subpackages:
   - assert
   - require
 - name: golang.org/x/tools
-  version: 44b4c5d044d148f4248b0188ff5ea3e57cfedbc5
+  version: 3d92dd60033c312e3ae7cac319c792271cf67e37
   subpackages:
   - cover
 - name: gopkg.in/inconshreveable/log15.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,8 +1,8 @@
-package: github.com/uber-go/zap
+package: go.uber.org/zap
 license: MIT
 import:
 - package: github.com/uber-common/bark
-- package: github.com/uber-go/atomic
+- package: go.uber.org/atomic
 testImport:
 - package: github.com/Sirupsen/logrus
 - package: github.com/apex/log

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -30,8 +30,8 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/uber-go/zap"
-	"github.com/uber-go/zap/spy"
+	. "go.uber.org/zap"
+	"go.uber.org/zap/spy"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -30,7 +30,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber-go/zap/spywrite"
+	"go.uber.org/zap/spywrite"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/level.go
+++ b/level.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/uber-go/atomic"
+	"go.uber.org/atomic"
 )
 
 var errMarshalNilLevel = errors.New("can't marshal a nil *Level to text")

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 type user struct {

--- a/logger_test.go
+++ b/logger_test.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/uber-go/zap/spywrite"
+	"go.uber.org/zap/spywrite"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/marshaler_example_test.go
+++ b/marshaler_example_test.go
@@ -23,7 +23,7 @@ package zap_test
 import (
 	"time"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 type Auth struct {

--- a/spy/logger.go
+++ b/spy/logger.go
@@ -23,7 +23,7 @@ package spy
 import (
 	"sync"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 // A Log is an encoding-agnostic representation of a log message.

--- a/tee_test.go
+++ b/tee_test.go
@@ -23,8 +23,8 @@ package zap_test
 import (
 	"testing"
 
-	"github.com/uber-go/zap"
-	"github.com/uber-go/zap/spy"
+	"go.uber.org/zap"
+	"go.uber.org/zap/spy"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/test_logger_bench_test.go
+++ b/test_logger_bench_test.go
@@ -23,7 +23,7 @@ package zap_test
 import (
 	"testing"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 func withBenchedTee(b *testing.B, f func(zap.Logger)) {

--- a/text_encoder_test.go
+++ b/text_encoder_test.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber-go/zap/spywrite"
+	"go.uber.org/zap/spywrite"
 )
 
 func newTextEncoder(opts ...TextOption) *textEncoder {

--- a/writer_test.go
+++ b/writer_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber-go/zap/spywrite"
+	"go.uber.org/zap/spywrite"
 )
 
 func requireWriteWorks(t testing.TB, ws WriteSyncer) {

--- a/zbark/bark.go
+++ b/zbark/bark.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 
 	"github.com/uber-common/bark"
 )

--- a/zbark/bark_test.go
+++ b/zbark/bark_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-common/bark"

--- a/zbark/debark.go
+++ b/zbark/debark.go
@@ -23,8 +23,8 @@ package zbark
 import (
 	"fmt"
 
-	"github.com/uber-go/zap"
-	"github.com/uber-go/zap/zwrap"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zwrap"
 
 	"github.com/uber-common/bark"
 )

--- a/zbark/debark_test.go
+++ b/zbark/debark_test.go
@@ -24,7 +24,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"

--- a/zbark/example_test.go
+++ b/zbark/example_test.go
@@ -23,8 +23,8 @@ package zbark_test
 import (
 	"os"
 
-	"github.com/uber-go/zap"
-	"github.com/uber-go/zap/zbark"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zbark"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/uber-common/bark"

--- a/zwrap/example_test.go
+++ b/zwrap/example_test.go
@@ -23,8 +23,8 @@ package zwrap_test
 import (
 	"time"
 
-	"github.com/uber-go/zap"
-	"github.com/uber-go/zap/zwrap"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zwrap"
 )
 
 func Example_standardize() {

--- a/zwrap/kvmap.go
+++ b/zwrap/kvmap.go
@@ -20,7 +20,7 @@
 
 package zwrap
 
-import "github.com/uber-go/zap"
+import "go.uber.org/zap"
 
 // KeyValueMap implements zap.KeyValue backed by a map.
 type KeyValueMap map[string]interface{}

--- a/zwrap/kvmap_test.go
+++ b/zwrap/kvmap_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 type unloggable struct{}

--- a/zwrap/sample.go
+++ b/zwrap/sample.go
@@ -24,9 +24,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/uber-go/zap"
-
-	"github.com/uber-go/atomic"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
 )
 
 type counters struct {

--- a/zwrap/sample_test.go
+++ b/zwrap/sample_test.go
@@ -25,9 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber-go/zap"
-	"github.com/uber-go/zap/spy"
-	"github.com/uber-go/zap/testutils"
+	"go.uber.org/zap"
+	"go.uber.org/zap/spy"
+	"go.uber.org/zap/testutils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/zwrap/standard.go
+++ b/zwrap/standard.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 )
 
 // ErrInvalidLevel indicates that the user chose an invalid Level when

--- a/zwrap/standard_test.go
+++ b/zwrap/standard_test.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/uber-go/zap"
+	"go.uber.org/zap"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
https://github.com/uber-go/zap/issues/203
