### PR TITLE
Add name support to SugaredLogger

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -273,6 +273,14 @@ func TestLoggerNames(t *testing.T) {
 			require.Equal(t, 1, logs.Len(), "Expected only one log entry to be written.")
 			assert.Equal(t, tt.expected, logs.AllUntimed()[0].Entry.LoggerName, "Unexpected logger name.")
 		})
+		withSugar(t, DebugLevel, nil, func(log *SugaredLogger, logs *observer.ObservedLogs) {
+			for _, n := range tt.names {
+				log = log.Named(n)
+			}
+			log.Infow("")
+			require.Equal(t, 1, logs.Len(), "Expected only one log entry to be written.")
+			assert.Equal(t, tt.expected, logs.AllUntimed()[0].Entry.LoggerName, "Unexpected logger name.")
+		})
 	}
 }
 

--- a/sugar.go
+++ b/sugar.go
@@ -50,6 +50,11 @@ func Desugar(s *SugaredLogger) Logger {
 	return s.core
 }
 
+// Named adds a sub-scope to the logger's name.
+func (s *SugaredLogger) Named(name string) *SugaredLogger {
+	return &SugaredLogger{core: s.core.Named(name)}
+}
+
 // With adds a variadic number of fields to the logging context. It accepts a
 // mix of strongly-typed zapcore.Field objects and loosely-typed key-value
 // pairs. When processing pairs, the first element of the pair is used as the


### PR DESCRIPTION
Make the sugared logger support the same top-level naming API as the base logger.
