### PR TITLE
Add benchmarks for lion's JSON logger

### DIFF
--- a/benchmarks/lion_test.go
+++ b/benchmarks/lion_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmarks
+
+import (
+	"io/ioutil"
+
+	"go.pedge.io/lion"
+)
+
+func newLion() lion.Logger {
+	return lion.NewLogger(lion.NewJSONWritePusher(ioutil.Discard))
+}

--- a/benchmarks/scenario_bench_test.go
+++ b/benchmarks/scenario_bench_test.go
@@ -322,6 +322,15 @@ func BenchmarkWithoutFields(b *testing.B) {
 			}
 		})
 	})
+	b.Run("go.pedge.io/lion", func(b *testing.B) {
+		logger := newLion()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				logger.Printf(getMessage(0))
+			}
+		})
+	})
 	b.Run("stdlib.Println", func(b *testing.B) {
 		logger := log.New(ioutil.Discard, "", log.LstdFlags)
 		b.ResetTimer()
@@ -453,6 +462,15 @@ func BenchmarkAccumulatedContext(b *testing.B) {
 			}
 		})
 	})
+	b.Run("go.pedge.io/lion", func(b *testing.B) {
+		logger := newLion().WithFields(fakeLogrusFields())
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				logger.Infof(getMessage(0))
+			}
+		})
+	})
 }
 
 func BenchmarkAddingFields(b *testing.B) {
@@ -532,6 +550,15 @@ func BenchmarkAddingFields(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				logger.WithFields(fakeLogrusFields()).Info(getMessage(0))
+			}
+		})
+	})
+	b.Run("go.pedge.io/lion", func(b *testing.B) {
+		logger := newLion()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				logger.WithFields(fakeLogrusFields()).Infof(getMessage(0))
 			}
 		})
 	})

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 180152df7e982d1d547ce1519ae8719387c21beabcf9d0d31cbb4c32fb46e5e8
-updated: 2017-02-14T14:40:09.454472688-08:00
+hash: a388f2aa2d844ff734fe0e8d309d1b67166f8434c1d331242c162bf92923ce5f
+updated: 2017-02-15T11:47:26.561157555-08:00
 imports:
 - name: go.uber.org/atomic
   version: 9e99152552a6ce13fa3b2ce4a9c4fb117cca4506
@@ -16,6 +16,8 @@ testImports:
   version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
+- name: github.com/fatih/color
+  version: 5ec5d9d3c2cf82e9688b34e9bc27a94d616a7193
 - name: github.com/go-kit/kit
   version: 0d6c91c61a1b3ac2467facd58a06fe89fd34aa3c
   subpackages:
@@ -42,6 +44,8 @@ testImports:
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/satori/go.uuid
+  version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/sirupsen/logrus
   version: 9b48ece7fc373043054858f8c0d362665e866004
 - name: github.com/stretchr/testify
@@ -49,6 +53,8 @@ testImports:
   subpackages:
   - assert
   - require
+- name: go.pedge.io/lion
+  version: d0ba5a16db3710bd9af5511722d8ddaf897fb0c1
 - name: golang.org/x/sys
   version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,7 @@ license: MIT
 import:
 - package: go.uber.org/atomic
 testImport:
+- package: github.com/satori/go.uuid
 - package: github.com/sirupsen/logrus
 - package: github.com/apex/log
   subpackages:
@@ -17,10 +18,10 @@ testImport:
 - package: gopkg.in/inconshreveable/log15.v2
 - package: github.com/mattn/goveralls
 - package: github.com/pborman/uuid
+- package: go.pedge.io/lion
 - package: golang.org/x/tools
   subpackages:
   - cover
-- package: golang.org/x/tools/cover
 - package: github.com/golang/lint
   subpackages:
   - golint


### PR DESCRIPTION
Add benchmarks for `go.pedge.io/lion`, but only benchmark the JSON logger.

At some point, we may want to add protobuf benchmarks, but I'd rather not introduce dependencies on the proto compiler just for tests.

Current results (from my machine, comparable to benchmarks in README):

```
testing: warning: no tests to run
BenchmarkWithoutFields/go.pedge.io/lion-4                        1000000              1738 ns/op            1224 B/op         10 allocs/op
BenchmarkAccumulatedContext/go.pedge.io/lion-4                    300000              6403 ns/op            3978 B/op         36 allocs/op
BenchmarkAddingFields/go.pedge.io/lion-4                          200000              9992 ns/op            5999 B/op         62 allocs/op
```