### PR TITLE
Add support for binary blobs

### DIFF
--- a/field.go
+++ b/field.go
@@ -21,7 +21,6 @@
 package zap
 
 import (
-	"encoding/base64"
 	"fmt"
 	"math"
 	"time"
@@ -35,9 +34,12 @@ func Skip() zapcore.Field {
 	return zapcore.Field{Type: zapcore.SkipType}
 }
 
-// Base64 constructs a field that eagerly base64-encodes bytes.
-func Base64(key string, val []byte) zapcore.Field {
-	return String(key, base64.StdEncoding.EncodeToString(val))
+// Binary constructs a field that carries an opaque binary blob.
+//
+// Binary data is serialized in an encoding-appropriate format. For example,
+// zap's JSON encoder base64-encodes binary blobs.
+func Binary(key string, val []byte) zapcore.Field {
+	return zapcore.Field{Key: key, Type: zapcore.BinaryType, Interface: val}
 }
 
 // Bool constructs a field with the given key and value.

--- a/field_test.go
+++ b/field_test.go
@@ -77,6 +77,7 @@ func TestFieldConstructors(t *testing.T) {
 		expect zapcore.Field
 	}{
 		{"Skip", zapcore.Field{Type: zapcore.SkipType}, Skip()},
+		{"Binary", zapcore.Field{Key: "k", Type: zapcore.BinaryType, Interface: []byte("ab12")}, Binary("k", []byte("ab12"))},
 		{"Bool", zapcore.Field{Key: "k", Type: zapcore.BoolType, Integer: 1}, Bool("k", true)},
 		{"Bool", zapcore.Field{Key: "k", Type: zapcore.BoolType, Integer: 1}, Bool("k", true)},
 		{"Complex128", zapcore.Field{Key: "k", Type: zapcore.Complex128Type, Interface: 1 + 2i}, Complex128("k", 1+2i)},
@@ -100,7 +101,6 @@ func TestFieldConstructors(t *testing.T) {
 		{"Error", Skip(), Error(nil)},
 		{"Error", zapcore.Field{Key: "error", Type: zapcore.ErrorType, Interface: fail}, Error(fail)},
 		{"Stringer", zapcore.Field{Key: "k", Type: zapcore.StringerType, Interface: addr}, Stringer("k", addr)},
-		{"Base64", zapcore.Field{Key: "k", Type: zapcore.StringType, String: "YWIxMg=="}, Base64("k", []byte("ab12"))},
 		{"Object", zapcore.Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: name}, Object("k", name)},
 		{"Any:ObjectMarshaler", Any("k", name), Object("k", name)},
 		{"Any:ArrayMarshaler", Any("k", bools([]bool{true})), Array("k", bools([]bool{true}))},

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -162,6 +162,7 @@ type ObjectEncoder interface {
 	AddObject(key string, marshaler ObjectMarshaler) error
 
 	// Built-in types.
+	AddBinary(key string, value []byte)
 	AddBool(key string, value bool)
 	AddComplex128(key string, value complex128)
 	AddComplex64(key string, value complex64)

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -37,6 +37,8 @@ const (
 	ArrayMarshalerType
 	// ObjectMarshalerType indicates that the field carries an ObjectMarshaler.
 	ObjectMarshalerType
+	// BinaryType indicates that the field carries an opaque binary blob.
+	BinaryType
 	// BoolType indicates that the field carries a bool.
 	BoolType
 	// Complex128Type indicates that the field carries a complex128.
@@ -106,6 +108,8 @@ func (f Field) AddTo(enc ObjectEncoder) {
 		err = enc.AddArray(f.Key, f.Interface.(ArrayMarshaler))
 	case ObjectMarshalerType:
 		err = enc.AddObject(f.Key, f.Interface.(ObjectMarshaler))
+	case BinaryType:
+		enc.AddBinary(f.Key, f.Interface.([]byte))
 	case BoolType:
 		enc.AddBool(f.Key, f.Integer == 1)
 	case Complex128Type:

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -21,6 +21,7 @@
 package zapcore
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"math"
 	"strconv"
@@ -74,6 +75,10 @@ func (enc *jsonEncoder) AddArray(key string, arr ArrayMarshaler) error {
 func (enc *jsonEncoder) AddObject(key string, obj ObjectMarshaler) error {
 	enc.addKey(key)
 	return enc.AppendObject(obj)
+}
+
+func (enc *jsonEncoder) AddBinary(key string, val []byte) {
+	enc.AddString(key, base64.StdEncoding.EncodeToString(val))
 }
 
 func (enc *jsonEncoder) AddBool(key string, val bool) {

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -97,6 +97,7 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 		expected string
 		f        func(Encoder)
 	}{
+		{"binary", `"k":"YWIxMg=="`, func(e Encoder) { e.AddBinary("k", []byte("ab12")) }},
 		{"bool", `"k\\":true`, func(e Encoder) { e.AddBool(`k\`, true) }}, // test key escaping once
 		{"bool", `"k":true`, func(e Encoder) { e.AddBool("k", true) }},
 		{"bool", `"k":false`, func(e Encoder) { e.AddBool("k", false) }},

--- a/zapcore/memory_encoder.go
+++ b/zapcore/memory_encoder.go
@@ -56,6 +56,9 @@ func (m *MapObjectEncoder) AddObject(k string, v ObjectMarshaler) error {
 	return v.MarshalLogObject(newMap)
 }
 
+// AddBinary implements ObjectEncoder.
+func (m *MapObjectEncoder) AddBinary(k string, v []byte) { m.cur[k] = v }
+
 // AddBool implements ObjectEncoder.
 func (m *MapObjectEncoder) AddBool(k string, v bool) { m.cur[k] = v }
 

--- a/zapcore/memory_encoder_test.go
+++ b/zapcore/memory_encoder_test.go
@@ -75,6 +75,11 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 			expected: []interface{}{wantTurducken, wantTurducken},
 		},
 		{
+			desc:     "AddBinary",
+			f:        func(e ObjectEncoder) { e.AddBinary("k", []byte("foo")) },
+			expected: []byte("foo"),
+		},
+		{
 			desc:     "AddBool",
 			f:        func(e ObjectEncoder) { e.AddBool("k", true) },
 			expected: true,


### PR DESCRIPTION
Replace Base64 with Binary, and add field and encoder support. This provides an
encoding-agnostic way to log opaque binary blobs.

This fixes #284.