### PR TITLE
Export Level-, Time-, and DurationEncoders

### DIFF
--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -60,9 +60,9 @@ func benchEncoder() zapcore.Encoder {
 		TimeKey:        "ts",
 		CallerKey:      "caller",
 		StacktraceKey:  "stacktrace",
-		EncodeTime:     func(t time.Time, enc zapcore.ArrayEncoder) { enc.AppendInt64(t.UnixNano() / int64(time.Millisecond)) },
-		EncodeDuration: func(d time.Duration, enc zapcore.ArrayEncoder) { enc.AppendInt64(int64(d)) },
-		EncodeLevel:    func(l zapcore.Level, enc zapcore.ArrayEncoder) { enc.AppendString(l.String()) },
+		EncodeTime:     zapcore.EpochTimeEncoder,
+		EncodeDuration: zapcore.NanosDurationEncoder,
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
 	})
 }
 

--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -61,7 +61,7 @@ func benchEncoder() zapcore.Encoder {
 		CallerKey:      "caller",
 		StacktraceKey:  "stacktrace",
 		EncodeTime:     zapcore.EpochTimeEncoder,
-		EncodeDuration: zapcore.NanosDurationEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
 		EncodeLevel:    zapcore.LowercaseLevelEncoder,
 	})
 }

--- a/logger.go
+++ b/logger.go
@@ -39,7 +39,7 @@ func defaultEncoderConfig() zapcore.EncoderConfig {
 		CallerKey:      "caller",
 		StacktraceKey:  "stacktrace",
 		EncodeTime:     zapcore.EpochTimeEncoder,
-		EncodeDuration: zapcore.NanosDurationEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
 		EncodeLevel:    zapcore.LowercaseLevelEncoder,
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -38,9 +38,9 @@ func defaultEncoderConfig() zapcore.EncoderConfig {
 		NameKey:        "name",
 		CallerKey:      "caller",
 		StacktraceKey:  "stacktrace",
-		EncodeTime:     func(t time.Time, enc zapcore.ArrayEncoder) { enc.AppendInt64(t.UnixNano() / int64(time.Millisecond)) },
-		EncodeDuration: func(d time.Duration, enc zapcore.ArrayEncoder) { enc.AppendInt64(int64(d)) },
-		EncodeLevel:    func(l zapcore.Level, enc zapcore.ArrayEncoder) { enc.AppendString(l.String()) },
+		EncodeTime:     zapcore.EpochTimeEncoder,
+		EncodeDuration: zapcore.NanosDurationEncoder,
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
 	}
 }
 

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -103,7 +103,12 @@ func (e *TimeEncoder) UnmarshalText(text []byte) error {
 // A DurationEncoder serializes a time.Duration to a primitive type.
 type DurationEncoder func(time.Duration, PrimitiveArrayEncoder)
 
-// NanosDurationEncoder serializes a time.Duration to an int64 number of
+// SecondsDurationEncoder serializes a time.Duration to a floating-point number of seconds elapsed.
+func SecondsDurationEncoder(d time.Duration, enc PrimitiveArrayEncoder) {
+	enc.AppendFloat64(float64(d) / float64(time.Second))
+}
+
+// NanosDurationEncoder serializes a time.Duration to an integer number of
 // nanoseconds elapsed.
 func NanosDurationEncoder(d time.Duration, enc PrimitiveArrayEncoder) {
 	enc.AppendInt64(int64(d))
@@ -122,8 +127,10 @@ func (e *DurationEncoder) UnmarshalText(text []byte) error {
 	switch string(text) {
 	case "string":
 		*e = StringDurationEncoder
-	default:
+	case "nanos":
 		*e = NanosDurationEncoder
+	default:
+		*e = SecondsDurationEncoder
 	}
 	return nil
 }

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -20,19 +20,130 @@
 
 package zapcore
 
-import "time"
+import (
+	"strings"
+	"time"
+)
+
+// A LevelEncoder serializes a Level to a primitive type.
+type LevelEncoder func(Level, PrimitiveArrayEncoder)
+
+// LowercaseLevelEncoder serializes a Level to a lowercase string. For example,
+// InfoLevel is serialized to "info".
+func LowercaseLevelEncoder(l Level, enc PrimitiveArrayEncoder) {
+	enc.AppendString(l.String())
+}
+
+// CapitalLevelEncoder serializes a Level to an all-caps string. For example,
+// InfoLevel is serialized to "INFO".
+func CapitalLevelEncoder(l Level, enc PrimitiveArrayEncoder) {
+	enc.AppendString(strings.ToUpper(l.String()))
+}
+
+// UnmarshalText unmarshals text to a LevelEncoder. "capital" is unmarshaled to
+// CapitalLevelEncoder, and anything else is unmarshaled to LowercaseLevelEncoder.
+func (e *LevelEncoder) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "capital":
+		*e = CapitalLevelEncoder
+	default:
+		*e = LowercaseLevelEncoder
+	}
+	return nil
+}
+
+// A TimeEncoder serializes a time.Time to a primitive type.
+type TimeEncoder func(time.Time, PrimitiveArrayEncoder)
+
+// EpochTimeEncoder serializes a time.Time to a floating-point number of seconds
+// since the Unix epoch.
+func EpochTimeEncoder(t time.Time, enc PrimitiveArrayEncoder) {
+	nanos := t.UnixNano()
+	sec := float64(nanos) / float64(time.Second)
+	enc.AppendFloat64(sec)
+}
+
+// EpochMillisTimeEncoder serializes a time.Time to a floating-point number of
+// milliseconds since the Unix epoch.
+func EpochMillisTimeEncoder(t time.Time, enc PrimitiveArrayEncoder) {
+	nanos := t.UnixNano()
+	millis := float64(nanos) / float64(time.Millisecond)
+	enc.AppendFloat64(millis)
+}
+
+// EpochNanosTimeEncoder serializes a time.Time to an integer number of
+// nanoseconds since the Unix epoch.
+func EpochNanosTimeEncoder(t time.Time, enc PrimitiveArrayEncoder) {
+	enc.AppendInt64(t.UnixNano())
+}
+
+// ISO8601TimeEncoder serializes a time.Time to an ISO8601-formatted string
+// with millisecond precision.
+func ISO8601TimeEncoder(t time.Time, enc PrimitiveArrayEncoder) {
+	enc.AppendString(t.Format("2006-01-02T15:04:05.999Z0700"))
+}
+
+// UnmarshalText unmarshals text to a TimeEncoder. "iso8601" and "ISO8601" are
+// unmarshaled to ISO8601TimeEncoder, "millis" is unmarshaled to
+// EpochMillisTimeEncoder, and anything else is unmarshaled to EpochTimeEncoder.
+func (e *TimeEncoder) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "iso8601", "ISO8601":
+		*e = ISO8601TimeEncoder
+	case "millis":
+		*e = EpochMillisTimeEncoder
+	case "nanos":
+		*e = EpochNanosTimeEncoder
+	default:
+		*e = EpochTimeEncoder
+	}
+	return nil
+}
+
+// A DurationEncoder serializes a time.Duration to a primitive type.
+type DurationEncoder func(time.Duration, PrimitiveArrayEncoder)
+
+// NanosDurationEncoder serializes a time.Duration to an int64 number of
+// nanoseconds elapsed.
+func NanosDurationEncoder(d time.Duration, enc PrimitiveArrayEncoder) {
+	enc.AppendInt64(int64(d))
+}
+
+// StringDurationEncoder serializes a time.Duration using its built-in String
+// method.
+func StringDurationEncoder(d time.Duration, enc PrimitiveArrayEncoder) {
+	enc.AppendString(d.String())
+}
+
+// UnmarshalText unmarshals text to a DurationEncoder. "string" is unmarshaled
+// to StringDurationEncoder, and anything else is unmarshaled to
+// NanosDurationEncoder.
+func (e *DurationEncoder) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "string":
+		*e = StringDurationEncoder
+	default:
+		*e = NanosDurationEncoder
+	}
+	return nil
+}
 
 // An EncoderConfig allows users to configure the concrete encoders supplied by
 // zapcore.
 type EncoderConfig struct {
 	// Set the keys used for each log entry.
-	MessageKey, LevelKey, TimeKey, NameKey, CallerKey, StacktraceKey string
+	MessageKey    string `json:"message_key",yaml:"message_key"`
+	LevelKey      string `json:"level_key",yaml:"level_key"`
+	TimeKey       string `json:"time_key",yaml:"time_key"`
+	NameKey       string `json:"name_key",yaml:"name_key"`
+	CallerKey     string `json:"caller_key",yaml:"caller_key"`
+	StacktraceKey string `json:"stacktrace_key",yaml:"stacktrace_key"`
 	// Configure the primitive representations of common complex types. For
 	// example, some users may want all time.Times serialized as floating-point
 	// seconds since epoch, while others may prefer ISO8601 strings.
-	EncodeLevel    func(Level, ArrayEncoder)
-	EncodeTime     func(time.Time, ArrayEncoder)
-	EncodeDuration func(time.Duration, ArrayEncoder)
+	EncodeLevel    LevelEncoder    `json:"level_encoder",yaml:"level_encoder"`
+	EncodeTime     TimeEncoder     `json:"time_encoder",yaml:"time_encoder"`
+	EncodeDuration DurationEncoder `json:"duration_encoder",yaml:"duration_encoder"`
 }
 
 // ObjectEncoder is a strongly-typed, encoding-agnostic interface for adding a
@@ -80,16 +191,31 @@ type ObjectEncoder interface {
 // arrays even though they aren't typical in Go. Like slices, ArrayEncoders
 // aren't safe for concurrent use (though typical use shouldn't require locks).
 type ArrayEncoder interface {
+	// Built-in types.
+	PrimitiveArrayEncoder
+
+	// Time-related types.
+	AppendDuration(time.Duration)
+	AppendTime(time.Time)
+
 	// Logging-specific marshalers.
 	AppendArray(ArrayMarshaler) error
 	AppendObject(ObjectMarshaler) error
 
+	// AppendReflected uses reflection to serialize arbitrary objects, so it's
+	// slow and allocation-heavy.
+	AppendReflected(value interface{}) error
+}
+
+// PrimitiveArrayEncoder is the subset of the ArrayEncoder interface that deals
+// only in Go's built-in types. It's included only so that Duration- and
+// TimeEncoders cannot trigger infinite recursion.
+type PrimitiveArrayEncoder interface {
 	// Built-in types.
 	AppendBool(bool)
 	AppendByte(byte)
 	AppendComplex128(complex128)
 	AppendComplex64(complex64)
-	AppendDuration(time.Duration)
 	AppendFloat64(float64)
 	AppendFloat32(float32)
 	AppendInt(int)
@@ -99,17 +225,12 @@ type ArrayEncoder interface {
 	AppendInt8(int8)
 	AppendRune(rune)
 	AppendString(string)
-	AppendTime(time.Time)
 	AppendUint(uint)
 	AppendUint64(uint64)
 	AppendUint32(uint32)
 	AppendUint16(uint16)
 	AppendUint8(uint8)
 	AppendUintptr(uintptr)
-
-	// AppendReflected uses reflection to serialize arbitrary objects, so it's
-	// slow and allocation-heavy.
-	AppendReflected(value interface{}) error
 }
 
 // Encoder is a format-agnostic interface for all log entry marshalers. Since

--- a/zapcore/encoder_test.go
+++ b/zapcore/encoder_test.go
@@ -52,7 +52,7 @@ func testEncoderConfig() EncoderConfig {
 		StacktraceKey:  "stacktrace",
 		EncodeTime:     EpochTimeEncoder,
 		EncodeLevel:    LowercaseLevelEncoder,
-		EncodeDuration: NanosDurationEncoder,
+		EncodeDuration: SecondsDurationEncoder,
 	}
 }
 
@@ -435,8 +435,9 @@ func TestDurationEncoders(t *testing.T) {
 		expected interface{} // output of serializing elapsed
 	}{
 		{"string", "1.0000005s"},
-		{"", int64(1000000500)},
-		{"something-random", int64(1000000500)},
+		{"nanos", int64(1000000500)},
+		{"", 1.0000005},
+		{"something-random", 1.0000005},
 	}
 
 	for _, tt := range tests {

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -123,7 +123,7 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 		{"string", `"k":"v\\"`, func(e Encoder) { e.AddString(`k`, `v\`) }},
 		{"string", `"k":"v"`, func(e Encoder) { e.AddString("k", "v") }},
 		{"string", `"k":""`, func(e Encoder) { e.AddString("k", "") }},
-		{"time", `"k":1000`, func(e Encoder) { e.AddTime("k", time.Unix(1, 0)) }},
+		{"time", `"k":1`, func(e Encoder) { e.AddTime("k", time.Unix(1, 0)) }},
 		{"uint", `"k":42`, func(e Encoder) { e.AddUint("k", 42) }},
 		{"uint64", `"k":42`, func(e Encoder) { e.AddUint64("k", 42) }},
 		{"uint32", `"k":42`, func(e Encoder) { e.AddUint32("k", 42) }},
@@ -235,7 +235,7 @@ func TestJSONEncoderArrays(t *testing.T) {
 		{"rune", `[1,1]`, func(e ArrayEncoder) { e.AppendRune(1) }},
 		{"string", `["k","k"]`, func(e ArrayEncoder) { e.AppendString("k") }},
 		{"string", `["k\\","k\\"]`, func(e ArrayEncoder) { e.AppendString(`k\`) }},
-		{"times", `[1000,1000]`, func(e ArrayEncoder) { e.AppendTime(time.Unix(1, 0)) }},
+		{"times", `[1,1]`, func(e ArrayEncoder) { e.AppendTime(time.Unix(1, 0)) }},
 		{"uint", `[42,42]`, func(e ArrayEncoder) { e.AppendUint(42) }},
 		{"uint64", `[42,42]`, func(e ArrayEncoder) { e.AppendUint64(42) }},
 		{"uint32", `[42,42]`, func(e ArrayEncoder) { e.AppendUint32(42) }},
@@ -321,8 +321,8 @@ func assertJSON(t *testing.T, expected string, enc *jsonEncoder) {
 
 func assertOutput(t testing.TB, desc string, expected string, f func(Encoder)) {
 	enc := &jsonEncoder{EncoderConfig: &EncoderConfig{
-		EncodeTime:     func(t time.Time, enc ArrayEncoder) { enc.AppendInt64(t.UnixNano() / int64(time.Millisecond)) },
-		EncodeDuration: func(d time.Duration, enc ArrayEncoder) { enc.AppendInt64(int64(d)) },
+		EncodeTime:     EpochTimeEncoder,
+		EncodeDuration: NanosDurationEncoder,
 	}}
 	f(enc)
 	assert.Equal(t, expected, string(enc.bytes), "Unexpected encoder output after adding a %s.", desc)

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -103,7 +103,7 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 		{"byte", `"k":1`, func(e Encoder) { e.AddByte("k", 1) }},
 		{"complex128", `"k":"1+2i"`, func(e Encoder) { e.AddComplex128("k", 1+2i) }},
 		{"complex64", `"k":"1+2i"`, func(e Encoder) { e.AddComplex64("k", 1+2i) }},
-		{"duration", `"k":1`, func(e Encoder) { e.AddDuration("k", 1) }},
+		{"duration", `"k":0.000000001`, func(e Encoder) { e.AddDuration("k", 1) }},
 		{"float64", `"k":1`, func(e Encoder) { e.AddFloat64("k", 1.0) }},
 		{"float64", `"k":10000000000`, func(e Encoder) { e.AddFloat64("k", 1e10) }},
 		{"float64", `"k":"NaN"`, func(e Encoder) { e.AddFloat64("k", math.NaN()) }},
@@ -224,7 +224,7 @@ func TestJSONEncoderArrays(t *testing.T) {
 		{"byte", `[1,1]`, func(e ArrayEncoder) { e.AppendByte(1) }},
 		{"complex128", `["1+2i","1+2i"]`, func(e ArrayEncoder) { e.AppendComplex128(1 + 2i) }},
 		{"complex64", `["1+2i","1+2i"]`, func(e ArrayEncoder) { e.AppendComplex64(1 + 2i) }},
-		{"durations", `[2,2]`, func(e ArrayEncoder) { e.AppendDuration(2) }},
+		{"durations", `[0.000000002,0.000000002]`, func(e ArrayEncoder) { e.AppendDuration(2) }},
 		{"float64", `[3.14,3.14]`, func(e ArrayEncoder) { e.AppendFloat64(3.14) }},
 		{"float32", `[3.14,3.14]`, func(e ArrayEncoder) { e.AppendFloat32(3.14) }},
 		{"int", `[42,42]`, func(e ArrayEncoder) { e.AppendInt(42) }},
@@ -322,7 +322,7 @@ func assertJSON(t *testing.T, expected string, enc *jsonEncoder) {
 func assertOutput(t testing.TB, desc string, expected string, f func(Encoder)) {
 	enc := &jsonEncoder{EncoderConfig: &EncoderConfig{
 		EncodeTime:     EpochTimeEncoder,
-		EncodeDuration: NanosDurationEncoder,
+		EncodeDuration: SecondsDurationEncoder,
 	}}
 	f(enc)
 	assert.Equal(t, expected, string(enc.bytes), "Unexpected encoder output after adding a %s.", desc)


### PR DESCRIPTION
This is another precursor to terse, config-based logger construction. Since we'd
like users to be able to hydrate a logger from JSON or YAML config, we must
provide a way for them to specify how they'd like levels, times, and durations
to be encoded. We'll do so by exporting a small selection of encoders and
implementing text.Unmarshaler.

Along the way, we fix a current bug that allows user-supplied encoders to recur
infinitely.

Note that this changes the default time encoding to floating-point seconds since
epoch, which is IMO a better default than our current integer
milliseconds-since-epoch. I plan to keep this the default for non-development
loggers.