### PR TITLE
Refactor internal error handling

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -154,8 +154,6 @@ func (ce *CheckedEntry) Write(fields ...Field) {
 	case WriteThenPanic:
 		panic(msg)
 	}
-
-	return
 }
 
 // AddFacility adds a facility that has agreed to log this entry. It's intended

--- a/logger.go
+++ b/logger.go
@@ -143,6 +143,8 @@ func (log *logger) Check(lvl Level, msg string) *CheckedEntry {
 		return ce
 	}
 
+	ce.ErrorOutput = log.errorOutput
+
 	if log.addCaller {
 		ce.Entry.Caller = MakeEntryCaller(runtime.Caller(log.callerSkip))
 		if !ce.Entry.Caller.Defined {
@@ -168,9 +170,7 @@ func (log *logger) Fatal(msg string, fields ...Field)  { log.Log(FatalLevel, msg
 
 func (log *logger) Log(lvl Level, msg string, fields ...Field) {
 	if ce := log.Check(lvl, msg); ce != nil {
-		if err := ce.Write(fields...); err != nil {
-			log.InternalError("write", err)
-		}
+		ce.Write(fields...)
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -21,7 +21,6 @@
 package zap
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -31,7 +30,6 @@ import (
 var (
 	_exit              = os.Exit // for tests
 	_defaultCallerSkip = 3       // for logger.callerSkip
-	errCaller          = errors.New("failed to get caller")
 )
 
 // A Logger enables leveled, structured logging. All methods are safe for
@@ -148,7 +146,8 @@ func (log *logger) Check(lvl Level, msg string) *CheckedEntry {
 	if log.addCaller {
 		ce.Entry.Caller = MakeEntryCaller(runtime.Caller(log.callerSkip))
 		if !ce.Entry.Caller.Defined {
-			log.InternalError("addCaller", errCaller)
+			fmt.Fprintf(log.errorOutput, "%v addCaller error: failed to get caller\n", time.Now().UTC())
+			log.errorOutput.Sync()
 		}
 	}
 
@@ -172,14 +171,6 @@ func (log *logger) Log(lvl Level, msg string, fields ...Field) {
 	if ce := log.Check(lvl, msg); ce != nil {
 		ce.Write(fields...)
 	}
-}
-
-// InternalError prints an internal error message to the configured
-// ErrorOutput. This method should only be used to report internal logger
-// problems and should not be used to report user-caused problems.
-func (log *logger) InternalError(cause string, err error) {
-	fmt.Fprintf(log.errorOutput, "%v %s error: %v\n", time.Now().UTC(), cause, err)
-	log.errorOutput.Sync()
 }
 
 // Facility returns the destination that logs entries are written to.


### PR DESCRIPTION
- handle write errors in CheckedEntry (which is the only remaining write path since we simplified logger over its own Check method)
- de-generic-ify the remaining logger  internal error case for caller adding

This introduces a regrettable API asymmetry:
- fac.Write returns an error
- but fac.Check().Write() eats it

I think we should go further (eventually or in this pr to reviewers' taste), but I haven't found a compelling path yet... something around:
- maybe we should have `type CheckedMessage struct {*CheckedEntry; ErrorOutput WriteSyncer}` and that's what the [Ll]ogger level uses... but then we have to also pool those separately in addition to...
- maybe `(*CheckedEntry).Write` should still return an error, but only if `ErrorOutput` is nil?

Fixes #223 