### PR TITLE
Avoid useless spaces in text encoder on blank message

### DIFF
--- a/text_encoder.go
+++ b/text_encoder.go
@@ -194,8 +194,10 @@ func (enc *textEncoder) addTime(final *textEncoder, t time.Time) {
 }
 
 func (enc *textEncoder) addMessage(final *textEncoder, msg string) {
-	final.bytes = append(final.bytes, ' ')
-	final.bytes = append(final.bytes, msg...)
+	if msg != "" {
+		final.bytes = append(final.bytes, ' ')
+		final.bytes = append(final.bytes, msg...)
+	}
 }
 
 // A TextOption is used to set options for a text encoder.


### PR DESCRIPTION
Before opening your pull request, please make sure that you've:

- [x] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [ ] added tests to cover your changes;
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).

Thanks for your contribution!

