### PR TITLE
Add the LevelEnablerFunc and test case

### DIFF
--- a/level.go
+++ b/level.go
@@ -72,6 +72,16 @@ const (
 	FatalLevel
 )
 
+// LevelEnablerFunc is a convenient way to implement LevelEnabler around an
+// anonymous function. It is also a valid Option to pass to a logger.
+type LevelEnablerFunc func(Level) bool
+
+// This allows an LevelEnablerFunc to be used as an option.
+func (f LevelEnablerFunc) apply(m *Meta) { m.LevelEnabler = f }
+
+// Enabled calls the wrapped function.
+func (f LevelEnablerFunc) Enabled(lvl Level) bool { return f(lvl) }
+
 // String returns a lower-case ASCII representation of the log level.
 func (l Level) String() string {
 	switch l {

--- a/level_test.go
+++ b/level_test.go
@@ -21,10 +21,24 @@
 package zap
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestLevelEnablerFunc(t *testing.T) {
+	//testing for the level enabler, I will generate a logger with the given
+	//level and it should be print out
+	opts := []Option{Fields(Int("foo", 42)), LevelEnablerFunc(func(l Level) bool { return l == DebugLevel })}
+	withJSONLogger(t, opts, func(log Logger, buf *testBuffer) {
+		log.Debug("@debug", Int("logger", 0))
+		log.Info("@info", Int("logger", 0))
+		assert.Equal(t, []string{
+			`{"level":"debug","msg":"@debug","foo":42,"logger":0}`,
+		}, strings.Split(buf.Stripped(), "\n"))
+	})
+}
 
 func TestLevelString(t *testing.T) {
 	tests := map[Level]string{

--- a/level_test.go
+++ b/level_test.go
@@ -21,22 +21,19 @@
 package zap
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLevelEnablerFunc(t *testing.T) {
-	//testing for the level enabler, I will generate a logger with the given
-	//level and it should be print out
 	opts := []Option{Fields(Int("foo", 42)), LevelEnablerFunc(func(l Level) bool { return l == DebugLevel })}
 	withJSONLogger(t, opts, func(log Logger, buf *testBuffer) {
 		log.Debug("@debug", Int("logger", 0))
 		log.Info("@info", Int("logger", 0))
 		assert.Equal(t, []string{
 			`{"level":"debug","msg":"@debug","foo":42,"logger":0}`,
-		}, strings.Split(buf.Stripped(), "\n"))
+		}, buf.Lines())
 	})
 }
 


### PR DESCRIPTION
This PR added the LevelEnablerFunc to give a convenient way creatng a LevelEnabler.
I have tried to give the test case to make sure it could be covered
#205 #201 
Hope it can help!

- [x] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [x] added tests to cover your changes;
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).
