### PR TITLE
JSON-serialize pointers as hex

### DIFF
--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -126,6 +126,11 @@ func (enc *jsonEncoder) AddUint64(key string, val uint64) {
 	enc.AppendUint64(val)
 }
 
+func (enc *jsonEncoder) AddUintptr(key string, val uintptr) {
+	enc.addKey(key)
+	enc.AppendUintptr(val)
+}
+
 func (enc *jsonEncoder) AppendArray(arr ArrayMarshaler) error {
 	enc.addElementSeparator()
 	enc.bytes = append(enc.bytes, '[')
@@ -187,6 +192,13 @@ func (enc *jsonEncoder) AppendUint64(val uint64) {
 	enc.bytes = strconv.AppendUint(enc.bytes, val, 10)
 }
 
+func (enc *jsonEncoder) AppendUintptr(val uintptr) {
+	enc.addElementSeparator()
+	enc.bytes = append(enc.bytes, `"0x`...)
+	enc.bytes = strconv.AppendUint(enc.bytes, uint64(val), 16)
+	enc.bytes = append(enc.bytes, '"')
+}
+
 func (enc *jsonEncoder) AddByte(k string, v byte)           { enc.AddUint8(k, uint8(v)) }
 func (enc *jsonEncoder) AddComplex64(k string, v complex64) { enc.AddComplex128(k, complex128(v)) }
 func (enc *jsonEncoder) AddFloat32(k string, v float32)     { enc.AddFloat64(k, float64(v)) }
@@ -199,7 +211,6 @@ func (enc *jsonEncoder) AddUint(k string, v uint)           { enc.AddUint64(k, u
 func (enc *jsonEncoder) AddUint32(k string, v uint32)       { enc.AddUint64(k, uint64(v)) }
 func (enc *jsonEncoder) AddUint16(k string, v uint16)       { enc.AddUint64(k, uint64(v)) }
 func (enc *jsonEncoder) AddUint8(k string, v uint8)         { enc.AddUint64(k, uint64(v)) }
-func (enc *jsonEncoder) AddUintptr(k string, v uintptr)     { enc.AddUint64(k, uint64(v)) }
 func (enc *jsonEncoder) AppendByte(v byte)                  { enc.AppendUint8(uint8(v)) }
 func (enc *jsonEncoder) AppendComplex64(v complex64)        { enc.AppendComplex128(complex128(v)) }
 func (enc *jsonEncoder) AppendDuration(val time.Duration)   { enc.EncodeDuration(val, enc) }
@@ -215,7 +226,6 @@ func (enc *jsonEncoder) AppendUint(v uint)                  { enc.AppendUint64(u
 func (enc *jsonEncoder) AppendUint32(v uint32)              { enc.AppendUint64(uint64(v)) }
 func (enc *jsonEncoder) AppendUint16(v uint16)              { enc.AppendUint64(uint64(v)) }
 func (enc *jsonEncoder) AppendUint8(v uint8)                { enc.AppendUint64(uint64(v)) }
-func (enc *jsonEncoder) AppendUintptr(v uintptr)            { enc.AppendUint64(uint64(v)) }
 
 func (enc *jsonEncoder) Clone() Encoder {
 	clone := *enc

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -129,7 +129,7 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 		{"uint32", `"k":42`, func(e Encoder) { e.AddUint32("k", 42) }},
 		{"uint16", `"k":42`, func(e Encoder) { e.AddUint16("k", 42) }},
 		{"uint8", `"k":42`, func(e Encoder) { e.AddUint8("k", 42) }},
-		{"uintptr", `"k":42`, func(e Encoder) { e.AddUintptr("k", 42) }},
+		{"uintptr", `"k":"0x2a"`, func(e Encoder) { e.AddUintptr("k", 42) }},
 		{
 			desc:     "object (success)",
 			expected: `"k":{"loggable":"yes"}`,
@@ -241,7 +241,7 @@ func TestJSONEncoderArrays(t *testing.T) {
 		{"uint32", `[42,42]`, func(e ArrayEncoder) { e.AppendUint32(42) }},
 		{"uint16", `[42,42]`, func(e ArrayEncoder) { e.AppendUint16(42) }},
 		{"uint8", `[42,42]`, func(e ArrayEncoder) { e.AppendUint8(42) }},
-		{"uintptr", `[42,42]`, func(e ArrayEncoder) { e.AppendUintptr(42) }},
+		{"uintptr", `["0x2a","0x2a"]`, func(e ArrayEncoder) { e.AppendUintptr(42) }},
 		{
 			desc:     "arrays (success)",
 			expected: `[[true],[true]]`,


### PR DESCRIPTION
This is a small change to encoder `uintptr` as hex, which is a bit more familiar and matches the standard lib's stacktraces. This seems like an improvement to me, but I can certainly be convinced to abandon it.