### PR TITLE
Make Logger a concrete type instead of an interface

### DIFF
--- a/benchmarks/zap_sugar_bench_test.go
+++ b/benchmarks/zap_sugar_bench_test.go
@@ -50,11 +50,11 @@ func fakeSugarFormatArgs() (string, []interface{}) {
 }
 
 func newSugarLogger(lvl zapcore.Level, options ...zap.Option) *zap.SugaredLogger {
-	return zap.Sugar(zap.New(zapcore.WriterFacility(
+	return zap.New(zapcore.WriterFacility(
 		benchEncoder(),
 		&testutils.Discarder{},
 		lvl,
-	), options...))
+	), options...).Sugar()
 }
 
 func BenchmarkZapSugarDisabledLevelsWithoutFields(b *testing.B) {

--- a/common_test.go
+++ b/common_test.go
@@ -34,7 +34,7 @@ func opts(opts ...Option) []Option {
 
 // Here specifically to introduce an easily-identifiable filename for testing
 // stacktraces and caller skips.
-func withLogger(t testing.TB, e zapcore.LevelEnabler, opts []Option, f func(Logger, *observer.ObservedLogs)) {
+func withLogger(t testing.TB, e zapcore.LevelEnabler, opts []Option, f func(*Logger, *observer.ObservedLogs)) {
 	var logs observer.ObservedLogs
 	fac := observer.New(e, logs.Add, true)
 	log := New(fac, opts...)
@@ -42,7 +42,7 @@ func withLogger(t testing.TB, e zapcore.LevelEnabler, opts []Option, f func(Logg
 }
 
 func withSugar(t testing.TB, e zapcore.LevelEnabler, opts []Option, f func(*SugaredLogger, *observer.ObservedLogs)) {
-	withLogger(t, e, opts, func(logger Logger, logs *observer.ObservedLogs) { f(Sugar(logger), logs) })
+	withLogger(t, e, opts, func(logger *Logger, logs *observer.ObservedLogs) { f(logger.Sugar(), logs) })
 }
 
 func runConcurrently(goroutines, iterations int, wg *sync.WaitGroup, f func()) {

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHandler() (AtomicLevel, Logger) {
+func newHandler() (AtomicLevel, *Logger) {
 	lvl := DynamicLevel()
 	// XXX should be a discard facility
 	fac := observer.New(lvl, func(observer.LoggedEntry) error { return nil }, false)

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -48,7 +48,7 @@ var _jane = &user{
 	CreatedAt: time.Date(1980, 1, 1, 12, 0, 0, 0, time.UTC),
 }
 
-func withBenchedLogger(b *testing.B, f func(Logger)) {
+func withBenchedLogger(b *testing.B, f func(*Logger)) {
 	logger := New(
 		zapcore.WriterFacility(zapcore.NewJSONEncoder(defaultEncoderConfig()),
 			&testutils.Discarder{},
@@ -63,81 +63,81 @@ func withBenchedLogger(b *testing.B, f func(Logger)) {
 }
 
 func BenchmarkNoContext(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("No context.")
 	})
 }
 
 func BenchmarkBoolField(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Boolean.", Bool("foo", true))
 	})
 }
 
 func BenchmarkFloat64Field(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Floating point.", Float64("foo", 3.14))
 	})
 }
 
 func BenchmarkIntField(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Integer.", Int("foo", 42))
 	})
 }
 
 func BenchmarkInt64Field(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("64-bit integer.", Int64("foo", 42))
 	})
 }
 
 func BenchmarkStringField(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Strings.", String("foo", "bar"))
 	})
 }
 
 func BenchmarkStringerField(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Level.", Stringer("foo", InfoLevel))
 	})
 }
 
 func BenchmarkTimeField(b *testing.B) {
 	t := time.Unix(0, 0)
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Time.", Time("foo", t))
 	})
 }
 
 func BenchmarkDurationField(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Duration", Duration("foo", time.Second))
 	})
 }
 
 func BenchmarkErrorField(b *testing.B) {
 	err := errors.New("egad")
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Error.", Error(err))
 	})
 }
 
 func BenchmarkStackField(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Error.", Stack())
 	})
 }
 
 func BenchmarkObjectField(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Arbitrary ObjectMarshaler.", Object("user", _jane))
 	})
 }
 
 func BenchmarkReflectField(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Reflection-based serialization.", Reflect("user", _jane))
 	})
 }
@@ -160,7 +160,7 @@ func BenchmarkAddCallerHook(b *testing.B) {
 }
 
 func Benchmark10Fields(b *testing.B) {
-	withBenchedLogger(b, func(log Logger) {
+	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Ten fields, passed at the log site.",
 			Int("one", 1),
 			Int("two", 2),

--- a/options.go
+++ b/options.go
@@ -24,19 +24,19 @@ import "go.uber.org/zap/zapcore"
 
 // Option is used to set options for the logger.
 type Option interface {
-	apply(*logger)
+	apply(*Logger)
 }
 
 // optionFunc wraps a func so it satisfies the Option interface.
-type optionFunc func(*logger)
+type optionFunc func(*Logger)
 
-func (f optionFunc) apply(log *logger) {
+func (f optionFunc) apply(log *Logger) {
 	f(log)
 }
 
 // Fields sets the initial fields for the logger.
 func Fields(fs ...zapcore.Field) Option {
-	return optionFunc(func(log *logger) {
+	return optionFunc(func(log *Logger) {
 		log.fac = log.fac.With(fs)
 	})
 }
@@ -45,7 +45,7 @@ func Fields(fs ...zapcore.Field) Option {
 // supplied WriteSyncer is automatically wrapped with a mutex, so it need not be
 // safe for concurrent use.
 func ErrorOutput(w zapcore.WriteSyncer) Option {
-	return optionFunc(func(log *logger) {
+	return optionFunc(func(log *Logger) {
 		log.errorOutput = zapcore.Lock(w)
 	})
 }
@@ -53,7 +53,7 @@ func ErrorOutput(w zapcore.WriteSyncer) Option {
 // Development puts the logger in development mode, which alters the behavior
 // of the DPanic method.
 func Development() Option {
-	return optionFunc(func(log *logger) {
+	return optionFunc(func(log *Logger) {
 		log.development = true
 	})
 }
@@ -61,7 +61,7 @@ func Development() Option {
 // AddCaller configures the Logger to annotate each message with the filename
 // and line number of zap's caller.
 func AddCaller() Option {
-	return optionFunc(func(log *logger) {
+	return optionFunc(func(log *Logger) {
 		log.addCaller = true
 	})
 }
@@ -69,7 +69,7 @@ func AddCaller() Option {
 // AddCallerSkip increases the number of callers skipped by caller annotation
 // (as enabled by the AddCaller option).
 func AddCallerSkip(skip int) Option {
-	return optionFunc(func(log *logger) {
+	return optionFunc(func(log *Logger) {
 		log.callerSkip += skip
 	})
 }
@@ -81,7 +81,7 @@ func AddCallerSkip(skip int) Option {
 // TODO: why is this called AddStacks rather than just AddStack or
 // AddStacktrace?
 func AddStacks(lvl zapcore.LevelEnabler) Option {
-	return optionFunc(func(log *logger) {
+	return optionFunc(func(log *Logger) {
 		log.addStack = lvl
 	})
 }

--- a/sugar.go
+++ b/sugar.go
@@ -32,25 +32,21 @@ const (
 	_nonStringKeyErrMsg = "Ignored key-value pairs with non-string keys."
 )
 
-// A SugaredLogger wraps the core Logger functionality in a slower, but less
-// verbose, API.
+// A SugaredLogger wraps the base Logger functionality in a slower, but less
+// verbose, API. Any Logger can be converted to a SugaredLogger with its Sugar
+// method.
 type SugaredLogger struct {
-	core Logger
-}
-
-// Sugar converts a Logger to a SugaredLogger.
-func Sugar(core Logger) *SugaredLogger {
-	// TODO: increment caller skip.
-	return &SugaredLogger{core}
+	core *Logger
 }
 
 // Desugar unwraps a SugaredLogger, exposing the original Logger.
-func Desugar(s *SugaredLogger) Logger {
-	// TODO: decrement caller skip.
-	return s.core
+func (s *SugaredLogger) Desugar() *Logger {
+	base := s.core.clone()
+	base.callerSkip -= 2
+	return base
 }
 
-// Named adds a sub-scope to the logger's name.
+// Named adds a sub-scope to the logger's name. See Logger.Named for details.
 func (s *SugaredLogger) Named(name string) *SugaredLogger {
 	return &SugaredLogger{core: s.core.Named(name)}
 }

--- a/sugar_bench_test.go
+++ b/sugar_bench_test.go
@@ -28,10 +28,10 @@ import (
 )
 
 func withBenchedSugar(b *testing.B, f func(*SugaredLogger)) {
-	logger := Sugar(New(zapcore.WriterFacility(zapcore.NewJSONEncoder(defaultEncoderConfig()),
+	logger := New(zapcore.WriterFacility(zapcore.NewJSONEncoder(defaultEncoderConfig()),
 		&testutils.Discarder{},
 		DebugLevel,
-	)))
+	)).Sugar()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/zapcore/write_syncer.go
+++ b/zapcore/write_syncer.go
@@ -35,9 +35,8 @@ type WriteSyncer interface {
 }
 
 // AddSync converts an io.Writer to a WriteSyncer. It attempts to be
-// intelligent: if the concrete type of the io.Writer implements WriteSyncer or
-// WriteFlusher, we'll use the existing Sync or Flush methods. If it doesn't,
-// we'll add a no-op Sync method.
+// intelligent: if the concrete type of the io.Writer implements WriteSyncer,
+// we'll use the existing Sync method. If it doesn't, we'll add a no-op Sync.
 func AddSync(w io.Writer) WriteSyncer {
 	switch w := w.(type) {
 	case WriteSyncer:


### PR DESCRIPTION
`zapcore.Facility` is the extension point we're offering to third-party
developers, so there's no need to make the logger an interface. In fact, an
interface will be *more* constraining, since we won't be able to add any methods
after version 1.0.

Along the way, this fixes our woes with `AddCaller` not working properly (#40).