### PR TITLE
Log timestamps in localtime for TextEncoder.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -126,7 +126,7 @@ func (log *logger) log(lvl Level, msg string, fields []Field) {
 		return
 	}
 
-	t := time.Now().UTC()
+	t := time.Now().Local()
 	if err := log.Encode(log.Output, t, lvl, msg, fields); err != nil {
 		log.InternalError("encoder", err)
 	}


### PR DESCRIPTION
Resolves #232.  Since others are asking for this, it seemed worth sharing the one-line change.  Didn't seem worth making people wait until 1.0 for such a simple and useful improvement.
