### PR TITLE
Use Println and Infoln for lion benchmarks

### DIFF
--- a/benchmarks/scenario_bench_test.go
+++ b/benchmarks/scenario_bench_test.go
@@ -327,7 +327,7 @@ func BenchmarkWithoutFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.Printf(getMessage(0))
+				logger.Println(getMessage(0))
 			}
 		})
 	})
@@ -467,7 +467,7 @@ func BenchmarkAccumulatedContext(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.Infof(getMessage(0))
+				logger.Infoln(getMessage(0))
 			}
 		})
 	})
@@ -558,7 +558,7 @@ func BenchmarkAddingFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.WithFields(fakeLogrusFields()).Infof(getMessage(0))
+				logger.WithFields(fakeLogrusFields()).Infoln(getMessage(0))
 			}
 		})
 	})


### PR DESCRIPTION
Small thing I missed on the last review, my apologies - the way to do non-formatted printing of a string in lion is to use Println/Infoln instead of Printf/Infof, the former calls fmt.Sprint while the latter calls fmt.Sprintf, which I think is a little more expensive.