### PR TITLE
Add support for logging to isolated namespaces

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -102,10 +102,10 @@ func TestArrayWrappers(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		enc := make(zapcore.MapObjectEncoder)
+		enc := zapcore.NewMapObjectEncoder()
 		tt.field.Key = "k"
 		tt.field.AddTo(enc)
-		assert.Equal(t, tt.expected, enc["k"], "%s: unexpected map contents.", tt.desc)
-		assert.Equal(t, 1, len(enc), "%s: found extra keys in map: %v", tt.desc, enc)
+		assert.Equal(t, tt.expected, enc.Fields["k"], "%s: unexpected map contents.", tt.desc)
+		assert.Equal(t, 1, len(enc.Fields), "%s: found extra keys in map: %v", tt.desc, enc.Fields)
 	}
 }

--- a/field.go
+++ b/field.go
@@ -213,12 +213,6 @@ func Object(key string, val zapcore.ObjectMarshaler) zapcore.Field {
 	return zapcore.Field{Key: key, Type: zapcore.ObjectMarshalerType, Interface: val}
 }
 
-// Nest takes a key and a variadic number of zapcore.Fields and creates a nested
-// namespace.
-func Nest(key string, fields ...zapcore.Field) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.ObjectMarshalerType, Interface: zapcore.Fields(fields)}
-}
-
 // Any takes a key and an arbitrary value and chooses the best way to represent
 // them as a field, falling back to a reflection-based approach only if
 // necessary.

--- a/field.go
+++ b/field.go
@@ -160,6 +160,15 @@ func Reflect(key string, val interface{}) zapcore.Field {
 	return zapcore.Field{Key: key, Type: zapcore.ReflectType, Interface: val}
 }
 
+// Namespace creates a named, isolated scope within the logger's context. All
+// subsequent fields will be added to the new namespace.
+//
+// This can help to prevent key collisions when injecting loggers into
+// sub-components or third-party libraries.
+func Namespace(key string) zapcore.Field {
+	return zapcore.Field{Key: key, Type: zapcore.NamespaceType}
+}
+
 // Stringer constructs a field with the given key and the output of the value's
 // String method. The Stringer's String method is called lazily.
 func Stringer(key string, val fmt.Stringer) zapcore.Field {

--- a/field_test.go
+++ b/field_test.go
@@ -70,7 +70,6 @@ func TestFieldConstructors(t *testing.T) {
 	addr := net.ParseIP("1.2.3.4")
 	name := username("phil")
 	ints := []int{5, 6}
-	nested := zapcore.Fields{String("name", "phil"), Int("age", 42)}
 
 	tests := []struct {
 		name   string
@@ -105,7 +104,6 @@ func TestFieldConstructors(t *testing.T) {
 		{"Stringer", zapcore.Field{Key: "k", Type: zapcore.StringerType, Interface: addr}, Stringer("k", addr)},
 		{"Base64", zapcore.Field{Key: "k", Type: zapcore.StringType, String: "YWIxMg=="}, Base64("k", []byte("ab12"))},
 		{"Object", zapcore.Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: name}, Object("k", name)},
-		{"Nest", zapcore.Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: nested}, Nest("k", nested...)},
 		{"Any:ObjectMarshaler", Any("k", name), Object("k", name)},
 		{"Any:ArrayMarshaler", Any("k", bools([]bool{true})), Array("k", bools([]bool{true}))},
 		{"Any:Bool", Any("k", true), Bool("k", true)},

--- a/field_test.go
+++ b/field_test.go
@@ -48,7 +48,7 @@ func assertCanBeReused(t testing.TB, field zapcore.Field) {
 	var wg sync.WaitGroup
 
 	for i := 0; i < 100; i++ {
-		enc := make(zapcore.MapObjectEncoder)
+		enc := zapcore.NewMapObjectEncoder()
 
 		// Ensure using the field in multiple encoders in separate goroutines
 		// does not cause any races or panics.

--- a/field_test.go
+++ b/field_test.go
@@ -130,6 +130,7 @@ func TestFieldConstructors(t *testing.T) {
 		{"Any:Duration", Any("k", time.Second), Duration("k", time.Second)},
 		{"Any:Stringer", Any("k", addr), Stringer("k", addr)},
 		{"Any:Fallback", Any("k", struct{}{}), Reflect("k", struct{}{})},
+		{"Namespace", Namespace("k"), zapcore.Field{Key: "k", Type: zapcore.NamespaceType}},
 	}
 
 	for _, tt := range tests {

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -69,6 +69,10 @@ type ObjectEncoder interface {
 	// AddReflected uses reflection to serialize arbitrary objects, so it's slow
 	// and allocation-heavy.
 	AddReflected(key string, value interface{}) error
+	// OpenNamespace opens an isolated namespace where all subsequent fields will
+	// be added. Applications can use namespaces to prevent key collisions when
+	// injecting loggers into sub-components or third-party libraries.
+	OpenNamespace(key string)
 }
 
 // ArrayEncoder is a strongly-typed, encoding-agnostic interface for adding

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -78,6 +78,9 @@ const (
 	// ReflectType indicates that the field carries an interface{}, which should
 	// be serialized using reflection.
 	ReflectType
+	// NamespaceType signals the beginning of an isolated namespace. All
+	// subsequent fields should be added to the new namespace.
+	NamespaceType
 	// StringerType indicates that the field carries a fmt.Stringer.
 	StringerType
 	// ErrorType indicates that the field carries an error.
@@ -147,6 +150,8 @@ func (f Field) AddTo(enc ObjectEncoder) {
 		enc.AddUintptr(f.Key, uintptr(f.Integer))
 	case ReflectType:
 		err = enc.AddReflected(f.Key, f.Interface)
+	case NamespaceType:
+		enc.OpenNamespace(f.Key)
 	case StringerType:
 		enc.AddString(f.Key, f.Interface.(fmt.Stringer).String())
 	case ErrorType:

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -197,13 +197,14 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 		{
 			desc: "namespace",
 			// EncodeEntry is responsible for closing all open namespaces.
-			expected: `"foo":1,"outer":{"foo":2,"inner":{"foo":3`,
+			expected: `"outermost":{"outer":{"foo":1,"inner":{"foo":2,"innermost":{`,
 			f: func(e Encoder) {
-				e.AddInt("foo", 1)
+				e.OpenNamespace("outermost")
 				e.OpenNamespace("outer")
-				e.AddInt("foo", 2)
+				e.AddInt("foo", 1)
 				e.OpenNamespace("inner")
-				e.AddInt("foo", 3)
+				e.AddInt("foo", 2)
+				e.OpenNamespace("innermost")
 			},
 		},
 	}

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -194,6 +194,18 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 				assert.Error(t, e.AddReflected("k", noJSON{}), "Unexpected success JSON-serializing a noJSON.")
 			},
 		},
+		{
+			desc: "namespace",
+			// EncodeEntry is responsible for closing all open namespaces.
+			expected: `"foo":1,"outer":{"foo":2,"inner":{"foo":3`,
+			f: func(e Encoder) {
+				e.AddInt("foo", 1)
+				e.OpenNamespace("outer")
+				e.AddInt("foo", 2)
+				e.OpenNamespace("inner")
+				e.AddInt("foo", 3)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/zapcore/json_encoder_test.go
+++ b/zapcore/json_encoder_test.go
@@ -298,3 +298,17 @@ func TestJSONEncodeEntry(t *testing.T) {
 		)
 	})
 }
+
+func TestJSONEncodeEntryClosesNamespaces(t *testing.T) {
+	withJSONEncoder(func(enc Encoder) {
+		enc.OpenNamespace("outer")
+		enc.OpenNamespace("inner")
+		buf, err := enc.EncodeEntry(Entry{Message: `hello`, Time: time.Unix(0, 0)}, nil)
+		assert.NoError(t, err, "EncodeEntry returned an unexpected error.")
+		assert.Equal(
+			t,
+			`{"level":"info","ts":0,"msg":"hello","outer":{"inner":{}}}`+"\n",
+			string(buf),
+		)
+	})
+}

--- a/zapcore/memory_encoder.go
+++ b/zapcore/memory_encoder.go
@@ -26,8 +26,10 @@ import "time"
 // map[string]interface{}. It's not fast enough for production use, but it's
 // helpful in tests.
 type MapObjectEncoder struct {
+	// Fields contains the entire encoded log context.
 	Fields map[string]interface{}
-	cur    map[string]interface{}
+	// cur is a pointer to the namespace we're currently writing to.
+	cur map[string]interface{}
 }
 
 // NewMapObjectEncoder creates a new map-backed ObjectEncoder.
@@ -61,7 +63,7 @@ func (m *MapObjectEncoder) AddBool(k string, v bool) { m.cur[k] = v }
 func (m *MapObjectEncoder) AddByte(k string, v byte) { m.cur[k] = v }
 
 // AddDuration implements ObjectEncoder.
-func (m MapObjectEncoder) AddDuration(k string, v time.Duration) { m[k] = v }
+func (m MapObjectEncoder) AddDuration(k string, v time.Duration) { m.cur[k] = v }
 
 // AddComplex128 implements ObjectEncoder.
 func (m *MapObjectEncoder) AddComplex128(k string, v complex128) { m.cur[k] = v }
@@ -97,7 +99,7 @@ func (m *MapObjectEncoder) AddRune(k string, v rune) { m.cur[k] = v }
 func (m *MapObjectEncoder) AddString(k string, v string) { m.cur[k] = v }
 
 // AddTime implements ObjectEncoder.
-func (m MapObjectEncoder) AddTime(k string, v time.Time) { m[k] = v }
+func (m MapObjectEncoder) AddTime(k string, v time.Time) { m.cur[k] = v }
 
 // AddUint implements ObjectEncoder.
 func (m *MapObjectEncoder) AddUint(k string, v uint) { m.cur[k] = v }

--- a/zapcore/memory_encoder.go
+++ b/zapcore/memory_encoder.go
@@ -123,6 +123,13 @@ func (m *MapObjectEncoder) AddReflected(k string, v interface{}) error {
 	return nil
 }
 
+// OpenNamespace implements ObjectEncoder.
+func (m *MapObjectEncoder) OpenNamespace(k string) {
+	ns := make(map[string]interface{})
+	m.cur[k] = ns
+	m.cur = ns
+}
+
 // sliceArrayEncoder is an ArrayEncoder backed by a simple []interface{}. Like
 // the MapObjectEncoder, it's not designed for production use.
 type sliceArrayEncoder struct {

--- a/zapcore/memory_encoder.go
+++ b/zapcore/memory_encoder.go
@@ -25,89 +25,101 @@ import "time"
 // MapObjectEncoder is an ObjectEncoder backed by a simple
 // map[string]interface{}. It's not fast enough for production use, but it's
 // helpful in tests.
-type MapObjectEncoder map[string]interface{}
+type MapObjectEncoder struct {
+	Fields map[string]interface{}
+	cur    map[string]interface{}
+}
+
+// NewMapObjectEncoder creates a new map-backed ObjectEncoder.
+func NewMapObjectEncoder() *MapObjectEncoder {
+	m := make(map[string]interface{})
+	return &MapObjectEncoder{
+		Fields: m,
+		cur:    m,
+	}
+}
 
 // AddArray implements ObjectEncoder.
-func (m MapObjectEncoder) AddArray(key string, v ArrayMarshaler) error {
+func (m *MapObjectEncoder) AddArray(key string, v ArrayMarshaler) error {
 	arr := &sliceArrayEncoder{}
 	err := v.MarshalLogArray(arr)
-	m[key] = arr.elems
+	m.cur[key] = arr.elems
 	return err
 }
 
 // AddObject implements ObjectEncoder.
-func (m MapObjectEncoder) AddObject(k string, v ObjectMarshaler) error {
-	newMap := make(MapObjectEncoder)
-	m[k] = newMap
+func (m *MapObjectEncoder) AddObject(k string, v ObjectMarshaler) error {
+	newMap := NewMapObjectEncoder()
+	m.cur[k] = newMap.Fields
 	return v.MarshalLogObject(newMap)
 }
 
 // AddBool implements ObjectEncoder.
-func (m MapObjectEncoder) AddBool(k string, v bool) { m[k] = v }
+func (m *MapObjectEncoder) AddBool(k string, v bool) { m.cur[k] = v }
 
 // AddByte implements ObjectEncoder.
-func (m MapObjectEncoder) AddByte(k string, v byte) { m[k] = v }
+func (m *MapObjectEncoder) AddByte(k string, v byte) { m.cur[k] = v }
 
 // AddDuration implements ObjectEncoder.
 func (m MapObjectEncoder) AddDuration(k string, v time.Duration) { m[k] = v }
 
 // AddComplex128 implements ObjectEncoder.
-func (m MapObjectEncoder) AddComplex128(k string, v complex128) { m[k] = v }
+func (m *MapObjectEncoder) AddComplex128(k string, v complex128) { m.cur[k] = v }
 
 // AddComplex64 implements ObjectEncoder.
-func (m MapObjectEncoder) AddComplex64(k string, v complex64) { m[k] = v }
+func (m *MapObjectEncoder) AddComplex64(k string, v complex64) { m.cur[k] = v }
 
 // AddFloat64 implements ObjectEncoder.
-func (m MapObjectEncoder) AddFloat64(k string, v float64) { m[k] = v }
+func (m *MapObjectEncoder) AddFloat64(k string, v float64) { m.cur[k] = v }
 
 // AddFloat32 implements ObjectEncoder.
-func (m MapObjectEncoder) AddFloat32(k string, v float32) { m[k] = v }
+func (m *MapObjectEncoder) AddFloat32(k string, v float32) { m.cur[k] = v }
 
 // AddInt implements ObjectEncoder.
-func (m MapObjectEncoder) AddInt(k string, v int) { m[k] = v }
+func (m *MapObjectEncoder) AddInt(k string, v int) { m.cur[k] = v }
 
 // AddInt64 implements ObjectEncoder.
-func (m MapObjectEncoder) AddInt64(k string, v int64) { m[k] = v }
+func (m *MapObjectEncoder) AddInt64(k string, v int64) { m.cur[k] = v }
 
 // AddInt32 implements ObjectEncoder.
-func (m MapObjectEncoder) AddInt32(k string, v int32) { m[k] = v }
+func (m *MapObjectEncoder) AddInt32(k string, v int32) { m.cur[k] = v }
 
 // AddInt16 implements ObjectEncoder.
-func (m MapObjectEncoder) AddInt16(k string, v int16) { m[k] = v }
+func (m *MapObjectEncoder) AddInt16(k string, v int16) { m.cur[k] = v }
 
 // AddInt8 implements ObjectEncoder.
-func (m MapObjectEncoder) AddInt8(k string, v int8) { m[k] = v }
+func (m *MapObjectEncoder) AddInt8(k string, v int8) { m.cur[k] = v }
 
 // AddRune implements ObjectEncoder.
-func (m MapObjectEncoder) AddRune(k string, v rune) { m[k] = v }
+func (m *MapObjectEncoder) AddRune(k string, v rune) { m.cur[k] = v }
 
 // AddString implements ObjectEncoder.
-func (m MapObjectEncoder) AddString(k string, v string) { m[k] = v }
+func (m *MapObjectEncoder) AddString(k string, v string) { m.cur[k] = v }
 
 // AddTime implements ObjectEncoder.
 func (m MapObjectEncoder) AddTime(k string, v time.Time) { m[k] = v }
 
 // AddUint implements ObjectEncoder.
-func (m MapObjectEncoder) AddUint(k string, v uint) { m[k] = v }
+func (m *MapObjectEncoder) AddUint(k string, v uint) { m.cur[k] = v }
 
 // AddUint64 implements ObjectEncoder.
-func (m MapObjectEncoder) AddUint64(k string, v uint64) { m[k] = v }
+func (m *MapObjectEncoder) AddUint64(k string, v uint64) { m.cur[k] = v }
 
 // AddUint32 implements ObjectEncoder.
-func (m MapObjectEncoder) AddUint32(k string, v uint32) { m[k] = v }
+func (m *MapObjectEncoder) AddUint32(k string, v uint32) { m.cur[k] = v }
 
 // AddUint16 implements ObjectEncoder.
-func (m MapObjectEncoder) AddUint16(k string, v uint16) { m[k] = v }
+func (m *MapObjectEncoder) AddUint16(k string, v uint16) { m.cur[k] = v }
 
 // AddUint8 implements ObjectEncoder.
-func (m MapObjectEncoder) AddUint8(k string, v uint8) { m[k] = v }
+func (m *MapObjectEncoder) AddUint8(k string, v uint8) { m.cur[k] = v }
 
 // AddUintptr implements ObjectEncoder.
-func (m MapObjectEncoder) AddUintptr(k string, v uintptr) { m[k] = v }
+func (m *MapObjectEncoder) AddUintptr(k string, v uintptr) { m.cur[k] = v }
 
 // AddReflected implements ObjectEncoder.
-func (m MapObjectEncoder) AddReflected(k string, v interface{}) error {
-	m[k] = v
+func (m *MapObjectEncoder) AddReflected(k string, v interface{}) error {
+	m.cur[k] = v
 	return nil
 }
 
@@ -125,9 +137,9 @@ func (s *sliceArrayEncoder) AppendArray(v ArrayMarshaler) error {
 }
 
 func (s *sliceArrayEncoder) AppendObject(v ObjectMarshaler) error {
-	m := make(MapObjectEncoder)
+	m := NewMapObjectEncoder()
 	err := v.MarshalLogObject(m)
-	s.elems = append(s.elems, m)
+	s.elems = append(s.elems, m.Fields)
 	return err
 }
 

--- a/zapcore/memory_encoder_test.go
+++ b/zapcore/memory_encoder_test.go
@@ -29,10 +29,10 @@ import (
 
 func TestMapObjectEncoderAdd(t *testing.T) {
 	// Expected output of a turducken.
-	wantTurducken := MapObjectEncoder{
+	wantTurducken := map[string]interface{}{
 		"ducks": []interface{}{
-			MapObjectEncoder{"in": "chicken"},
-			MapObjectEncoder{"in": "chicken"},
+			map[string]interface{}{"in": "chicken"},
+			map[string]interface{}{"in": "chicken"},
 		},
 	}
 
@@ -46,7 +46,7 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 			f: func(e ObjectEncoder) {
 				assert.NoError(t, e.AddObject("k", loggable{true}), "Expected AddObject to succeed.")
 			},
-			expected: MapObjectEncoder{"loggable": "yes"},
+			expected: map[string]interface{}{"loggable": "yes"},
 		},
 		{
 			desc: "AddObject (nested)",
@@ -189,9 +189,9 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		enc := make(MapObjectEncoder)
+		enc := NewMapObjectEncoder()
 		tt.f(enc)
-		assert.Equal(t, tt.expected, enc["k"], "Unexpected encoder output.")
+		assert.Equal(t, tt.expected, enc.Fields["k"], "Unexpected encoder output.")
 	}
 }
 func TestSliceArrayEncoderAppend(t *testing.T) {
@@ -242,14 +242,14 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		enc := make(MapObjectEncoder)
+		enc := NewMapObjectEncoder()
 		assert.NoError(t, enc.AddArray("k", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
 			tt.f(arr)
 			tt.f(arr)
 			return nil
 		})), "Expected AddArray to succeed.")
 
-		arr, ok := enc["k"].([]interface{})
+		arr, ok := enc.Fields["k"].([]interface{})
 		if !ok {
 			t.Errorf("Test case %s didn't encode an array.", tt.desc)
 			continue
@@ -259,7 +259,12 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 }
 
 func TestMapObjectEncoderReflectionFailures(t *testing.T) {
-	enc := make(MapObjectEncoder)
+	enc := NewMapObjectEncoder()
 	assert.Error(t, enc.AddObject("object", loggable{false}), "Expected AddObject to fail.")
-	assert.Equal(t, MapObjectEncoder{"object": MapObjectEncoder{}}, enc, "Expected encoder to use empty values on errors.")
+	assert.Equal(
+		t,
+		map[string]interface{}{"object": map[string]interface{}{}},
+		enc.Fields,
+		"Expected encoder to use empty values on errors.",
+	)
 }

--- a/zapcore/memory_encoder_test.go
+++ b/zapcore/memory_encoder_test.go
@@ -186,6 +186,26 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 			},
 			expected: map[string]interface{}{"foo": 5},
 		},
+		{
+			desc: "OpenNamespace",
+			f: func(e ObjectEncoder) {
+				e.OpenNamespace("k")
+				e.AddInt("foo", 1)
+				e.OpenNamespace("middle")
+				e.AddInt("foo", 2)
+				e.OpenNamespace("inner")
+				e.AddInt("foo", 3)
+			},
+			expected: map[string]interface{}{
+				"foo": 1,
+				"middle": map[string]interface{}{
+					"foo": 2,
+					"inner": map[string]interface{}{
+						"foo": 3,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add an `OpenNamespace` method to encoders and create a `NamespaceType` field. This allows applications to force sub-components and third-party libraries to log into an isolated namespace, preventing key collisions. The approach taken here emphasizes that fields are just messages to encoders, and it combines well with #251 to let the sugared logger also support namespacing.

Along the way, this PR removes the `Nest` field constructor and encoder method, since they haven't proved useful in production and will inevitably create confusion with namespaces. If users need that functionality, they can still use `Object("foo", Fields{someField, someOtherField})`.

This fixes #132.