### PR TITLE
Add test coverage for using levels in a FlagSet

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -29,6 +29,8 @@ import (
 // LevelFlag defines a Level flag with specified name, default value and
 // usage string. The return value is the address of a Level value that stores
 // the value of the flag.
+//
+// Note that you can also use any non-nil *Level as a flag.Value.
 func LevelFlag(name string, defaultLevel zapcore.Level, usage string) *zapcore.Level {
 	lvl := defaultLevel
 	flag.Var(&lvl, name, usage)


### PR DESCRIPTION
Levels implement `flag.Value`, so they should be usable in the standard lib's
flag sets. However, this wasn't covered by tests.

In the final push for docs, we'll need examples for these use cases.