### PR TITLE
Fix README references to github.com/uber-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pinned in zap's [glide.lock][] file. [↩](#anchor-versions)
 [ci]: https://travis-ci.org/uber-go/zap
 [cov-img]: https://coveralls.io/repos/github/uber-go/zap/badge.svg?branch=master
 [cov]: https://coveralls.io/github/uber-go/zap?branch=master
-[benchmarking suite]: https://github.com/uber-go/zap/tree/master/benchmarks
-[glide.lock]: https://github.com/uber-go/zap/blob/master/glide.lock
-[bark]: https://github.com/uber-common/bark
-[v1]: https://github.com/uber-go/zap/projects/1
+[benchmarking suite]: https://go.uber.org/zap/tree/master/benchmarks
+[glide.lock]: https://go.uber.org/zap/blob/master/glide.lock
+[bark]: https://go.uber.org/bark
+[v1]: https://go.uber.org/zap/projects/1


### PR DESCRIPTION
Missed by #206; no other hits on `git grep github.com/uber-go`.