### PR TITLE
Update travis to use go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 sudo: false
 go:
   - 1.7
-  - 1.8rc3
+  - 1.8
   - tip
 go_import_path: go.uber.org/zap
 env:


### PR DESCRIPTION
Travis uses https://github.com/travis-ci/gimme to install go versions, so this should just work.
