### PR TITLE
Make encoder config more modular

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -33,7 +33,7 @@ func BenchmarkBoolsArrayMarshaler(b *testing.B) {
 	// Keep this benchmark here to capture the overhead of the ArrayMarshaler
 	// wrapper.
 	bs := make([]bool, 50)
-	enc := zapcore.NewJSONEncoder(zapcore.JSONConfig{})
+	enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Bools("array", bs).AddTo(enc.Clone())
@@ -42,7 +42,7 @@ func BenchmarkBoolsArrayMarshaler(b *testing.B) {
 
 func BenchmarkBoolsReflect(b *testing.B) {
 	bs := make([]bool, 50)
-	enc := zapcore.NewJSONEncoder(zapcore.JSONConfig{})
+	enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{})
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Reflect("array", bs).AddTo(enc.Clone())

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -54,27 +54,15 @@ var _jane = user{
 
 // TODO: remove this when we figure out a new config & options story.
 func benchEncoder() zapcore.Encoder {
-	msgF := func(msg string) zapcore.Field {
-		return zap.String("msg", msg)
-	}
-	timeF := func(t time.Time) zapcore.Field {
-		millis := t.UnixNano() / int64(time.Millisecond)
-		return zap.Int64("ts", millis)
-	}
-	levelF := func(l zapcore.Level) zapcore.Field {
-		return zap.String("level", l.String())
-	}
-	nameF := func(n string) zapcore.Field {
-		if n == "" {
-			return zap.Skip()
-		}
-		return zap.String("name", n)
-	}
-	return zapcore.NewJSONEncoder(zapcore.JSONConfig{
-		MessageFormatter: msgF,
-		TimeFormatter:    timeF,
-		LevelFormatter:   levelF,
-		NameFormatter:    nameF,
+	return zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+		MessageKey:        "msg",
+		LevelKey:          "level",
+		TimeKey:           "ts",
+		CallerKey:         "caller",
+		StacktraceKey:     "stacktrace",
+		TimeFormatter:     func(t time.Time, enc zapcore.ArrayEncoder) { enc.AppendInt64(t.UnixNano() / int64(time.Millisecond)) },
+		DurationFormatter: func(d time.Duration, enc zapcore.ArrayEncoder) { enc.AppendInt64(int64(d)) },
+		LevelFormatter:    func(l zapcore.Level, enc zapcore.ArrayEncoder) { enc.AppendString(l.String()) },
 	})
 }
 

--- a/logger.go
+++ b/logger.go
@@ -30,28 +30,17 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func defaultEncoderConfig() zapcore.JSONConfig {
-	msgF := func(msg string) zapcore.Field {
-		return String("msg", msg)
-	}
-	timeF := func(t time.Time) zapcore.Field {
-		millis := t.UnixNano() / int64(time.Millisecond)
-		return Int64("ts", millis)
-	}
-	levelF := func(l zapcore.Level) zapcore.Field {
-		return String("level", l.String())
-	}
-	nameF := func(n string) zapcore.Field {
-		if n == "" {
-			return Skip()
-		}
-		return String("name", n)
-	}
-	return zapcore.JSONConfig{
-		MessageFormatter: msgF,
-		TimeFormatter:    timeF,
-		LevelFormatter:   levelF,
-		NameFormatter:    nameF,
+func defaultEncoderConfig() zapcore.EncoderConfig {
+	return zapcore.EncoderConfig{
+		MessageKey:        "msg",
+		TimeKey:           "ts",
+		LevelKey:          "level",
+		NameKey:           "name",
+		CallerKey:         "caller",
+		StacktraceKey:     "stacktrace",
+		TimeFormatter:     func(t time.Time, enc zapcore.ArrayEncoder) { enc.AppendInt64(t.UnixNano() / int64(time.Millisecond)) },
+		DurationFormatter: func(d time.Duration, enc zapcore.ArrayEncoder) { enc.AppendInt64(int64(d)) },
+		LevelFormatter:    func(l zapcore.Level, enc zapcore.ArrayEncoder) { enc.AppendString(l.String()) },
 	}
 }
 

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -20,6 +20,21 @@
 
 package zapcore
 
+import "time"
+
+// An EncoderConfig allows users to configure the concrete encoders supplied by
+// zapcore.
+type EncoderConfig struct {
+	// Set the keys used for each log entry.
+	MessageKey, LevelKey, TimeKey, NameKey, CallerKey, StacktraceKey string
+	// Configure the primitive representations of common complex types. For
+	// example, some users may want all time.Times serialized as floating-point
+	// seconds since epoch, while others may prefer ISO8601 strings.
+	LevelFormatter    func(Level, ArrayEncoder)
+	TimeFormatter     func(time.Time, ArrayEncoder)
+	DurationFormatter func(time.Duration, ArrayEncoder)
+}
+
 // ObjectEncoder is a strongly-typed, encoding-agnostic interface for adding a
 // map- or struct-like object to the logging context. Like maps, ObjectEncoders
 // aren't safe for concurrent use (though typical use shouldn't require locks).

--- a/zapcore/facility_test.go
+++ b/zapcore/facility_test.go
@@ -106,7 +106,7 @@ func TestWriterFacilitySyncsOutput(t *testing.T) {
 	for _, tt := range tests {
 		sink := &testutils.Discarder{}
 		fac := WriterFacility(
-			NewJSONEncoder(testJSONConfig()),
+			NewJSONEncoder(testEncoderConfig()),
 			sink,
 			DebugLevel,
 		)
@@ -118,7 +118,7 @@ func TestWriterFacilitySyncsOutput(t *testing.T) {
 
 func TestWriterFacilityWriteFailure(t *testing.T) {
 	fac := WriterFacility(
-		NewJSONEncoder(testJSONConfig()),
+		NewJSONEncoder(testEncoderConfig()),
 		Lock(&testutils.FailWriter{}),
 		DebugLevel,
 	)
@@ -129,7 +129,7 @@ func TestWriterFacilityWriteFailure(t *testing.T) {
 
 func TestWriterFacilityShortWrite(t *testing.T) {
 	fac := WriterFacility(
-		NewJSONEncoder(testJSONConfig()),
+		NewJSONEncoder(testEncoderConfig()),
 		Lock(&testutils.ShortWriter{}),
 		DebugLevel,
 	)

--- a/zapcore/tee_logger_bench_test.go
+++ b/zapcore/tee_logger_bench_test.go
@@ -29,8 +29,8 @@ import (
 
 func withBenchedTee(b *testing.B, f func(Facility)) {
 	fac := Tee(
-		WriterFacility(NewJSONEncoder(testJSONConfig()), &testutils.Discarder{}, DebugLevel),
-		WriterFacility(NewJSONEncoder(testJSONConfig()), &testutils.Discarder{}, InfoLevel),
+		WriterFacility(NewJSONEncoder(testEncoderConfig()), &testutils.Discarder{}, DebugLevel),
+		WriterFacility(NewJSONEncoder(testEncoderConfig()), &testutils.Discarder{}, InfoLevel),
 	)
 	b.ResetTimer()
 	f(fac)


### PR DESCRIPTION
This is a pre-factoring before addressing #259. It makes encoder configuration more modular, splitting configuration of message/name/timestamp keys from the formatting of the values. (This was enabled by our work on array support.) Two things to note about that change:

1. It highlights our need for a user-facing defaults + functional options paradigm (#221). Once we have one of those, most of the long struct declarations introduced here will go away.
2. In `zapcore`, I didn't attempt to guard against nil formatters; I'd rather let the user-facing `zap` package define safe defaults (also part of #221).