### PR TITLE
Implement flag.{Value,Getter} for zap.Level

### DIFF
--- a/level.go
+++ b/level.go
@@ -141,6 +141,34 @@ func (l *Level) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// Set sets the level for the flag.Value interface.
+func (l *Level) Set(s string) error {
+	switch string(s) {
+	case "debug":
+		*l = DebugLevel
+	case "info":
+		*l = InfoLevel
+	case "warn":
+		*l = WarnLevel
+	case "error":
+		*l = ErrorLevel
+	case "dpanic":
+		*l = DPanicLevel
+	case "panic":
+		*l = PanicLevel
+	case "fatal":
+		*l = FatalLevel
+	default:
+		return fmt.Errorf("unrecognized level: %q", s)
+	}
+	return nil
+}
+
+// Get gets the level for the flag.Getter interface.
+func (l *Level) Get() interface{} {
+	return *l
+}
+
 // Enabled returns true if the given level is at or above this level.
 func (l Level) Enabled(lvl Level) bool {
 	return lvl >= l

--- a/level.go
+++ b/level.go
@@ -143,7 +143,7 @@ func (l *Level) UnmarshalText(text []byte) error {
 
 // Set sets the level for the flag.Value interface.
 func (l *Level) Set(s string) error {
-	switch string(s) {
+	switch s {
 	case "debug":
 		*l = DebugLevel
 	case "info":

--- a/level_test.go
+++ b/level_test.go
@@ -21,6 +21,9 @@
 package zap
 
 import (
+	"bytes"
+	"flag"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,4 +104,54 @@ func TestLevelUnmarshalUnknownText(t *testing.T) {
 	var l Level
 	err := l.UnmarshalText([]byte("foo"))
 	assert.Contains(t, err.Error(), "unrecognized level", "Expected unmarshaling arbitrary text to fail.")
+}
+
+func TestLevelAsFlagValue(t *testing.T) {
+	var (
+		lvl Level
+		buf bytes.Buffer
+	)
+
+	fs := flag.NewFlagSet("levelTest", flag.ContinueOnError)
+	fs.SetOutput(&buf)
+	fs.Var(&lvl, "level", "a log level")
+
+	// zero default isn't visible
+	fs.PrintDefaults()
+	assert.Equal(t, []string{
+		"  -level value",
+		"    \ta log level",
+		"",
+	}, strings.Split(buf.String(), "\n"), "expected zero default to not show")
+	buf.Reset()
+
+	// changing works
+	assert.Equal(t, InfoLevel, lvl)
+	assert.NoError(t, fs.Parse([]string{"-level", "warn"}))
+	assert.Equal(t, WarnLevel, lvl)
+	assert.NoError(t, fs.Parse([]string{"-level", "debug"}))
+	assert.Equal(t, DebugLevel, lvl)
+
+	// non-zero default
+	fs = flag.NewFlagSet("levelTest", flag.ContinueOnError)
+	fs.SetOutput(&buf)
+	fs.Var(&lvl, "level", "a log level")
+	fs.PrintDefaults()
+	assert.Equal(t, []string{
+		"  -level value",
+		"    \ta log level (default debug)",
+		"",
+	}, strings.Split(buf.String(), "\n"), "expected non-zero default to show")
+	buf.Reset()
+
+	// errors work
+	assert.Error(t, fs.Parse([]string{"-level", "nope"}))
+	assert.Equal(t, []string{
+		`invalid value "nope" for flag -level: unrecognized level: "nope"`,
+		"Usage of levelTest:",
+		"  -level value",
+		"    \ta log level (default debug)",
+		"",
+	}, strings.Split(buf.String(), "\n"), "expected error output")
+	buf.Reset()
 }

--- a/level_test.go
+++ b/level_test.go
@@ -116,15 +116,6 @@ func TestLevelAsFlagValue(t *testing.T) {
 	fs.SetOutput(&buf)
 	fs.Var(&lvl, "level", "a log level")
 
-	// zero default isn't visible
-	fs.PrintDefaults()
-	assert.Equal(t, []string{
-		"  -level value",
-		"    \ta log level",
-		"",
-	}, strings.Split(buf.String(), "\n"), "expected zero default to not show")
-	buf.Reset()
-
 	// changing works
 	assert.Equal(t, InfoLevel, lvl)
 	assert.NoError(t, fs.Parse([]string{"-level", "warn"}))
@@ -132,26 +123,11 @@ func TestLevelAsFlagValue(t *testing.T) {
 	assert.NoError(t, fs.Parse([]string{"-level", "debug"}))
 	assert.Equal(t, DebugLevel, lvl)
 
-	// non-zero default
-	fs = flag.NewFlagSet("levelTest", flag.ContinueOnError)
-	fs.SetOutput(&buf)
-	fs.Var(&lvl, "level", "a log level")
-	fs.PrintDefaults()
-	assert.Equal(t, []string{
-		"  -level value",
-		"    \ta log level (default debug)",
-		"",
-	}, strings.Split(buf.String(), "\n"), "expected non-zero default to show")
-	buf.Reset()
-
 	// errors work
 	assert.Error(t, fs.Parse([]string{"-level", "nope"}))
-	assert.Equal(t, []string{
+	assert.Equal(t,
 		`invalid value "nope" for flag -level: unrecognized level: "nope"`,
-		"Usage of levelTest:",
-		"  -level value",
-		"    \ta log level (default debug)",
-		"",
-	}, strings.Split(buf.String(), "\n"), "expected error output")
+		strings.Split(buf.String(), "\n")[0],
+		"expected error output")
 	buf.Reset()
 }


### PR DESCRIPTION
This makes it easy to add a `flag.Var` to control a program's log level.