### PR TITLE
Run benchmarks on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ install:
 script:
   - make lint
   - make test
+  - make bench
 after_success:
   - make coveralls


### PR DESCRIPTION
We can't easily fail builds for performance regressions, but we can and
should ensure that the benchmarks run without error on each build.