### PR TITLE
Re-introduce read-only hooks as a facility

### DIFF
--- a/zapcore/hook.go
+++ b/zapcore/hook.go
@@ -30,9 +30,10 @@ type hooked struct {
 // Hooked wraps a facility and runs a collection of user-defined callback hooks
 // each time a message is logged.
 func Hooked(fac Facility, hooks ...func(Entry) error) Facility {
+	funcs := append([]func(Entry) error{}, hooks...)
 	return &hooked{
 		Facility: fac,
-		funcs:    hooks,
+		funcs:    funcs,
 	}
 }
 
@@ -52,8 +53,8 @@ func (h *hooked) With(fields []Field) Facility {
 
 func (h *hooked) Write(ent Entry, _ []Field) error {
 	var errs multierror.Error
-	for _, f := range h.funcs {
-		errs = errs.Append(f(ent))
+	for i := range h.funcs {
+		errs = errs.Append(h.funcs[i](ent))
 	}
 	return errs.AsError()
 }

--- a/zapcore/hook.go
+++ b/zapcore/hook.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zapcore
+
+import "go.uber.org/zap/internal/multierror"
+
+type hooked struct {
+	Facility
+	funcs []func(Entry) error
+}
+
+// Hooked wraps a facility and runs a collection of user-defined callback hooks
+// each time a message is logged.
+func Hooked(fac Facility, hooks ...func(Entry) error) Facility {
+	return &hooked{
+		Facility: fac,
+		funcs:    hooks,
+	}
+}
+
+func (h *hooked) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
+	if downstream := h.Facility.Check(ent, ce); downstream != nil {
+		return downstream.AddFacility(ent, h)
+	}
+	return ce
+}
+
+func (h *hooked) With(fields []Field) Facility {
+	return &hooked{
+		Facility: h.Facility.With(fields),
+		funcs:    h.funcs,
+	}
+}
+
+func (h *hooked) Write(ent Entry, _ []Field) error {
+	var errs multierror.Error
+	for _, f := range h.funcs {
+		errs = errs.Append(f(ent))
+	}
+	return errs.AsError()
+}

--- a/zapcore/hook_test.go
+++ b/zapcore/hook_test.go
@@ -42,9 +42,9 @@ func TestHooks(t *testing.T) {
 		intField := makeInt64Field("foo", 42)
 		ent := Entry{Message: "bar", Level: tt.entryLevel}
 
-		var called bool
+		var called int
 		f := func(e Entry) error {
-			called = true
+			called++
 			assert.Equal(t, ent, e, "Hook called with unexpected Entry.")
 			return nil
 		}
@@ -55,7 +55,7 @@ func TestHooks(t *testing.T) {
 		}
 
 		if tt.expectCall {
-			assert.True(t, called, "Expected to call hook.")
+			assert.Equal(t, 1, called, "Expected to call hook once.")
 			assert.Equal(
 				t,
 				[]ObservedLog{{Entry: ent, Context: []Field{intField}}},
@@ -63,7 +63,7 @@ func TestHooks(t *testing.T) {
 				"Unexpected logs written out.",
 			)
 		} else {
-			assert.False(t, called, "Didn't expect to call hook.")
+			assert.Equal(t, 0, called, "Didn't expect to call hook.")
 			assert.Equal(t, 0, logs.Len(), "Unexpected logs written out.")
 		}
 	}

--- a/zapcore/hook_test.go
+++ b/zapcore/hook_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zapcore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHooks(t *testing.T) {
+	tests := []struct {
+		entryLevel    Level
+		facilityLevel Level
+		expectCall    bool
+	}{
+		{DebugLevel, InfoLevel, false},
+		{InfoLevel, InfoLevel, true},
+		{WarnLevel, InfoLevel, true},
+	}
+
+	for _, tt := range tests {
+		fac, logs := NewObserver(tt.facilityLevel, 1)
+		intField := makeInt64Field("foo", 42)
+		ent := Entry{Message: "bar", Level: tt.entryLevel}
+
+		var called bool
+		f := func(e Entry) error {
+			called = true
+			assert.Equal(t, ent, e, "Hook called with unexpected Entry.")
+			return nil
+		}
+
+		h := Hooked(fac, f)
+		if ce := h.With([]Field{intField}).Check(ent, nil); ce != nil {
+			ce.Write()
+		}
+
+		if tt.expectCall {
+			assert.True(t, called, "Expected to call hook.")
+			assert.Equal(
+				t,
+				[]ObservedLog{{Entry: ent, Context: []Field{intField}}},
+				logs.AllUntimed(),
+				"Unexpected logs written out.",
+			)
+		} else {
+			assert.False(t, called, "Didn't expect to call hook.")
+			assert.Equal(t, 0, logs.Len(), "Unexpected logs written out.")
+		}
+	}
+}


### PR DESCRIPTION
Re-introduce simple read-only hooks as a facility wrapper. This doesn't fully
satisfy our desire for an observing facility, but it's simple and doesn't
introduce any new external APIs before v1.0.

This should address the immediate needs from #220. We can continue to iterate on a full-fledged observer and introduce it in a post-1.0 point release.