### PR TITLE
Update Tee to use no-op Facility

### DIFF
--- a/zapcore/tee.go
+++ b/zapcore/tee.go
@@ -23,13 +23,14 @@ package zapcore
 import "go.uber.org/zap/internal/multierror"
 
 // Tee creates a Facility that duplicates log entries into two or more
-// facilities; if you call it with less than two, you get back the one facility
-// you passed (or nil in the pathological case).
+// Facilities.
+//
+// Calling it with a single Facility returns the input unchanged, and calling
+// it with no input returns a no-op Facility.
 func Tee(facs ...Facility) Facility {
 	switch len(facs) {
 	case 0:
-		// TODO: return NullFacility?
-		return nil
+		return NopFacility()
 	case 1:
 		return facs[0]
 	default:

--- a/zapcore/tee_test.go
+++ b/zapcore/tee_test.go
@@ -29,31 +29,107 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTeeLogsBoth(t *testing.T) {
-	var logs1, logs2 observer.ObservedLogs
-	fac1 := observer.New(DebugLevel, logs1.Add, true)
-	fac2 := observer.New(WarnLevel, logs2.Add, true)
-	tee := Tee(fac1, fac2)
+func withTee(f func(fac Facility, debugLogs, warnLogs *observer.ObservedLogs)) {
+	var debugLogs, warnLogs observer.ObservedLogs
+	tee := Tee(
+		observer.New(DebugLevel, debugLogs.Add, true),
+		observer.New(WarnLevel, warnLogs.Add, true),
+	)
+	f(tee, &debugLogs, &warnLogs)
+}
 
-	debugEntry := Entry{Level: DebugLevel, Message: "log-at-debug"}
-	infoEntry := Entry{Level: InfoLevel, Message: "log-at-info"}
-	warnEntry := Entry{Level: WarnLevel, Message: "log-at-warn"}
-	errorEntry := Entry{Level: ErrorLevel, Message: "log-at-error"}
-	for _, ent := range []Entry{debugEntry, infoEntry, warnEntry, errorEntry} {
+func TestTeeUnusualInput(t *testing.T) {
+	// Verify that Tee handles receiving one and no inputs correctly.
+	t.Run("one input", func(t *testing.T) {
+		obs := observer.New(DebugLevel, nil, true)
+		assert.Equal(t, obs, Tee(obs), "Expected to return single inputs unchanged.")
+	})
+	t.Run("no input", func(t *testing.T) {
+		assert.Equal(t, NopFacility(), Tee(), "Expected to return NopFacility.")
+	})
+}
+
+func TestTeeCheck(t *testing.T) {
+	withTee(func(tee Facility, debugLogs, warnLogs *observer.ObservedLogs) {
+		debugEntry := Entry{Level: DebugLevel, Message: "log-at-debug"}
+		infoEntry := Entry{Level: InfoLevel, Message: "log-at-info"}
+		warnEntry := Entry{Level: WarnLevel, Message: "log-at-warn"}
+		errorEntry := Entry{Level: ErrorLevel, Message: "log-at-error"}
+		for _, ent := range []Entry{debugEntry, infoEntry, warnEntry, errorEntry} {
+			if ce := tee.Check(ent, nil); ce != nil {
+				ce.Write()
+			}
+		}
+
+		assert.Equal(t, []observer.LoggedEntry{
+			{Entry: debugEntry, Context: []Field{}},
+			{Entry: infoEntry, Context: []Field{}},
+			{Entry: warnEntry, Context: []Field{}},
+			{Entry: errorEntry, Context: []Field{}},
+		}, debugLogs.All())
+
+		assert.Equal(t, []observer.LoggedEntry{
+			{Entry: warnEntry, Context: []Field{}},
+			{Entry: errorEntry, Context: []Field{}},
+		}, warnLogs.All())
+	})
+}
+
+func TestTeeWrite(t *testing.T) {
+	// Calling the tee's Write method directly should always log, regardless of
+	// the configured level.
+	withTee(func(tee Facility, debugLogs, warnLogs *observer.ObservedLogs) {
+		debugEntry := Entry{Level: DebugLevel, Message: "log-at-debug"}
+		warnEntry := Entry{Level: WarnLevel, Message: "log-at-warn"}
+		for _, ent := range []Entry{debugEntry, warnEntry} {
+			tee.Write(ent, nil)
+		}
+
+		for _, logs := range []*observer.ObservedLogs{debugLogs, warnLogs} {
+			assert.Equal(t, []observer.LoggedEntry{
+				{Entry: debugEntry, Context: []Field{}},
+				{Entry: warnEntry, Context: []Field{}},
+			}, logs.All())
+		}
+	})
+}
+
+func TestTeeWith(t *testing.T) {
+	withTee(func(tee Facility, debugLogs, warnLogs *observer.ObservedLogs) {
+		f := makeInt64Field("k", 42)
+		tee = tee.With([]Field{f})
+		ent := Entry{Level: WarnLevel, Message: "log-at-warn"}
 		if ce := tee.Check(ent, nil); ce != nil {
 			ce.Write()
 		}
+
+		for _, logs := range []*observer.ObservedLogs{debugLogs, warnLogs} {
+			assert.Equal(t, []observer.LoggedEntry{
+				{Entry: ent, Context: []Field{f}},
+			}, logs.All())
+		}
+	})
+}
+
+func TestTeeEnabled(t *testing.T) {
+	tee := Tee(
+		observer.New(InfoLevel, nil, false),
+		observer.New(WarnLevel, nil, false),
+	)
+	tests := []struct {
+		lvl     Level
+		enabled bool
+	}{
+		{DebugLevel, false},
+		{InfoLevel, true},
+		{WarnLevel, true},
+		{ErrorLevel, true},
+		{DPanicLevel, true},
+		{PanicLevel, true},
+		{FatalLevel, true},
 	}
 
-	assert.Equal(t, []observer.LoggedEntry{
-		{Entry: debugEntry, Context: []Field{}},
-		{Entry: infoEntry, Context: []Field{}},
-		{Entry: warnEntry, Context: []Field{}},
-		{Entry: errorEntry, Context: []Field{}},
-	}, logs1.All())
-
-	assert.Equal(t, []observer.LoggedEntry{
-		{Entry: warnEntry, Context: []Field{}},
-		{Entry: errorEntry, Context: []Field{}},
-	}, logs2.All())
+	for _, tt := range tests {
+		assert.Equal(t, tt.enabled, tee.Enabled(tt.lvl), "Unexpected Enabled result for level %s.", tt.lvl)
+	}
 }


### PR DESCRIPTION
The facility tee should be using the no-op introduced in #278. Added a small unit test to verify behavior when passed one or zero inputs.