### PR TITLE
Initial support for arrays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export GO15VENDOREXPERIMENT=1
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 PKGS ?= $(shell glide novendor)
 # Many Go tools take file globs or directories as arguments instead of packages.
-PKG_FILES ?= *.go zapcore benchmarks testutils internal/buffers internal/exit
+PKG_FILES ?= *.go zapcore benchmarks testutils internal/buffers internal/exit internal/multierror
 
 # The linting tools evolve with each Go version, so run them only on the latest
 # stable release.

--- a/array.go
+++ b/array.go
@@ -20,56 +20,18 @@
 
 package zap
 
-import (
-	"go.uber.org/zap/internal/multierror"
-	"go.uber.org/zap/zapcore"
-)
+import "go.uber.org/zap/zapcore"
 
-// TODO: actually add an example showing off how to use these wrappers with the
-// Array field constructor.
-
-// Arrays wraps a slice of ArrayMarshalers so that it satisfies the
-// ArrayMarshaler interface. See the Array function for a usage example.
-func Arrays(as []zapcore.ArrayMarshaler) zapcore.ArrayMarshaler {
-	return arrayMarshalers(as)
+// Array constructs a field with the given key and ArrayMarshaler. It provides
+// a flexible, but still type-safe and efficient, way to add array-like types
+// to the logging context. The struct's MarshalLogArray method is called lazily.
+func Array(key string, val zapcore.ArrayMarshaler) zapcore.Field {
+	return zapcore.Field{Key: key, Type: zapcore.ArrayMarshalerType, Interface: val}
 }
 
-// Objects wraps a slice of ObjectMarshalers so that it satisfies the
-// ArrayMarshaler interface. See the Array function for a usage example.
-func Objects(os []zapcore.ObjectMarshaler) zapcore.ArrayMarshaler {
-	return objectMarshalers(os)
-}
-
-// Bools wraps a slice of bools so that it satisfies the ArrayMarshaler
-// interface. See the Array function for a usage example.
-func Bools(bs []bool) zapcore.ArrayMarshaler {
-	return bools(bs)
-}
-
-type arrayMarshalers []zapcore.ArrayMarshaler
-
-func (as arrayMarshalers) MarshalLogArray(arr zapcore.ArrayEncoder) error {
-	var errs *multierror.Error
-	for i := range as {
-		if as[i] == nil {
-			continue
-		}
-		errs = errs.Append(arr.AppendArray(as[i]))
-	}
-	return errs.AsError()
-}
-
-type objectMarshalers []zapcore.ObjectMarshaler
-
-func (os objectMarshalers) MarshalLogArray(arr zapcore.ArrayEncoder) error {
-	var errs *multierror.Error
-	for i := range os {
-		if os[i] == nil {
-			continue
-		}
-		errs = errs.Append(arr.AppendObject(os[i]))
-	}
-	return errs.AsError()
+// Bools constructs a field that carries a slice of bools.
+func Bools(key string, bs []bool) zapcore.Field {
+	return Array(key, bools(bs))
 }
 
 type bools []bool

--- a/array.go
+++ b/array.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"go.uber.org/zap/internal/multierror"
+	"go.uber.org/zap/zapcore"
+)
+
+// TODO: actually add an example showing off how to use these wrappers with the
+// Array field constructor.
+
+// Arrays wraps a slice of ArrayMarshalers so that it satisfies the
+// ArrayMarshaler interface. See the Array function for a usage example.
+func Arrays(as []zapcore.ArrayMarshaler) zapcore.ArrayMarshaler {
+	return arrayMarshalers(as)
+}
+
+// Objects wraps a slice of ObjectMarshalers so that it satisfies the
+// ArrayMarshaler interface. See the Array function for a usage example.
+func Objects(os []zapcore.ObjectMarshaler) zapcore.ArrayMarshaler {
+	return objectMarshalers(os)
+}
+
+// Bools wraps a slice of bools so that it satisfies the ArrayMarshaler
+// interface. See the Array function for a usage example.
+func Bools(bs []bool) zapcore.ArrayMarshaler {
+	return bools(bs)
+}
+
+type arrayMarshalers []zapcore.ArrayMarshaler
+
+func (as arrayMarshalers) MarshalLogArray(arr zapcore.ArrayEncoder) error {
+	var errs *multierror.Error
+	for i := range as {
+		if as[i] == nil {
+			continue
+		}
+		errs = errs.Append(arr.AppendArray(as[i]))
+	}
+	return errs.AsError()
+}
+
+type objectMarshalers []zapcore.ObjectMarshaler
+
+func (os objectMarshalers) MarshalLogArray(arr zapcore.ArrayEncoder) error {
+	var errs *multierror.Error
+	for i := range os {
+		if os[i] == nil {
+			continue
+		}
+		errs = errs.Append(arr.AppendObject(os[i]))
+	}
+	return errs.AsError()
+}
+
+type bools []bool
+
+func (bs bools) MarshalLogArray(arr zapcore.ArrayEncoder) error {
+	for i := range bs {
+		arr.AppendBool(bs[i])
+	}
+	return nil
+}

--- a/array_test.go
+++ b/array_test.go
@@ -18,19 +18,48 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package zapcore
+package zap
 
-// ObjectEncoder is an encoding-agnostic interface to add structured data to the
-// logging context. Like maps, ObjectEncoders aren't safe for concurrent use
-// (though typical use shouldn't require locks).
-type ObjectEncoder interface {
-	AddBool(key string, value bool)
-	AddFloat64(key string, value float64)
-	AddInt64(key string, value int64)
-	AddUint64(key string, value uint64)
-	AddObject(key string, marshaler ObjectMarshaler) error
-	// AddReflected uses reflection to serialize arbitrary objects, so it's slow
-	// and allocation-heavy.
-	AddReflected(key string, value interface{}) error
-	AddString(key, value string)
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.uber.org/zap/zapcore"
+)
+
+func TestArrayWrappers(t *testing.T) {
+	tests := []struct {
+		desc     string
+		array    zapcore.ArrayMarshaler
+		expected []interface{}
+	}{
+		{
+			"arrays",
+			Arrays([]zapcore.ArrayMarshaler{
+				Bools([]bool{true}),
+				Bools([]bool{false}),
+			}),
+			[]interface{}{
+				[]interface{}{true},
+				[]interface{}{false},
+			},
+		},
+		{
+			"objects",
+			Objects([]zapcore.ObjectMarshaler{
+				zapcore.ObjectMarshalerFunc(func(_ zapcore.ObjectEncoder) error { return nil }),
+				zapcore.ObjectMarshalerFunc(func(_ zapcore.ObjectEncoder) error { return nil }),
+			}),
+			[]interface{}{zapcore.MapObjectEncoder{}, zapcore.MapObjectEncoder{}},
+		},
+		{"bools", Bools([]bool{true, false}), []interface{}{true, false}},
+	}
+
+	for _, tt := range tests {
+		enc := make(zapcore.MapObjectEncoder)
+		Array("k", tt.array).AddTo(enc)
+		assert.Equal(t, tt.expected, enc["k"], "%s: unexpected map contents.", tt.desc)
+		assert.Equal(t, 1, len(enc), "%s: found extra keys in map: %v", tt.desc, enc)
+	}
 }

--- a/array_test.go
+++ b/array_test.go
@@ -28,6 +28,26 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+func BenchmarkBoolsArrayMarshaler(b *testing.B) {
+	// Keep this benchmark here to capture the overhead of the ArrayMarshaler
+	// wrapper.
+	bs := make([]bool, 50)
+	enc := zapcore.NewJSONEncoder(zapcore.JSONConfig{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Array("array", Bools(bs)).AddTo(enc.Clone())
+	}
+}
+
+func BenchmarkBoolsReflect(b *testing.B) {
+	bs := make([]bool, 50)
+	enc := zapcore.NewJSONEncoder(zapcore.JSONConfig{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Reflect("array", bs).AddTo(enc.Clone())
+	}
+}
+
 func TestArrayWrappers(t *testing.T) {
 	tests := []struct {
 		desc     string

--- a/array_test.go
+++ b/array_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"go.uber.org/zap/zapcore"
 )
 
@@ -35,7 +34,7 @@ func BenchmarkBoolsArrayMarshaler(b *testing.B) {
 	enc := zapcore.NewJSONEncoder(zapcore.JSONConfig{})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Array("array", Bools(bs)).AddTo(enc.Clone())
+		Bools("array", bs).AddTo(enc.Clone())
 	}
 }
 
@@ -51,34 +50,17 @@ func BenchmarkBoolsReflect(b *testing.B) {
 func TestArrayWrappers(t *testing.T) {
 	tests := []struct {
 		desc     string
-		array    zapcore.ArrayMarshaler
+		field    zapcore.Field
 		expected []interface{}
 	}{
-		{
-			"arrays",
-			Arrays([]zapcore.ArrayMarshaler{
-				Bools([]bool{true}),
-				Bools([]bool{false}),
-			}),
-			[]interface{}{
-				[]interface{}{true},
-				[]interface{}{false},
-			},
-		},
-		{
-			"objects",
-			Objects([]zapcore.ObjectMarshaler{
-				zapcore.ObjectMarshalerFunc(func(_ zapcore.ObjectEncoder) error { return nil }),
-				zapcore.ObjectMarshalerFunc(func(_ zapcore.ObjectEncoder) error { return nil }),
-			}),
-			[]interface{}{zapcore.MapObjectEncoder{}, zapcore.MapObjectEncoder{}},
-		},
-		{"bools", Bools([]bool{true, false}), []interface{}{true, false}},
+		{"empty bools", Bools("", []bool{}), []interface{}(nil)},
+		{"bools", Bools("", []bool{true, false}), []interface{}{true, false}},
 	}
 
 	for _, tt := range tests {
 		enc := make(zapcore.MapObjectEncoder)
-		Array("k", tt.array).AddTo(enc)
+		tt.field.Key = "k"
+		tt.field.AddTo(enc)
 		assert.Equal(t, tt.expected, enc["k"], "%s: unexpected map contents.", tt.desc)
 		assert.Equal(t, 1, len(enc), "%s: found extra keys in map: %v", tt.desc, enc)
 	}

--- a/field.go
+++ b/field.go
@@ -133,11 +133,19 @@ func Duration(key string, val time.Duration) zapcore.Field {
 }
 
 // Object constructs a field with the given key and ObjectMarshaler. It
-// provides a flexible, but still type-safe and efficient, way to add
-// user-defined types to the logging context. The struct's MarshalLogObject
-// method is called lazily.
+// provides a flexible, but still type-safe and efficient, way to add map- or
+// struct-like user-defined types to the logging context. The struct's
+// MarshalLogObject method is called lazily.
 func Object(key string, val zapcore.ObjectMarshaler) zapcore.Field {
 	return zapcore.Field{Key: key, Type: zapcore.ObjectMarshalerType, Interface: val}
+}
+
+// Array constructs a field with the given key and ArrayMarshaler. It provides
+// a flexible, but still type-safe and efficient, way to add array-like
+// user-defined types to the logging context. The struct's MarshalLogArray
+// method is called lazily.
+func Array(key string, val zapcore.ArrayMarshaler) zapcore.Field {
+	return zapcore.Field{Key: key, Type: zapcore.ArrayMarshalerType, Interface: val}
 }
 
 // Reflect constructs a field with the given key and an arbitrary object. It uses

--- a/field.go
+++ b/field.go
@@ -140,13 +140,6 @@ func Object(key string, val zapcore.ObjectMarshaler) zapcore.Field {
 	return zapcore.Field{Key: key, Type: zapcore.ObjectMarshalerType, Interface: val}
 }
 
-// Array constructs a field with the given key and ArrayMarshaler. It provides
-// a flexible, but still type-safe and efficient, way to add array-like types
-// to the logging context. The struct's MarshalLogArray method is called lazily.
-func Array(key string, val zapcore.ArrayMarshaler) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.ArrayMarshalerType, Interface: val}
-}
-
 // Reflect constructs a field with the given key and an arbitrary object. It uses
 // an encoding-appropriate, reflection-based function to lazily serialize nearly
 // any object into the logging context, but it's relatively slow and

--- a/field.go
+++ b/field.go
@@ -141,9 +141,8 @@ func Object(key string, val zapcore.ObjectMarshaler) zapcore.Field {
 }
 
 // Array constructs a field with the given key and ArrayMarshaler. It provides
-// a flexible, but still type-safe and efficient, way to add array-like
-// user-defined types to the logging context. The struct's MarshalLogArray
-// method is called lazily.
+// a flexible, but still type-safe and efficient, way to add array-like types
+// to the logging context. The struct's MarshalLogArray method is called lazily.
 func Array(key string, val zapcore.ArrayMarshaler) zapcore.Field {
 	return zapcore.Field{Key: key, Type: zapcore.ArrayMarshalerType, Interface: val}
 }

--- a/internal/multierror/multierror.go
+++ b/internal/multierror/multierror.go
@@ -22,7 +22,7 @@
 // a single error.
 package multierror
 
-import "go.uber.org/zap/buffers"
+import "go.uber.org/zap/internal/buffers"
 
 // implement the standard lib's error interface on a private type so that we
 // can't forget to call Error.AsError().
@@ -50,10 +50,7 @@ type Error struct {
 //
 // Note that failing to use AsError will almost certainly lead to bugs with
 // non-nil interfaces containing nil concrete values.
-func (e *Error) AsError() error {
-	if e == nil {
-		return nil
-	}
+func (e Error) AsError() error {
 	switch len(e.errs) {
 	case 0:
 		return nil
@@ -65,12 +62,9 @@ func (e *Error) AsError() error {
 }
 
 // Append adds an error to the collection. Adding a nil error is a no-op.
-func (e *Error) Append(err error) *Error {
+func (e Error) Append(err error) Error {
 	if err == nil {
 		return e
-	}
-	if e == nil {
-		e = &Error{}
 	}
 	e.errs = append(e.errs, err)
 	return e

--- a/internal/multierror/multierror.go
+++ b/internal/multierror/multierror.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package multierror provides a simple way to treat a collection of errors as
+// a single error.
+package multierror
+
+import "go.uber.org/zap/buffers"
+
+// implement the standard lib's error interface on a private type so that we
+// can't forget to call Error.AsError().
+type errSlice []error
+
+func (es errSlice) Error() string {
+	b := buffers.Get()
+	for i, err := range es {
+		if i > 0 {
+			b = append(b, ';', ' ')
+		}
+		b = append(b, err.Error()...)
+	}
+	ret := string(b)
+	buffers.Put(b)
+	return ret
+}
+
+// Error wraps a []error to implement the error interface.
+type Error struct {
+	errs errSlice
+}
+
+// AsError converts the collection to a single error value.
+//
+// Note that failing to use AsError will almost certainly lead to bugs with
+// non-nil interfaces containing nil concrete values.
+func (e *Error) AsError() error {
+	if e == nil {
+		return nil
+	}
+	switch len(e.errs) {
+	case 0:
+		return nil
+	case 1:
+		return e.errs[0]
+	default:
+		return e.errs
+	}
+}
+
+// Append adds an error to the collection. Adding a nil error is a no-op.
+func (e *Error) Append(err error) *Error {
+	if err == nil {
+		return e
+	}
+	if e == nil {
+		e = &Error{}
+	}
+	e.errs = append(e.errs, err)
+	return e
+}

--- a/internal/multierror/multierror_test.go
+++ b/internal/multierror/multierror_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package multierror
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorSliceString(t *testing.T) {
+	tests := []struct {
+		errs     errSlice
+		expected string
+	}{
+		{nil, ""},
+		{errSlice{}, ""},
+		{errSlice{errors.New("foo")}, "foo"},
+		{errSlice{errors.New("foo"), errors.New("bar")}, "foo; bar"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.errs.Error(), "Unexpected output from Error method.")
+	}
+}
+
+func TestMultiErrorAsError(t *testing.T) {
+	assert.Nil(t, (*Error)(nil).AsError(), "Expected calling AsError on nil to return nil.")
+	assert.Nil(t, (&Error{}).AsError(), "Expected calling AsError with no accumulated errors to return nil.")
+
+	e := errors.New("foo")
+	assert.Equal(
+		t,
+		e,
+		(&Error{errSlice{e}}).AsError(),
+		"Expected AsError with single error to return the original error.",
+	)
+
+	m := &Error{errSlice{errors.New("foo"), errors.New("bar")}}
+	assert.Equal(t, m.errs, m.AsError(), "Unexpected AsError output with multiple errors.")
+}
+
+func TestErrorAppend(t *testing.T) {
+	foo := errors.New("foo")
+	bar := errors.New("bar")
+	for _, base := range []*Error{nil, &Error{}} {
+		base = base.Append(nil).Append(foo).Append(nil).Append(bar)
+		assert.Equal(t, errSlice{foo, bar}, base.errs, "Collected errors don't match expectations.")
+	}
+}

--- a/internal/multierror/multierror_test.go
+++ b/internal/multierror/multierror_test.go
@@ -62,7 +62,7 @@ func TestMultiErrorAsError(t *testing.T) {
 func TestErrorAppend(t *testing.T) {
 	foo := errors.New("foo")
 	bar := errors.New("bar")
-	for _, base := range []*Error{nil, &Error{}} {
+	for _, base := range []*Error{nil, {}} {
 		base = base.Append(nil).Append(foo).Append(nil).Append(bar)
 		assert.Equal(t, errSlice{foo, bar}, base.errs, "Collected errors don't match expectations.")
 	}

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -22,6 +22,31 @@ package zapcore
 
 import "io"
 
+// ObjectEncoder is a strongly-typed, encoding-agnostic interface for adding a
+// map[string]interface{} to the logging context. Like maps, ObjectEncoders
+// aren't safe for concurrent use (though typical use shouldn't require locks).
+type ObjectEncoder interface {
+	AddBool(key string, value bool)
+	AddFloat64(key string, value float64)
+	AddInt64(key string, value int64)
+	AddUint64(key string, value uint64)
+	AddObject(key string, marshaler ObjectMarshaler) error
+	AddArray(key string, marshaler ArrayMarshaler) error
+	// AddReflected uses reflection to serialize arbitrary objects, so it's slow
+	// and allocation-heavy.
+	AddReflected(key string, value interface{}) error
+	AddString(key, value string)
+}
+
+// ArrayEncoder is a strongly-typed, encoding-agnostic interface for adding a
+// []interface{} to the logging context. Like slices, ArrayEncoders aren't safe
+// for concurrent use (though typical use shouldn't require locks).
+type ArrayEncoder interface {
+	AppendArray(ArrayMarshaler) error
+	AppendObject(ObjectMarshaler) error
+	AppendBool(bool)
+}
+
 // Encoder is a format-agnostic interface for all log entry marshalers. Since
 // log encoders don't need to support the same wide range of use cases as
 // general-purpose marshalers, it's possible to make them faster and

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -23,7 +23,7 @@ package zapcore
 import "io"
 
 // ObjectEncoder is a strongly-typed, encoding-agnostic interface for adding a
-// map[string]interface{} to the logging context. Like maps, ObjectEncoders
+// map- or struct-like object to the logging context. Like maps, ObjectEncoders
 // aren't safe for concurrent use (though typical use shouldn't require locks).
 type ObjectEncoder interface {
 	AddBool(key string, value bool)
@@ -38,9 +38,10 @@ type ObjectEncoder interface {
 	AddString(key, value string)
 }
 
-// ArrayEncoder is a strongly-typed, encoding-agnostic interface for adding a
-// []interface{} to the logging context. Like slices, ArrayEncoders aren't safe
-// for concurrent use (though typical use shouldn't require locks).
+// ArrayEncoder is a strongly-typed, encoding-agnostic interface for adding
+// array-like objects to the logging context. Of note, it supports mixed-type
+// arrays even though they aren't typical in Go. Like slices, ArrayEncoders
+// aren't safe for concurrent use (though typical use shouldn't require locks).
 type ArrayEncoder interface {
 	AppendArray(ArrayMarshaler) error
 	AppendObject(ObjectMarshaler) error

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -162,7 +162,7 @@ func (ce *CheckedEntry) Write(fields ...Field) {
 	}
 	ce.dirty = true
 
-	var errs *multierror.Error
+	var errs multierror.Error
 	for i := range ce.facs {
 		errs = errs.Append(ce.facs[i].Write(ce.Entry, fields))
 	}

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -44,6 +44,8 @@ const (
 	StringType
 	// ObjectMarshalerType indicates that the field carries an ObjectMarshaler.
 	ObjectMarshalerType
+	// ArrayMarshalerType indicates that the field carries an ArrayMarshaler.
+	ArrayMarshalerType
 	// ReflectType indicates that the field carries an interface{}, which should
 	// be serialized using reflection.
 	ReflectType
@@ -86,6 +88,8 @@ func (f Field) AddTo(enc ObjectEncoder) {
 		enc.AddString(f.Key, f.Interface.(fmt.Stringer).String())
 	case ObjectMarshalerType:
 		err = enc.AddObject(f.Key, f.Interface.(ObjectMarshaler))
+	case ArrayMarshalerType:
+		err = enc.AddArray(f.Key, f.Interface.(ArrayMarshaler))
 	case ReflectType:
 		err = enc.AddReflected(f.Key, f.Interface)
 	case ErrorType:

--- a/zapcore/json_encoder_bench_test.go
+++ b/zapcore/json_encoder_bench_test.go
@@ -63,8 +63,8 @@ func BenchmarkZapJSON(b *testing.B) {
 		for pb.Next() {
 			enc := newJSONEncoder(cfg)
 			enc.AddString("str", "foo")
-			enc.AddInt64("int", 1)
-			enc.AddInt64("int64", 1)
+			enc.AddInt64("int64-1", 1)
+			enc.AddInt64("int64-2", 2)
 			enc.AddFloat64("float64", 1.0)
 			enc.AddString("string1", "\n")
 			enc.AddString("string2", "💩")
@@ -92,7 +92,7 @@ func BenchmarkStandardJSON(b *testing.B) {
 		Time:    time.Unix(0, 0),
 		Fields: map[string]interface{}{
 			"str":     "foo",
-			"int64-1": int(1),
+			"int64-1": int64(1),
 			"int64-2": int64(1),
 			"float64": float64(1.0),
 			"string1": "\n",

--- a/zapcore/json_encoder_test.go
+++ b/zapcore/json_encoder_test.go
@@ -55,7 +55,7 @@ func (t turducken) MarshalLogObject(enc ObjectEncoder) error {
 type turduckens int
 
 func (t turduckens) MarshalLogArray(enc ArrayEncoder) error {
-	var errs *multierror.Error
+	var errs multierror.Error
 	tur := turducken{}
 	for i := 0; i < int(t); i++ {
 		errs = errs.Append(enc.AppendObject(tur))

--- a/zapcore/marshaler.go
+++ b/zapcore/marshaler.go
@@ -27,7 +27,7 @@ type ObjectMarshaler interface {
 	MarshalLogObject(ObjectEncoder) error
 }
 
-// ObjectMarshalerFunc is a type adapter that allows using a function as a
+// ObjectMarshalerFunc is a type adapter that turns a function into an
 // ObjectMarshaler.
 type ObjectMarshalerFunc func(ObjectEncoder) error
 
@@ -36,4 +36,18 @@ func (f ObjectMarshalerFunc) MarshalLogObject(enc ObjectEncoder) error {
 	return f(enc)
 }
 
-// TODO: Add LogArrayMarshaler and ArrayEncoder interfaces.
+// ArrayMarshaler allows user-defined types to efficiently add themselves to the
+// logging context, and to selectively omit information which shouldn't be
+// included in logs (e.g., passwords).
+type ArrayMarshaler interface {
+	MarshalLogArray(ArrayEncoder) error
+}
+
+// ArrayMarshalerFunc is a type adapter that turns a function into an
+// ArrayMarshaler.
+type ArrayMarshalerFunc func(ArrayEncoder) error
+
+// MarshalLogArray calls the underlying function.
+func (f ArrayMarshalerFunc) MarshalLogArray(enc ArrayEncoder) error {
+	return f(enc)
+}

--- a/zapcore/tee.go
+++ b/zapcore/tee.go
@@ -20,6 +20,8 @@
 
 package zapcore
 
+import "go.uber.org/zap/internal/multierror"
+
 // Tee creates a Facility that duplicates log entries into two or more
 // facilities; if you call it with less than two, you get back the one facility
 // you passed (or nil in the pathological case).
@@ -62,11 +64,9 @@ func (mf multiFacility) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
 }
 
 func (mf multiFacility) Write(ent Entry, fields []Field) error {
-	var errs multiError
+	var errs *multierror.Error
 	for i := range mf {
-		if err := mf[i].Write(ent, fields); err != nil {
-			errs = append(errs, err)
-		}
+		errs = errs.Append(mf[i].Write(ent, fields))
 	}
-	return errs.asError()
+	return errs.AsError()
 }

--- a/zapcore/tee.go
+++ b/zapcore/tee.go
@@ -64,7 +64,7 @@ func (mf multiFacility) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
 }
 
 func (mf multiFacility) Write(ent Entry, fields []Field) error {
-	var errs *multierror.Error
+	var errs multierror.Error
 	for i := range mf {
 		errs = errs.Append(mf[i].Write(ent, fields))
 	}

--- a/zapcore/write_syncer.go
+++ b/zapcore/write_syncer.go
@@ -98,7 +98,7 @@ func MultiWriteSyncer(ws ...WriteSyncer) WriteSyncer {
 // the smallest number is returned even though Write() is called on
 // all of them.
 func (ws multiWriteSyncer) Write(p []byte) (int, error) {
-	var errs *multierror.Error
+	var errs multierror.Error
 	nWritten := 0
 	for _, w := range ws {
 		n, err := w.Write(p)
@@ -113,7 +113,7 @@ func (ws multiWriteSyncer) Write(p []byte) (int, error) {
 }
 
 func (ws multiWriteSyncer) Sync() error {
-	var errs *multierror.Error
+	var errs multierror.Error
 	for _, w := range ws {
 		errs = errs.Append(w.Sync())
 	}

--- a/zapcore/write_syncer_test.go
+++ b/zapcore/write_syncer_test.go
@@ -115,13 +115,6 @@ func TestMultiWriteSyncerSync_NoErrorsOnDiscard(t *testing.T) {
 	assert.NoError(t, ws.Sync(), "Expected error-free sync to /dev/null")
 }
 
-func TestMultiError_WrapsStrings(t *testing.T) {
-	err := multiError{errors.New("battlestar"), errors.New("galactaca")}
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "battlestar")
-	assert.Contains(t, err.Error(), "galactaca")
-}
-
 func TestMultiWriteSyncerSync_AllCalled(t *testing.T) {
 	failed, second := &testutils.Buffer{}, &testutils.Buffer{}
 


### PR DESCRIPTION
Add basic support for logging arrays. To limit the scope of this commit,
it introduces only arrays of ObjectMarshalers, arrays of arrays, and
arrays of bools. It should, however, clarify how I intend to support
arrays of other types.

Of note, I opted not to have `zap.Bools` return a `Field`. Instead, it
returns a `zapcore.ArrayMarshaler`. This lets us build arrays of
heterogenous arrays. For most users, this will be papered over by the
upcoming `zap.Any(key string, val interface{}) zapcore.Field` function,
which will basically be a huge type switch.

(Along the way, I broke out our multi-error implementation into a separate
internal package.)

This starts to address #136, and is an alternative to the approach in #211.

From the small benchmarks included in this PR:
```
BenchmarkBoolsArrayMarshaler-4   	 1000000	      1028 ns/op	    1088 B/op	       3 allocs/op
BenchmarkBoolsReflect-4          	  500000	      3293 ns/op	    2280 B/op	       8 allocs/op
```
All allocations in the ArrayMarshaler benchmark come from allocating byte slices for encoders.
