### PR TITLE
Fix Coveralls.io integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test:
 
 .PHONY: coveralls
 coveralls:
-	goveralls -service=travis-ci .
+	goveralls -service=travis-ci
 
 .PHONY: bench
 BENCH ?= .

--- a/benchmarks/doc.go
+++ b/benchmarks/doc.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package benchmarks contains only benchmarks comparing zap to other
+// structured logging libraries.
+package benchmarks


### PR DESCRIPTION
At some point, we updated the versions of our dependencies and didn't notice an
API change in the `goveralls` package; since then, coverage reporting has been
broken. Unfortuately, the Coveralls.io service itself isn't reliable enough to
be a required step in each build.

For now, let's just update our usage of `goveralls`. This also requires adding a
non-test file to the `benchmarks` package - otherwise `goveralls` complains and
exits.