### PR TITLE
Add benchmark for stacktrace generation

### DIFF
--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -170,6 +170,20 @@ func BenchmarkZapAddingFields(b *testing.B) {
 	})
 }
 
+func BenchmarkZapAddingFieldsAndStacktrace(b *testing.B) {
+	logger := zap.New(zapcore.WriterFacility(
+		benchEncoder(),
+		&testutils.Discarder{},
+		zap.DebugLevel,
+	), zap.AddStacks(zapcore.InfoLevel))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("Go fast-ish with trace!", fakeFields()...)
+		}
+	})
+}
+
 func BenchmarkZapWithAccumulatedContext(b *testing.B) {
 	context := fakeFields()
 	logger := zap.New(


### PR DESCRIPTION
The "relatively speaking" comment on stack generation
has peaked my interest, so I wanted to see what is the impact
of generating a trace compared to a regular log.

Without and with results:

```
BenchmarkZapAddingFields-8                       3000000               606 ns/op             769 B/op          4 allocs/op
BenchmarkZapAddingFieldsAndStacktrace-8           100000             16526 ns/op            1957 B/op          6 allocs/op
```