### PR TITLE
Fix json and yaml tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PKG_FILES ?= *.go zapcore benchmarks buffer testutils internal/bufferpool intern
 # stable release.
 GO_VERSION := $(shell go version | cut -d " " -f 3)
 GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
-LINTABLE_MINOR_VERSIONS := 7
+LINTABLE_MINOR_VERSIONS := 7 8
 ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 SHOULD_LINT := true
 endif

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PKG_FILES ?= *.go zapcore benchmarks buffer testutils internal/bufferpool intern
 # stable release.
 GO_VERSION := $(shell go version | cut -d " " -f 3)
 GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
-LINTABLE_MINOR_VERSIONS := 7 8
+LINTABLE_MINOR_VERSIONS := 7
 ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 SHOULD_LINT := true
 endif

--- a/config.go
+++ b/config.go
@@ -34,8 +34,8 @@ import (
 //
 // Values configured here are per-second. See zapcore.NewSampler for details.
 type SamplingConfig struct {
-	Initial    int `json:"initial",yaml:"initial"`
-	Thereafter int `json:"therafter",yaml:"thereafter"`
+	Initial    int `json:"initial" yaml:"initial"`
+	Thereafter int `json:"therafter" yaml:"thereafter"`
 }
 
 // Config offers a declarative way to construct a logger.
@@ -48,33 +48,33 @@ type Config struct {
 	// level, so calling Config.Level.SetLevel will atomically change the log
 	// level of all loggers descended from this config. The zero value is
 	// InfoLevel.
-	Level AtomicLevel `json:"level",yaml:"level"`
+	Level AtomicLevel `json:"level" yaml:"level"`
 	// Development puts the logger in development mode, which changes the
 	// behavior of DPanicLevel and takes stacktraces more liberally.
-	Development bool `json:"development",yaml:"development"`
+	Development bool `json:"development" yaml:"development"`
 	// DisableCaller stops annotating logs with the calling function's file
 	// name and line number. By default, all logs are annotated.
-	DisableCaller bool `json:"disableCaller",yaml:"disableCaller"`
+	DisableCaller bool `json:"disableCaller" yaml:"disableCaller"`
 	// DisableStacktrace completely disables automatic stacktrace capturing. By
 	// default, stacktraces are captured for WarnLevel and above logs in
 	// development and ErrorLevel and above in production.
-	DisableStacktrace bool `json:"disableStacktrace",yaml:"disableStacktrace"`
+	DisableStacktrace bool `json:"disableStacktrace" yaml:"disableStacktrace"`
 	// Sampling sets a sampling policy. A nil SamplingConfig disables sampling.
-	Sampling *SamplingConfig `json:"sampling",yaml:"sampling"`
+	Sampling *SamplingConfig `json:"sampling" yaml:"sampling"`
 	// Encoding sets the logger's encoding. Valid values are "json" and
 	// "console".
-	Encoding string `json:"encoding",yaml:"encoding"`
+	Encoding string `json:"encoding" yaml:"encoding"`
 	// EncoderConfig sets options for the chosen encoder. See
 	// zapcore.EncoderConfig for details.
-	EncoderConfig zapcore.EncoderConfig `json:"encoderConfig",yaml:"encoderConfig"`
+	EncoderConfig zapcore.EncoderConfig `json:"encoderConfig" yaml:"encoderConfig"`
 	// OutputPaths is a list of paths to write logging output to. See Open for
 	// details.
-	OutputPaths []string `json:"outputPaths",yaml:"outputPaths"`
+	OutputPaths []string `json:"outputPaths" yaml:"outputPaths"`
 	// ErrorOutputPaths is a list of paths to write internal logger errors to.
 	// The default is standard error.
-	ErrorOutputPaths []string `json:"errorOutputPaths",yaml:"errorOutputPaths"`
+	ErrorOutputPaths []string `json:"errorOutputPaths" yaml:"errorOutputPaths"`
 	// InitialFields is a collection of fields to add to the root logger.
-	InitialFields map[string]interface{} `json:"initialFields",yaml:"initialFields"`
+	InitialFields map[string]interface{} `json:"initialFields" yaml:"initialFields"`
 }
 
 // NewProductionConfig is the recommended production configuration. Logging is

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -141,18 +141,18 @@ func (e *DurationEncoder) UnmarshalText(text []byte) error {
 // zapcore.
 type EncoderConfig struct {
 	// Set the keys used for each log entry.
-	MessageKey    string `json:"messageKey",yaml:"messageKey"`
-	LevelKey      string `json:"levelKey",yaml:"levelKey"`
-	TimeKey       string `json:"timeKey",yaml:"timeKey"`
-	NameKey       string `json:"nameKey",yaml:"nameKey"`
-	CallerKey     string `json:"callerKey",yaml:"callerKey"`
-	StacktraceKey string `json:"stacktraceKey",yaml:"stacktraceKey"`
+	MessageKey    string `json:"messageKey" yaml:"messageKey"`
+	LevelKey      string `json:"levelKey" yaml:"levelKey"`
+	TimeKey       string `json:"timeKey" yaml:"timeKey"`
+	NameKey       string `json:"nameKey" yaml:"nameKey"`
+	CallerKey     string `json:"callerKey" yaml:"callerKey"`
+	StacktraceKey string `json:"stacktraceKey" yaml:"stacktraceKey"`
 	// Configure the primitive representations of common complex types. For
 	// example, some users may want all time.Times serialized as floating-point
 	// seconds since epoch, while others may prefer ISO8601 strings.
-	EncodeLevel    LevelEncoder    `json:"levelEncoder",yaml:"levelEncoder"`
-	EncodeTime     TimeEncoder     `json:"timeEncoder",yaml:"timeEncoder"`
-	EncodeDuration DurationEncoder `json:"durationEncoder",yaml:"durationEncoder"`
+	EncodeLevel    LevelEncoder    `json:"levelEncoder" yaml:"levelEncoder"`
+	EncodeTime     TimeEncoder     `json:"timeEncoder" yaml:"timeEncoder"`
+	EncodeDuration DurationEncoder `json:"durationEncoder" yaml:"durationEncoder"`
 }
 
 // ObjectEncoder is a strongly-typed, encoding-agnostic interface for adding a


### PR DESCRIPTION
I would also like to change the tags to be underscore re: https://github.com/uber-go/fx/issues/256

This also adds go 1.8 as a valid lintable go version.

```
config.go:37: struct field tag `json:"initial",yaml:"initial"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
config.go:38: struct field tag `json:"therafter",yaml:"thereafter"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
config.go:51: struct field tag `json:"level",yaml:"level"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
config.go:54: struct field tag `json:"development",yaml:"development"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
config.go:57: struct field tag `json:"disableCaller",yaml:"disableCaller"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
config.go:61: struct field tag `json:"disableStacktrace",yaml:"disableStacktrace"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
config.go:63: struct field tag `json:"sampling",yaml:"sampling"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
config.go:66: struct field tag `json:"encoding",yaml:"encoding"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
config.go:69: struct field tag `json:"encoderConfig",yaml:"encoderConfig"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
config.go:72: struct field tag `json:"outputPaths",yaml:"outputPaths"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
config.go:75: struct field tag `json:"errorOutputPaths",yaml:"errorOutputPaths"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
config.go:77: struct field tag `json:"initialFields",yaml:"initialFields"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
zapcore/encoder.go:144: struct field tag `json:"messageKey",yaml:"messageKey"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
zapcore/encoder.go:145: struct field tag `json:"levelKey",yaml:"levelKey"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
zapcore/encoder.go:146: struct field tag `json:"timeKey",yaml:"timeKey"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
zapcore/encoder.go:147: struct field tag `json:"nameKey",yaml:"nameKey"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
zapcore/encoder.go:148: struct field tag `json:"callerKey",yaml:"callerKey"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
zapcore/encoder.go:149: struct field tag `json:"stacktraceKey",yaml:"stacktraceKey"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
zapcore/encoder.go:153: struct field tag `json:"levelEncoder",yaml:"levelEncoder"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
zapcore/encoder.go:154: struct field tag `json:"timeEncoder",yaml:"timeEncoder"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
zapcore/encoder.go:155: struct field tag `json:"durationEncoder",yaml:"durationEncoder"` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
```