### PR TITLE
Rewrite sampler to fix oversampling

### DIFF
--- a/benchmarks/zap_bench_test.go
+++ b/benchmarks/zap_bench_test.go
@@ -237,7 +237,7 @@ func BenchmarkZapSampleCheckWithoutFields(b *testing.B) {
 		benchEncoder(),
 		&testutils.Discarder{},
 		zap.DebugLevel,
-	), time.Second, 10, 10000))
+	), 50*time.Millisecond, 10, 10000))
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0


### PR DESCRIPTION
See discussion on how the current sampler is wrong:
https://github.com/uber-go/zap/pull/252#discussion_r99447146

Instead of using `time.AfterFunc` and resetting timers, use timestamps on the entries, and maintain a sliding window for the current "tick" with atomics to track when the counters should be reset. This avoids all allocations.

The alternate approach is to start the timer as soon as the first message for any bucket is logged, but that would cause more timers to be started, which costs an allocation as well as requiring a global lock on the timer heap.

Performance of sampler on `dev`:
```
BenchmarkZapSampleCheckWithoutFields-8          500000000               33.4 ns/op
```

Performance of sampler based on atomics:
```
BenchmarkZapSampleCheckWithoutFields-8          500000000               35.4 ns/op
```
