### PR TITLE
Add a no-op Facility

### DIFF
--- a/zapcore/facility.go
+++ b/zapcore/facility.go
@@ -41,6 +41,19 @@ type Facility interface {
 	Write(Entry, []Field) error
 }
 
+type nopFacility struct{}
+
+// NopFacility returns a no-op Facility.
+func NopFacility() Facility { return nopFacility{} }
+
+func (nopFacility) Enabled(Level) bool { return false }
+
+func (n nopFacility) With([]Field) Facility { return n }
+
+func (n nopFacility) Check(_ Entry, ce *CheckedEntry) *CheckedEntry { return ce }
+
+func (nopFacility) Write(Entry, []Field) error { return nil }
+
 // WriterFacility creates a facility that writes logs to a WriteSyncer. By
 // default, if w is nil, os.Stdout is used.
 func WriterFacility(enc Encoder, ws WriteSyncer, enab LevelEnabler) Facility {

--- a/zapcore/facility.go
+++ b/zapcore/facility.go
@@ -44,15 +44,11 @@ type Facility interface {
 type nopFacility struct{}
 
 // NopFacility returns a no-op Facility.
-func NopFacility() Facility { return nopFacility{} }
-
-func (nopFacility) Enabled(Level) bool { return false }
-
-func (n nopFacility) With([]Field) Facility { return n }
-
-func (n nopFacility) Check(_ Entry, ce *CheckedEntry) *CheckedEntry { return ce }
-
-func (nopFacility) Write(Entry, []Field) error { return nil }
+func NopFacility() Facility                                       { return nopFacility{} }
+func (nopFacility) Enabled(Level) bool                            { return false }
+func (n nopFacility) With([]Field) Facility                       { return n }
+func (nopFacility) Check(_ Entry, ce *CheckedEntry) *CheckedEntry { return ce }
+func (nopFacility) Write(Entry, []Field) error                    { return nil }
 
 // WriterFacility creates a facility that writes logs to a WriteSyncer. By
 // default, if w is nil, os.Stdout is used.

--- a/zapcore/facility_test.go
+++ b/zapcore/facility_test.go
@@ -36,6 +36,34 @@ func makeInt64Field(key string, val int) Field {
 	return Field{Type: Int64Type, Integer: int64(val), Key: key}
 }
 
+func TestNopFacility(t *testing.T) {
+	entry := Entry{
+		Message:    "test",
+		Level:      InfoLevel,
+		Time:       time.Now(),
+		LoggerName: "main",
+		Stack:      "fake-stack",
+	}
+	ce := &CheckedEntry{}
+
+	allLevels := []Level{
+		DebugLevel,
+		InfoLevel,
+		WarnLevel,
+		ErrorLevel,
+		DPanicLevel,
+		PanicLevel,
+		FatalLevel,
+	}
+	fac := NopFacility()
+	assert.Equal(t, fac, fac.With([]Field{makeInt64Field("k", 42)}), "Expected no-op With.")
+	for _, level := range allLevels {
+		assert.False(t, fac.Enabled(level), "Expected all levels to be disabled in no-op facility.")
+		assert.Equal(t, ce, fac.Check(entry, ce), "Expected no-op Check to return checked entry unchanged.")
+		assert.NoError(t, fac.Write(entry, nil), "Expected no-op Writes to always succeed.")
+	}
+}
+
 func TestObserverWith(t *testing.T) {
 	var logs observer.ObservedLogs
 	sf1 := observer.New(InfoLevel, logs.Add, true)


### PR DESCRIPTION
This is a portion of our terse config and global logger story; for both, we'll
want a no-op logger, and therefore, a no-op Facility.