### PR TITLE
Improve error messages when using old import paths

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -19,4 +19,4 @@
 // THE SOFTWARE.
 
 // Package zap provides fast, structured, leveled logging in Go.
-package zap
+package zap // import "go.uber.org/zap"

--- a/zapcore/doc.go
+++ b/zapcore/doc.go
@@ -21,4 +21,4 @@
 // Package zapcore defines and implements the low-level interfaces upon which
 // zap is built. By providing alternate implementations of these interfaces,
 // external packages can extend zap's capabilities.
-package zapcore
+package zapcore // import "go.uber.org/zap/zapcore"


### PR DESCRIPTION
Add the magic comments required to provide better error messages when users try
to import "github.com/uber-go/zap" and ".../zapcore".