### PR TITLE
Skip formatting in the SugaredLogger if the level is disabled

### DIFF
--- a/benchmarks/zap_sugar_bench_test.go
+++ b/benchmarks/zap_sugar_bench_test.go
@@ -43,6 +43,12 @@ func fakeSugarFields() []interface{} {
 	}
 }
 
+func fakeSugarFormatArgs() (string, []interface{}) {
+	template := "some args: %d %v %v %s %v %v %v %v %v"
+	args := []interface{}{1, 2, 3.0, "four!", zap.DebugLevel, true, time.Unix(0, 0), time.Second, "done!"}
+	return template, args
+}
+
 func newSugarLogger(lvl zapcore.Level, options ...zap.Option) *zap.SugaredLogger {
 	return zap.Sugar(zap.New(zapcore.WriterFacility(
 		benchEncoder(),
@@ -61,6 +67,17 @@ func BenchmarkZapSugarDisabledLevelsWithoutFields(b *testing.B) {
 	})
 }
 
+func BenchmarkZapSugarFmtDisabledLevelsWithoutFields(b *testing.B) {
+	logger := newSugarLogger(zap.ErrorLevel)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			template, args := fakeSugarFormatArgs()
+			logger.Infof(template, args...)
+		}
+	})
+}
+
 func BenchmarkZapSugarDisabledLevelsAccumulatedContext(b *testing.B) {
 	context := fakeFields()
 	logger := newSugarLogger(zap.ErrorLevel, zap.Fields(context...))
@@ -68,6 +85,18 @@ func BenchmarkZapSugarDisabledLevelsAccumulatedContext(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			logger.Info("Should be discarded.")
+		}
+	})
+}
+
+func BenchmarkZapSugarFmtDisabledLevelsAccumulatedContext(b *testing.B) {
+	context := fakeFields()
+	logger := newSugarLogger(zap.ErrorLevel, zap.Fields(context...))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			template, args := fakeSugarFormatArgs()
+			logger.Infof(template, args...)
 		}
 	})
 }
@@ -102,12 +131,34 @@ func BenchmarkZapSugarWithAccumulatedContext(b *testing.B) {
 	})
 }
 
+func BenchmarkZapSugarFmtWithAccumulatedContext(b *testing.B) {
+	logger := newSugarLogger(zap.DebugLevel).With(fakeSugarFields()...)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			template, args := fakeSugarFormatArgs()
+			logger.Infof(template, args...)
+		}
+	})
+}
+
 func BenchmarkZapSugarWithoutFields(b *testing.B) {
 	logger := newSugarLogger(zap.DebugLevel)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			logger.Info("Go fast.")
+		}
+	})
+}
+
+func BenchmarkZapSugarFmtWithoutFields(b *testing.B) {
+	logger := newSugarLogger(zap.DebugLevel)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			template, args := fakeSugarFormatArgs()
+			logger.Infof(template, args...)
 		}
 	})
 }

--- a/sugar.go
+++ b/sugar.go
@@ -88,74 +88,74 @@ func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
 
 // Debug uses fmt.Sprint to construct and log a message.
 func (s *SugaredLogger) Debug(args ...interface{}) {
-	s.log(DebugLevel, fmt.Sprint(args...), nil)
+	s.log(DebugLevel, "", args, nil)
 }
 
 // Info uses fmt.Sprint to construct and log a message.
 func (s *SugaredLogger) Info(args ...interface{}) {
-	s.log(InfoLevel, fmt.Sprint(args...), nil)
+	s.log(InfoLevel, "", args, nil)
 }
 
 // Warn uses fmt.Sprint to construct and log a message.
 func (s *SugaredLogger) Warn(args ...interface{}) {
-	s.log(WarnLevel, fmt.Sprint(args...), nil)
+	s.log(WarnLevel, "", args, nil)
 }
 
 // Error uses fmt.Sprint to construct and log a message.
 func (s *SugaredLogger) Error(args ...interface{}) {
-	s.log(ErrorLevel, fmt.Sprint(args...), nil)
+	s.log(ErrorLevel, "", args, nil)
 }
 
 // DPanic uses fmt.Sprint to construct and log a message. In development, the
 // logger then panics. (See DPanicLevel for details.)
 func (s *SugaredLogger) DPanic(args ...interface{}) {
-	s.log(DPanicLevel, fmt.Sprint(args...), nil)
+	s.log(DPanicLevel, "", args, nil)
 }
 
 // Panic uses fmt.Sprint to construct and log a message, then panics.
 func (s *SugaredLogger) Panic(args ...interface{}) {
-	s.log(PanicLevel, fmt.Sprint(args...), nil)
+	s.log(PanicLevel, "", args, nil)
 }
 
 // Fatal uses fmt.Sprint to construct and log a message, then calls os.Exit.
 func (s *SugaredLogger) Fatal(args ...interface{}) {
-	s.log(FatalLevel, fmt.Sprint(args...), nil)
+	s.log(FatalLevel, "", args, nil)
 }
 
 // Debugf uses fmt.Sprintf to log a templated message.
 func (s *SugaredLogger) Debugf(template string, args ...interface{}) {
-	s.log(DebugLevel, fmt.Sprintf(template, args...), nil)
+	s.log(DebugLevel, template, args, nil)
 }
 
 // Infof uses fmt.Sprintf to log a templated message.
 func (s *SugaredLogger) Infof(template string, args ...interface{}) {
-	s.log(InfoLevel, fmt.Sprintf(template, args...), nil)
+	s.log(InfoLevel, template, args, nil)
 }
 
 // Warnf uses fmt.Sprintf to log a templated message.
 func (s *SugaredLogger) Warnf(template string, args ...interface{}) {
-	s.log(WarnLevel, fmt.Sprintf(template, args...), nil)
+	s.log(WarnLevel, template, args, nil)
 }
 
 // Errorf uses fmt.Sprintf to log a templated message.
 func (s *SugaredLogger) Errorf(template string, args ...interface{}) {
-	s.log(ErrorLevel, fmt.Sprintf(template, args...), nil)
+	s.log(ErrorLevel, template, args, nil)
 }
 
 // DPanicf uses fmt.Sprintf to log a templated message. In development, the
 // logger then panics. (See DPanicLevel for details.)
 func (s *SugaredLogger) DPanicf(template string, args ...interface{}) {
-	s.log(DPanicLevel, fmt.Sprintf(template, args...), nil)
+	s.log(DPanicLevel, template, args, nil)
 }
 
 // Panicf uses fmt.Sprintf to log a templated message, then panics.
 func (s *SugaredLogger) Panicf(template string, args ...interface{}) {
-	s.log(PanicLevel, fmt.Sprintf(template, args...), nil)
+	s.log(PanicLevel, template, args, nil)
 }
 
 // Fatalf uses fmt.Sprintf to log a templated message, then calls os.Exit.
 func (s *SugaredLogger) Fatalf(template string, args ...interface{}) {
-	s.log(FatalLevel, fmt.Sprintf(template, args...), nil)
+	s.log(FatalLevel, template, args, nil)
 }
 
 // Debugw logs a message with some additional context. The variadic key-value
@@ -164,47 +164,61 @@ func (s *SugaredLogger) Fatalf(template string, args ...interface{}) {
 // When debug-level logging is disabled, this is much faster than
 //  s.With(keysAndValues).Debug(msg)
 func (s *SugaredLogger) Debugw(msg string, keysAndValues ...interface{}) {
-	s.log(DebugLevel, msg, keysAndValues)
+	s.log(DebugLevel, msg, nil, keysAndValues)
 }
 
 // Infow logs a message with some additional context. The variadic key-value
 // pairs are treated as they are in With.
 func (s *SugaredLogger) Infow(msg string, keysAndValues ...interface{}) {
-	s.log(InfoLevel, msg, keysAndValues)
+	s.log(InfoLevel, msg, nil, keysAndValues)
 }
 
 // Warnw logs a message with some additional context. The variadic key-value
 // pairs are treated as they are in With.
 func (s *SugaredLogger) Warnw(msg string, keysAndValues ...interface{}) {
-	s.log(WarnLevel, msg, keysAndValues)
+	s.log(WarnLevel, msg, nil, keysAndValues)
 }
 
 // Errorw logs a message with some additional context. The variadic key-value
 // pairs are treated as they are in With.
 func (s *SugaredLogger) Errorw(msg string, keysAndValues ...interface{}) {
-	s.log(ErrorLevel, msg, keysAndValues)
+	s.log(ErrorLevel, msg, nil, keysAndValues)
 }
 
 // DPanicw logs a message with some additional context. In development, the
 // logger then panics. (See DPanicLevel for details.) The variadic key-value
 // pairs are treated as they are in With.
 func (s *SugaredLogger) DPanicw(msg string, keysAndValues ...interface{}) {
-	s.log(DPanicLevel, msg, keysAndValues)
+	s.log(DPanicLevel, msg, nil, keysAndValues)
 }
 
 // Panicw logs a message with some additional context, then panics. The
 // variadic key-value pairs are treated as they are in With.
 func (s *SugaredLogger) Panicw(msg string, keysAndValues ...interface{}) {
-	s.log(PanicLevel, msg, keysAndValues)
+	s.log(PanicLevel, msg, nil, keysAndValues)
 }
 
 // Fatalw logs a message with some additional context, then calls os.Exit. The
 // variadic key-value pairs are treated as they are in With.
 func (s *SugaredLogger) Fatalw(msg string, keysAndValues ...interface{}) {
-	s.log(FatalLevel, msg, keysAndValues)
+	s.log(FatalLevel, msg, nil, keysAndValues)
 }
 
-func (s *SugaredLogger) log(lvl zapcore.Level, msg string, context []interface{}) {
+func (s *SugaredLogger) log(lvl zapcore.Level, template string, fmtArgs []interface{}, context []interface{}) {
+	// If logging at this level is completely disabled, skip the overhead of
+	// string formatting.
+	if lvl < DPanicLevel && !s.core.Facility().Enabled(lvl) {
+		return
+	}
+
+	// Format with Sprint, Sprintf, or neither.
+	msg := template
+	if msg == "" && len(fmtArgs) > 0 {
+		msg = fmt.Sprint(fmtArgs...)
+	} else if msg != "" && len(fmtArgs) > 0 {
+		msg = fmt.Sprintf(template, fmtArgs...)
+	}
+
 	if ce := s.core.Check(lvl, msg); ce != nil {
 		ce.Write(s.sweetenFields(context)...)
 	}

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -215,7 +215,8 @@ func TestSugarTemplatedLogging(t *testing.T) {
 	}{
 		{"", nil, ""},
 		{"foo", nil, "foo"},
-		{"", []interface{}{"foo"}, "%!(EXTRA string=foo)"},
+		// If the user fails to pass a template, degrade to fmt.Sprint.
+		{"", []interface{}{"foo"}, "foo"},
 	}
 
 	// Common to all test cases.


### PR DESCRIPTION
If levels are completely disabled, attempt to avoid the cost of string formatting.