### PR TITLE
Explicitly test go1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 sudo: false
 go:
   - 1.7
+  - 1.8rc3
   - tip
 go_import_path: go.uber.org/zap
 env:


### PR DESCRIPTION
A release branch has been cut, but we are only testing against 'tip'.