### PR TITLE
Add xlog to benchmark

### DIFF
--- a/benchmarks/xlog_bench_test.go
+++ b/benchmarks/xlog_bench_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmarks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/xlog"
+)
+
+func newXlog(additionalFields xlog.F) xlog.Logger {
+	conf := xlog.Config{
+		Level:  xlog.LevelDebug,
+		Output: xlog.Discard,
+	}
+	if len(additionalFields) > 0 {
+		conf.Fields = additionalFields
+	}
+	return xlog.New(conf)
+}
+
+func BenchmarkXlogAddingFields(b *testing.B) {
+	logger := newXlog(nil)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go fast.", xlog.F{
+				"int":               1,
+				"int64":             int64(1),
+				"float":             3.0,
+				"string":            "four!",
+				"bool":              true,
+				"time":              time.Unix(0, 0),
+				"error":             errExample.Error(),
+				"duration":          time.Second,
+				"user-defined type": _jane,
+				"another string":    "done!",
+			})
+		}
+	})
+}
+
+func BenchmarkXlogWithAccumulatedContext(b *testing.B) {
+	logger := newXlog(xlog.F{
+		"int":               1,
+		"int64":             int64(1),
+		"float":             3.0,
+		"string":            "four!",
+		"bool":              true,
+		"time":              time.Unix(0, 0),
+		"error":             errExample.Error(),
+		"duration":          time.Second,
+		"user-defined type": _jane,
+		"another string":    "done!",
+	})
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go really fast.")
+		}
+	})
+}
+
+func BenchmarkXlogWithoutFields(b *testing.B) {
+	logger := newXlog(nil)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go fast.")
+		}
+	})
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,34 @@
-hash: 4cc8fc30ee17b2d6c783a0daf74a1140c9cabc209be57a701505660674f212cc
-updated: 2016-12-08T18:23:01.675037107+01:00
+hash: 83e854052288e4a1cec48cfb84f10ab72abc0fd775dad65265ae374825992d75
+updated: 2017-01-06T20:27:51.354639162+03:00
 imports:
 - name: github.com/cactus/go-statsd-client
   version: d8eabe07bc70ff9ba6a56836cde99d1ea3d005f7
   subpackages:
   - statsd
+- name: github.com/rs/xlog
+  version: ee33a676e5f4bbda5b80dace72043f7e3b61ebda
+  subpackages:
+  - internal/term
 - name: github.com/Sirupsen/logrus
   version: 881bee4e20a5d11a6a88a5667c6f292072ac1963
 - name: github.com/uber-common/bark
   version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
+- name: github.com/uber-go/atomic
+  version: 9e99152552a6ce13fa3b2ce4a9c4fb117cca4506
+- name: github.com/uber-go/zap
+  version: a5783ee4b216a927da8f839c45cfbf9d694e1467
+  subpackages:
+  - zwrap
 - name: go.uber.org/atomic
   version: 9e99152552a6ce13fa3b2ce4a9c4fb117cca4506
+- name: go.uber.org/zap
+  version: a5783ee4b216a927da8f839c45cfbf9d694e1467
+  subpackages:
+  - zwrap
+  - spywrite
+  - zbark
+  - spy
+  - testutils
 - name: golang.org/x/sys
   version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
   subpackages:
@@ -54,11 +72,21 @@ testImports:
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/rs/xhandler
+  version: ed27b6fd65218132ee50cd95f38474a3d8a2cd12
+- name: github.com/rs/xid
+  version: 7ad1944187bff4393fd47fd2b786ef24bc268d98
+- name: github.com/Sirupsen/logrus
+  version: 881bee4e20a5d11a6a88a5667c6f292072ac1963
 - name: github.com/stretchr/testify
   version: 18a02ba4a312f95da08ff4cfc0055750ce50ae9e
   subpackages:
   - assert
   - require
+- name: golang.org/x/net
+  version: 905989bd20b7c354fd28a61074eed1c8f49ebc89
+  subpackages:
+  - context
 - name: golang.org/x/tools
   version: 3d92dd60033c312e3ae7cac319c792271cf67e37
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,7 @@ license: MIT
 import:
 - package: github.com/uber-common/bark
 - package: go.uber.org/atomic
+- package: github.com/rs/xlog
 testImport:
 - package: github.com/Sirupsen/logrus
 - package: github.com/apex/log
@@ -21,7 +22,6 @@ testImport:
 - package: golang.org/x/tools
   subpackages:
   - cover
-- package: golang.org/x/tools/cover
 - package: github.com/golang/lint
   subpackages:
   - golint


### PR DESCRIPTION
Added to dev branch github.com.rs/xlog for benchmarking
result of benchmarki you can see on  [bench_out.txt](https://github.com/uber-go/zap/files/690408/bench_out.txt)


-----
Before opening your pull request, please make sure that you've:

- [x] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [x] added tests to cover your changes; (not needed - because all changes already in _test.go file)
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).

Thanks for your contribution!
