### PR TITLE
Fix allocation when returning []byte to pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export GO15VENDOREXPERIMENT=1
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 PKGS ?= $(shell glide novendor)
 # Many Go tools take file globs or directories as arguments instead of packages.
-PKG_FILES ?= *.go zapcore benchmarks testutils internal/buffers internal/exit internal/multierror
+PKG_FILES ?= *.go zapcore benchmarks buffer testutils internal/bufferpool internal/exit internal/multierror
 
 # The linting tools evolve with each Go version, so run them only on the latest
 # stable release.

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -49,7 +49,7 @@ func (b *Buffer) AppendString(s string) {
 
 // AppendInt appends an integer to the underlying buffer (assuming base 10).
 func (b *Buffer) AppendInt(i int64) {
-	b.bs = strconv.AppendInt(b.bs, int64(i), 10)
+	b.bs = strconv.AppendInt(b.bs, i, 10)
 }
 
 // AppendUint appends an unsigned integer to the underlying buffer (assuming

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package buffer provides a thin wrapper around a byte slice. Unlike the
+// standard library's bytes.Buffer, it supports a portion of the strconv
+// package's zero-allocation formatters.
+package buffer
+
+import "strconv"
+
+const _size = 1024 // by default, create 1 KiB buffers
+
+// Buffer is a thin wrapper around a byte slice.
+type Buffer struct {
+	bs []byte
+}
+
+// New creates a new Buffer of the default size.
+func New() *Buffer {
+	return &Buffer{make([]byte, 0, _size)}
+}
+
+// AppendByte writes a single byte to the Buffer.
+func (b *Buffer) AppendByte(v byte) {
+	b.bs = append(b.bs, v)
+}
+
+// AppendString writes a string to the Buffer.
+func (b *Buffer) AppendString(s string) {
+	b.bs = append(b.bs, s...)
+}
+
+// AppendInt appends an integer to the underlying buffer (assuming base 10).
+func (b *Buffer) AppendInt(i int64) {
+	b.bs = strconv.AppendInt(b.bs, int64(i), 10)
+}
+
+// AppendUint appends an unsigned integer to the underlying buffer (assuming
+// base 10).
+func (b *Buffer) AppendUint(i uint64) {
+	b.bs = strconv.AppendUint(b.bs, i, 10)
+}
+
+// AppendBool appends a bool to the underlying buffer.
+func (b *Buffer) AppendBool(v bool) {
+	b.bs = strconv.AppendBool(b.bs, v)
+}
+
+// AppendFloat appends a float to the underlying buffer. It doesn't quote NaN
+// or +/- Inf.
+func (b *Buffer) AppendFloat(f float64, bitSize int) {
+	b.bs = strconv.AppendFloat(b.bs, f, 'f', -1, bitSize)
+}
+
+// Len returns the length of the underlying byte slice.
+func (b *Buffer) Len() int {
+	return len(b.bs)
+}
+
+// Cap returns the capacity of the underlying byte slice.
+func (b *Buffer) Cap() int {
+	return cap(b.bs)
+}
+
+// Bytes returns a mutable reference to the underlying byte slice.
+func (b *Buffer) Bytes() []byte {
+	return b.bs
+}
+
+// String returns a string copy of the underlying byte slice.
+func (b *Buffer) String() string {
+	return string(b.bs)
+}
+
+// Reset resets the underlying byte slice. Subsequent writes re-use the slice's
+// backing array.
+func (b *Buffer) Reset() {
+	b.bs = b.bs[:0]
+}
+
+// Write implements io.Writer.
+func (b *Buffer) Write(bs []byte) (int, error) {
+	b.bs = append(b.bs, bs...)
+	return len(bs), nil
+}

--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package buffer
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBufferWrites(t *testing.T) {
+	buf := New()
+
+	tests := []struct {
+		desc string
+		f    func()
+		want string
+	}{
+		{"AppendByte", func() { buf.AppendByte('v') }, "v"},
+		{"AppendString", func() { buf.AppendString("foo") }, "foo"},
+		{"AppendIntPositive", func() { buf.AppendInt(42) }, "42"},
+		{"AppendIntNegative", func() { buf.AppendInt(-42) }, "-42"},
+		{"AppendUint", func() { buf.AppendUint(42) }, "42"},
+		{"AppendBool", func() { buf.AppendBool(true) }, "true"},
+		{"AppendFloat64", func() { buf.AppendFloat(3.14, 64) }, "3.14"},
+		// Intenationally introduce some floating-point error.
+		{"AppendFloat32", func() { buf.AppendFloat(float64(float32(3.14)), 32) }, "3.14"},
+		{"AppendWrite", func() { buf.Write([]byte("foo")) }, "foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			buf.Reset()
+			tt.f()
+			assert.Equal(t, tt.want, buf.String(), "Unexpected buffer.String().")
+			assert.Equal(t, tt.want, string(buf.Bytes()), "Unexpected string(buffer.Bytes()).")
+			assert.Equal(t, len(tt.want), buf.Len(), "Unexpected buffer length.")
+			// We're not writing more than a kibibyte in tests.
+			assert.Equal(t, _size, buf.Cap(), "Expected buffer capacity to remain constant.")
+		})
+	}
+}
+
+func BenchmarkBuffers(b *testing.B) {
+	// Because we use the strconv.AppendFoo functions so liberally, we can't
+	// use the standard library's bytes.Buffer anyways (without incurring a
+	// bunch of extra allocations). Nevertheless, let's make sure that we're
+	// not losing any precious nanoseconds.
+	str := strings.Repeat("a", 1024)
+	slice := make([]byte, 1024)
+	buf := bytes.NewBuffer(slice)
+	custom := New()
+	b.Run("ByteSlice", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			slice = append(slice, str...)
+			slice = slice[:0]
+		}
+	})
+	b.Run("BytesBuffer", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf.WriteString(str)
+			buf.Reset()
+		}
+	})
+	b.Run("CustomBuffer", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			custom.AppendString(str)
+			custom.Reset()
+		}
+	})
+}

--- a/field.go
+++ b/field.go
@@ -25,7 +25,7 @@ import (
 	"math"
 	"time"
 
-	"go.uber.org/zap/internal/buffers"
+	"go.uber.org/zap/internal/bufferpool"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -188,13 +188,14 @@ func Error(err error) zapcore.Field {
 // allocation and takes ~10 microseconds.
 func Stack() zapcore.Field {
 	// Try to avoid allocating a buffer.
-	buf := buffers.Get()
+	buf := bufferpool.Get()
+	bs := buf.Bytes()
 	// Returning the stacktrace as a string costs an allocation, but saves us
 	// from expanding the zapcore.Field union struct to include a byte slice. Since
 	// taking a stacktrace is already so expensive (~10us), the extra allocation
 	// is okay.
-	field := String("stacktrace", takeStacktrace(buf[:cap(buf)], false))
-	buffers.Put(buf)
+	field := String("stacktrace", takeStacktrace(bs[:cap(bs)], false))
+	bufferpool.Put(buf)
 	return field
 }
 

--- a/internal/multierror/multierror.go
+++ b/internal/multierror/multierror.go
@@ -22,22 +22,23 @@
 // a single error.
 package multierror
 
-import "go.uber.org/zap/internal/buffers"
+import "go.uber.org/zap/internal/bufferpool"
 
 // implement the standard lib's error interface on a private type so that we
 // can't forget to call Error.AsError().
 type errSlice []error
 
 func (es errSlice) Error() string {
-	b := buffers.Get()
+	b := bufferpool.Get()
 	for i, err := range es {
 		if i > 0 {
-			b = append(b, ';', ' ')
+			b.AppendByte(';')
+			b.AppendByte(' ')
 		}
-		b = append(b, err.Error()...)
+		b.AppendString(err.Error())
 	}
-	ret := string(b)
-	buffers.Put(b)
+	ret := b.String()
+	bufferpool.Put(b)
 	return ret
 }
 

--- a/zapcore/console_encoder_bench_test.go
+++ b/zapcore/console_encoder_bench_test.go
@@ -23,7 +23,7 @@ package zapcore_test
 import (
 	"testing"
 
-	"go.uber.org/zap/internal/buffers"
+	"go.uber.org/zap/internal/bufferpool"
 	. "go.uber.org/zap/zapcore"
 )
 
@@ -44,7 +44,7 @@ func BenchmarkZapConsole(b *testing.B) {
 				Message: "fake",
 				Level:   DebugLevel,
 			}, nil)
-			buffers.Put(buf)
+			bufferpool.Put(buf)
 		}
 	})
 }

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -23,6 +23,8 @@ package zapcore
 import (
 	"strings"
 	"time"
+
+	"go.uber.org/zap/buffer"
 )
 
 // A LevelEncoder serializes a Level to a primitive type.
@@ -254,5 +256,5 @@ type Encoder interface {
 
 	// EncodeEntry encodes an entry and fields, along with any accumulated
 	// context, into a byte buffer and returns it.
-	EncodeEntry(Entry, []Field) ([]byte, error)
+	EncodeEntry(Entry, []Field) (*buffer.Buffer, error)
 }

--- a/zapcore/encoder_test.go
+++ b/zapcore/encoder_test.go
@@ -363,7 +363,7 @@ func TestEncoderConfiguration(t *testing.T) {
 			assert.Equal(
 				t,
 				tt.expectedJSON+"\n",
-				string(jsonOut),
+				jsonOut.String(),
 				"Unexpected JSON output: expected to %v.", tt.desc,
 			)
 		}
@@ -372,7 +372,7 @@ func TestEncoderConfiguration(t *testing.T) {
 			assert.Equal(
 				t,
 				tt.expectedConsole+"\n",
-				string(consoleOut),
+				consoleOut.String(),
 				"Unexpected console output: expected to %v.", tt.desc,
 			)
 		}

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -22,11 +22,10 @@ package zapcore
 
 import (
 	"fmt"
-	"strconv"
 	"sync"
 	"time"
 
-	"go.uber.org/zap/internal/buffers"
+	"go.uber.org/zap/internal/bufferpool"
 	"go.uber.org/zap/internal/exit"
 	"go.uber.org/zap/internal/multierror"
 )
@@ -81,12 +80,12 @@ func (ec EntryCaller) String() string {
 	if !ec.Defined {
 		return ""
 	}
-	buf := buffers.Get()
-	buf = append(buf, ec.File...)
-	buf = append(buf, ':')
-	buf = strconv.AppendInt(buf, int64(ec.Line), 10)
-	caller := string(buf)
-	buffers.Put(buf)
+	buf := bufferpool.Get()
+	buf.AppendString(ec.File)
+	buf.AppendByte(':')
+	buf.AppendInt(int64(ec.Line))
+	caller := buf.String()
+	bufferpool.Put(buf)
 	return caller
 }
 

--- a/zapcore/facility.go
+++ b/zapcore/facility.go
@@ -20,12 +20,7 @@
 
 package zapcore
 
-import (
-	"io"
-
-	"go.uber.org/zap/buffer"
-	"go.uber.org/zap/internal/bufferpool"
-)
+import "go.uber.org/zap/internal/bufferpool"
 
 // Facility is a destination for log entries. It can have pervasive fields
 // added with With().
@@ -80,7 +75,7 @@ func (iof *ioFacility) Write(ent Entry, fields []Field) error {
 	if err != nil {
 		return err
 	}
-	err = checkPartialWrite(iof.out, buf)
+	_, err = iof.out.Write(buf.Bytes())
 	bufferpool.Put(buf)
 	if err != nil {
 		return err
@@ -98,17 +93,4 @@ func (iof *ioFacility) clone() *ioFacility {
 		enc:          iof.enc.Clone(),
 		out:          iof.out,
 	}
-}
-
-// checkPartialWrite writes to an io.Writer, and upgrades partial writes to an
-// error if no other write error occured.
-func checkPartialWrite(w io.Writer, buf *buffer.Buffer) error {
-	n, err := w.Write(buf.Bytes())
-	if err != nil {
-		return err
-	}
-	if n != buf.Len() {
-		return io.ErrShortWrite
-	}
-	return nil
 }

--- a/zapcore/facility_test.go
+++ b/zapcore/facility_test.go
@@ -153,14 +153,3 @@ func TestWriterFacilityWriteFailure(t *testing.T) {
 	// Should log the error.
 	assert.Error(t, err, "Expected writing Entry to fail.")
 }
-
-func TestWriterFacilityShortWrite(t *testing.T) {
-	fac := WriterFacility(
-		NewJSONEncoder(testEncoderConfig()),
-		Lock(&testutils.ShortWriter{}),
-		DebugLevel,
-	)
-	err := fac.Write(Entry{}, nil)
-	// Should log the error.
-	assert.Error(t, err, "Expected writing Entry to fail.")
-}

--- a/zapcore/json_encoder_bench_test.go
+++ b/zapcore/json_encoder_bench_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/internal/buffers"
+	"go.uber.org/zap/internal/bufferpool"
 	. "go.uber.org/zap/zapcore"
 )
 
@@ -56,7 +56,7 @@ func BenchmarkZapJSON(b *testing.B) {
 				Message: "fake",
 				Level:   DebugLevel,
 			}, nil)
-			buffers.Put(buf)
+			bufferpool.Put(buf)
 		}
 	})
 }


### PR DESCRIPTION
In order to pool byte slices without incurring an allocation (by casting into
`interface{}`), we need to switch to using a pointer type. The natural candidate
is the standard library's `bytes.Buffer`; it's a bit slower than straight
slices, but that's probably okay. However, we use `strconv.AppendFloat` and
friends to avoid allocations in the encoder, and those functions won't work with
`byte.Buffer`.

Instead, this PR adds a small `Buffer` type that implements just the bits of
`bytes.Buffer` and `strconv` that we need. It renames the private `buffers`
package to `bufferpool` to clarify the difference between the two.

Before:

```
BenchmarkZapWithoutFields-4      3000000               436 ns/op              80 B/op          2 allocs/op
```

After:

```
BenchmarkZapWithoutFields-4      5000000               331 ns/op              32 B/op          1 allocs/op
```

This fixes #288.
