### PR TITLE
Add RFC3339NanoFormatter and UnixNanoFormatter

### DIFF
--- a/json_options.go
+++ b/json_options.go
@@ -59,11 +59,27 @@ func EpochFormatter(key string) TimeFormatter {
 	})
 }
 
+// UnixNanoFormatter encodes the entry time as a single int64 with nanosecond
+// precision under the provided key.
+func UnixNanoFormatter(key string) TimeFormatter {
+	return TimeFormatter(func(t time.Time) Field {
+		return Int64(key, t.UnixNano())
+	})
+}
+
 // RFC3339Formatter encodes the entry time as an RFC3339-formatted string under
 // the provided key.
 func RFC3339Formatter(key string) TimeFormatter {
 	return TimeFormatter(func(t time.Time) Field {
 		return String(key, t.Format(time.RFC3339))
+	})
+}
+
+// RFC3339NanoFormatter encodes the entry time as an RFC3339-formatted string
+// with nanosecond precision under the provided key.
+func RFC3339NanoFormatter(key string) TimeFormatter {
+	return TimeFormatter(func(t time.Time) Field {
+		return String(key, t.Format(time.RFC3339Nano))
 	})
 }
 

--- a/json_options_test.go
+++ b/json_options_test.go
@@ -22,6 +22,7 @@ package zap
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -57,6 +58,23 @@ func TestTimeFormatters(t *testing.T) {
 
 	for _, tt := range tests {
 		assert.Equal(t, tt.expected, tt.formatter(epoch), "Unexpected output from TimeFormatter %s.", tt.name)
+	}
+}
+
+func TestNanoTimeFormatters(t *testing.T) {
+	testtime := time.Date(2017, time.February, 4, 18, 48, 2, 300537459, time.UTC)
+
+	tests := []struct {
+		name      string
+		formatter TimeFormatter
+		expected  Field
+	}{
+		{"UnixNanoFormatter", UnixNanoFormatter("the-time"), Int64("the-time", 1486234082300537459)},
+		{"RFC3339Nano", RFC3339NanoFormatter("ts"), String("ts", "2017-02-04T18:48:02.300537459Z")},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, tt.formatter(testtime), "Unexpected output from TimeFormatter %s.", tt.name)
 	}
 }
 


### PR DESCRIPTION
Adds support for two different methods of logging in nanosecond precision without losing information. 

Both are new TimeFormatters, so that no existing code will break. RFC3339NanoFormatter is similar to RFC3339Formatter but uses `time.RFC3339Nano` instead of `time.RFC3339`, and UnixNanoFormatter uses `time.Time.UnixNano()` int64 output that is fast to both serialize and read back in time.Time format.

See #275 for the issue in question.


- [x] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [x] added tests to cover your changes;
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).