### PR TITLE
Drop support for Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: false
 go:
-  - 1.6
   - 1.7
   - tip
 go_import_path: go.uber.org/zap


### PR DESCRIPTION
As part of the 1.0 release, I'd really like to structure our benchmarks (and
some of our tests) using sub-tests/benchmarks. Go 1.8 is only a few weeks away
from a release, so I don't think it's too bad to drop support for 1.6 now.