### PR TITLE
Double down on loosely-typed fields for SugaredLogger

### DIFF
--- a/sugar.go
+++ b/sugar.go
@@ -74,9 +74,9 @@ func Desugar(s *SugaredLogger) Logger {
 //
 // Note that the keys in key-value pairs should be strings. In development,
 // passing a non-string key panics. In production, the logger is more
-// forgiving: a separate error is logged, but the key is coerced to a string
-// with fmt.Sprint and execution continues. Passing an orphaned key triggers
-// similar behavior: panics in development and errors in production.
+// forgiving: a separate error is logged, but the key-value pair is skipped and
+// execution continues. Passing an orphaned key triggers similar behavior:
+// panics in development and errors in production.
 func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
 	return &SugaredLogger{core: s.core.With(s.sweetenFields(args)...)}
 }

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestSugarWith(t *testing.T) {
 	// Convenience functions to create expected error logs.
-	ignored := func(msg string) observer.LoggedEntry {
+	ignored := func(msg interface{}) observer.LoggedEntry {
 		return observer.LoggedEntry{
 			Entry:   zapcore.Entry{Level: DPanicLevel, Message: _oddNumberErrMsg},
 			Context: []zapcore.Field{Any("ignored", msg)},
@@ -88,6 +88,12 @@ func TestSugarWith(t *testing.T) {
 			errLogs:  []observer.LoggedEntry{ignored("dangling")},
 		},
 		{
+			desc:     "structured field and a dangling non-string key",
+			args:     []interface{}{Int("foo", 42), 13},
+			expected: []zapcore.Field{Int("foo", 42)},
+			errLogs:  []observer.LoggedEntry{ignored(13)},
+		},
+		{
 			desc:     "key-value pair and a dangling key",
 			args:     []interface{}{"foo", 42, "dangling"},
 			expected: []zapcore.Field{Int("foo", 42)},
@@ -107,8 +113,8 @@ func TestSugarWith(t *testing.T) {
 		},
 		{
 			desc:     "pairs, structured fields, non-string keys, and a dangling key",
-			args:     []interface{}{"foo", 42, true, "bar", Int("structure", 11), 42, "reversed", "dangling"},
-			expected: []zapcore.Field{Int("foo", 42), Int("structure", 11)},
+			args:     []interface{}{"foo", 42, true, "bar", Int("structure", 11), 42, "reversed", "baz", "quux", "dangling"},
+			expected: []zapcore.Field{Int("foo", 42), Int("structure", 11), String("baz", "quux")},
 			errLogs: []observer.LoggedEntry{
 				ignored("dangling"),
 				nonString(invalidPair{2, true, "bar"}, invalidPair{5, 42, "reversed"}),

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -38,10 +38,10 @@ func TestSugarWith(t *testing.T) {
 			Context: []zapcore.Field{Any("ignored", msg)},
 		}
 	}
-	nonString := func(pos int, key, val interface{}) observer.LoggedEntry {
+	nonString := func(pairs ...invalidPair) observer.LoggedEntry {
 		return observer.LoggedEntry{
 			Entry:   zapcore.Entry{Level: DPanicLevel, Message: _nonStringKeyErrMsg},
-			Context: []zapcore.Field{Int("position", pos), Any("key", key), Any("value", val)},
+			Context: []zapcore.Field{Array("invalid", invalidPairs(pairs))},
 		}
 	}
 
@@ -103,13 +103,16 @@ func TestSugarWith(t *testing.T) {
 			desc:     "one non-string key",
 			args:     []interface{}{"foo", 42, true, "bar"},
 			expected: []zapcore.Field{Int("foo", 42)},
-			errLogs:  []observer.LoggedEntry{nonString(2, true, "bar")},
+			errLogs:  []observer.LoggedEntry{nonString(invalidPair{2, true, "bar"})},
 		},
 		{
 			desc:     "pairs, structured fields, non-string keys, and a dangling key",
 			args:     []interface{}{"foo", 42, true, "bar", Int("structure", 11), 42, "reversed", "dangling"},
 			expected: []zapcore.Field{Int("foo", 42), Int("structure", 11)},
-			errLogs:  []observer.LoggedEntry{nonString(2, true, "bar"), nonString(5, 42, "reversed"), ignored("dangling")},
+			errLogs: []observer.LoggedEntry{
+				ignored("dangling"),
+				nonString(invalidPair{2, true, "bar"}, invalidPair{5, 42, "reversed"}),
+			},
 		},
 	}
 

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -44,6 +44,13 @@ func TestSugarWith(t *testing.T) {
 		{[]interface{}{}, []zapcore.Field{}, nil},
 		{[]interface{}{"should ignore"}, []zapcore.Field{}, []observer.LoggedEntry{ignored}},
 		{[]interface{}{"foo", 42, "true", "bar"}, []zapcore.Field{Int("foo", 42), String("true", "bar")}, nil},
+		{[]interface{}{Int("foo", 42)}, []zapcore.Field{Int("foo", 42)}, nil},
+		{[]interface{}{Int("foo", 42), "should ignore"}, []zapcore.Field{Int("foo", 42)}, []observer.LoggedEntry{ignored}},
+		{
+			[]interface{}{"first", "field", Int("foo", 42), "baz", "quux", "should ignore"},
+			[]zapcore.Field{String("first", "field"), Int("foo", 42), String("baz", "quux")},
+			[]observer.LoggedEntry{ignored},
+		},
 		{
 			args:     []interface{}{"foo", 42, true, "bar"},
 			expected: []zapcore.Field{Int("foo", 42), String("true", "bar")},


### PR DESCRIPTION
Some of zap's strongly-typed fields rely on the field constructors to do some
work, so it's difficult for users to replicate their effects using the variadic
key-value pairs that the sugared logger prefers. (`Stack()` is a good example of
this.)

To accommodate these use cases, the sugared logger has a `WithFields` method,
but this isn't very satisfying; for symmetry, we'd also want `InfoWithFields`,
`DebugWithFields`, etc.

This PR doubles down on developer ergonomics (over compile-time safety) by
making `With`, `Debugw`, `Infow`, etc. able to accept a mix of zapcore.Fields
and loosely-typed key-value pairs. This obviates the `WithFields` method.