### PR TITLE
export the _callerSkip to make AddCaller user can change the skip manually

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -32,7 +32,7 @@ var (
 	errCaller       = errors.New("failed to get caller")
 	// Skip Caller, Logger.log, and the leveled Logger method when using
 	// runtime.Caller.
-	_callerSkip = 4
+	CallerSkip = 4
 )
 
 // A Hook is executed each time the logger writes an Entry. It can modify the
@@ -55,7 +55,7 @@ func AddCaller() Option {
 		if e == nil {
 			return errHookNilEntry
 		}
-		_, filename, line, ok := runtime.Caller(_callerSkip)
+		_, filename, line, ok := runtime.Caller(CallerSkip)
 		if !ok {
 			return errCaller
 		}

--- a/hook_test.go
+++ b/hook_test.go
@@ -41,9 +41,9 @@ func TestHookAddCallerFail(t *testing.T) {
 	buf := &testBuffer{}
 	errBuf := &testBuffer{}
 
-	originalSkip := _callerSkip
-	_callerSkip = 1e3
-	defer func() { _callerSkip = originalSkip }()
+	originalSkip := CallerSkip
+	CallerSkip = 1e3
+	defer func() { CallerSkip = originalSkip }()
 
 	logger := New(NewJSONEncoder(), DebugLevel, Output(buf), ErrorOutput(errBuf), AddCaller())
 	logger.Info("Failure.")


### PR DESCRIPTION
export the _callerSkip for user to change the skip manually

- [*] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [*] added tests to cover your changes;
- [*] run the test suite locally (`make test`); and finally,
- [*] run the linters locally (`make lint`).