### PR TITLE
Skip runtime and some zap frames in stacktraces

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -50,7 +50,7 @@ func TestConfig(t *testing.T) {
 			expectRe: "DEBUG\t.*go.uber.org/zap/config_test.go:" + `\d+` + "\tdebug\t" + `{"k": "v", "z": "zz"}` + "\n" +
 				"INFO\t.*go.uber.org/zap/config_test.go:" + `\d+` + "\tinfo\t" + `{"k": "v", "z": "zz"}` + "\n" +
 				"WARN\t.*go.uber.org/zap/config_test.go:" + `\d+` + "\twarn\t" + `{"k": "v", "z": "zz"}` + "\n" +
-				`goroutine \d+ \[running\]:`,
+				`go.uber.org/zap.TestConfig.func1`,
 		},
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -68,17 +68,13 @@ func TestConfig(t *testing.T) {
 			logger, err := tt.cfg.Build(Hooks(hook))
 			require.NoError(t, err, "Unexpected error constructing logger.")
 
-			withStacktraceIgnorePrefixes([]string{}, func() {
+			withNoStacktraceIgnorePrefixes(func() {
 				logger.Debug("debug")
 				logger.Info("info")
 				logger.Warn("warn")
 
 				byteContents, err := ioutil.ReadAll(temp)
-				// not doing require so no problem with lock in withStacktraceIgnorePrefixes
-				assert.NoError(t, err, "Couldn't read log contents from temp file.")
-				if err != nil {
-					return
-				}
+				require.NoError(t, err, "Couldn't read log contents from temp file.")
 				logs := string(byteContents)
 				assert.Regexp(t, tt.expectRe, logs, "Unexpected log output.")
 

--- a/config_test.go
+++ b/config_test.go
@@ -68,21 +68,19 @@ func TestConfig(t *testing.T) {
 			logger, err := tt.cfg.Build(Hooks(hook))
 			require.NoError(t, err, "Unexpected error constructing logger.")
 
-			withNoStacktraceIgnorePrefixes(func() {
-				logger.Debug("debug")
-				logger.Info("info")
-				logger.Warn("warn")
+			logger.Debug("debug")
+			logger.Info("info")
+			logger.Warn("warn")
 
-				byteContents, err := ioutil.ReadAll(temp)
-				require.NoError(t, err, "Couldn't read log contents from temp file.")
-				logs := string(byteContents)
-				assert.Regexp(t, tt.expectRe, logs, "Unexpected log output.")
+			byteContents, err := ioutil.ReadAll(temp)
+			require.NoError(t, err, "Couldn't read log contents from temp file.")
+			logs := string(byteContents)
+			assert.Regexp(t, tt.expectRe, logs, "Unexpected log output.")
 
-				for i := 0; i < 200; i++ {
-					logger.Info("sampling")
-				}
-				assert.Equal(t, tt.expectN, count.Load(), "Hook called an unexpected number of times.")
-			})
+			for i := 0; i < 200; i++ {
+				logger.Info("sampling")
+			}
+			assert.Equal(t, tt.expectN, count.Load(), "Hook called an unexpected number of times.")
 		})
 	}
 }

--- a/field.go
+++ b/field.go
@@ -25,7 +25,6 @@ import (
 	"math"
 	"time"
 
-	"go.uber.org/zap/internal/bufferpool"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -195,20 +194,11 @@ func NamedError(key string, err error) zapcore.Field {
 // extremely expensive (relatively speaking); this function both makes an
 // allocation and takes ~10 microseconds.
 func Stack(key string) zapcore.Field {
-	return stack(key, 4)
-}
-
-// needed for testing
-func stack(key string, skip int) zapcore.Field {
-	// Try to avoid allocating a buffer.
-	buf := bufferpool.Get()
 	// Returning the stacktrace as a string costs an allocation, but saves us
 	// from expanding the zapcore.Field union struct to include a byte slice. Since
 	// taking a stacktrace is already so expensive (~10us), the extra allocation
 	// is okay.
-	field := String(key, takeStacktrace(buf, skip))
-	bufferpool.Put(buf)
-	return field
+	return String(key, takeStacktrace())
 }
 
 // Duration constructs a field with the given key and value. The encoder

--- a/field.go
+++ b/field.go
@@ -195,14 +195,18 @@ func NamedError(key string, err error) zapcore.Field {
 // extremely expensive (relatively speaking); this function both makes an
 // allocation and takes ~10 microseconds.
 func Stack(key string) zapcore.Field {
+	return stack(key, 4)
+}
+
+// needed for testing
+func stack(key string, skip int) zapcore.Field {
 	// Try to avoid allocating a buffer.
 	buf := bufferpool.Get()
-	bs := buf.Bytes()
 	// Returning the stacktrace as a string costs an allocation, but saves us
 	// from expanding the zapcore.Field union struct to include a byte slice. Since
 	// taking a stacktrace is already so expensive (~10us), the extra allocation
 	// is okay.
-	field := String(key, takeStacktrace(bs[:cap(bs)], false))
+	field := String(key, takeStacktrace(buf, skip))
 	bufferpool.Put(buf)
 	return field
 }

--- a/field.go
+++ b/field.go
@@ -191,8 +191,8 @@ func NamedError(key string, err error) zapcore.Field {
 
 // Stack constructs a field that stores a stacktrace of the current goroutine
 // under provided key. Keep in mind that taking a stacktrace is eager and
-// extremely expensive (relatively speaking); this function both makes an
-// allocation and takes ~10 microseconds.
+// expensive (relatively speaking); this function both makes an allocation and
+// takes about two microseconds.
 func Stack(key string) zapcore.Field {
 	// Returning the stacktrace as a string costs an allocation, but saves us
 	// from expanding the zapcore.Field union struct to include a byte slice. Since

--- a/field_test.go
+++ b/field_test.go
@@ -164,7 +164,7 @@ func TestFieldConstructors(t *testing.T) {
 }
 
 func TestStackField(t *testing.T) {
-	withStacktraceIgnorePrefixes([]string{}, func() {
+	withNoStacktraceIgnorePrefixes(func() {
 		f := Stack("stacktrace")
 		assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 		assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")

--- a/field_test.go
+++ b/field_test.go
@@ -164,11 +164,9 @@ func TestFieldConstructors(t *testing.T) {
 }
 
 func TestStackField(t *testing.T) {
-	withNoStacktraceIgnorePrefixes(func() {
-		f := Stack("stacktrace")
-		assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
-		assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
-		assert.Contains(t, f.String, "zap.TestStackField", "Expected stacktrace to contain caller.")
-		assertCanBeReused(t, f)
-	})
+	f := Stack("stacktrace")
+	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
+	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
+	assert.Contains(t, f.String, "zap.TestStackField", "Expected stacktrace to contain caller.")
+	assertCanBeReused(t, f)
 }

--- a/field_test.go
+++ b/field_test.go
@@ -164,9 +164,11 @@ func TestFieldConstructors(t *testing.T) {
 }
 
 func TestStackField(t *testing.T) {
-	f := Stack("stacktrace")
-	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
-	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
-	assert.Contains(t, f.String, "zap.TestStackField", "Expected stacktrace to contain caller.")
-	assertCanBeReused(t, f)
+	withStacktraceIgnorePrefixes([]string{}, func() {
+		f := Stack("stacktrace")
+		assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
+		assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
+		assert.Contains(t, f.String, "zap.TestStackField", "Expected stacktrace to contain caller.")
+		assertCanBeReused(t, f)
+	})
 }

--- a/field_test.go
+++ b/field_test.go
@@ -164,7 +164,7 @@ func TestFieldConstructors(t *testing.T) {
 }
 
 func TestStackField(t *testing.T) {
-	f := stack("stacktrace", 0)
+	f := Stack("stacktrace")
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
 	assert.Contains(t, f.String, "zap.TestStackField", "Expected stacktrace to contain caller.")

--- a/field_test.go
+++ b/field_test.go
@@ -164,7 +164,7 @@ func TestFieldConstructors(t *testing.T) {
 }
 
 func TestStackField(t *testing.T) {
-	f := Stack("stacktrace")
+	f := stack("stacktrace", 0)
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
 	assert.Contains(t, f.String, "zap.TestStackField", "Expected stacktrace to contain caller.")

--- a/logger_test.go
+++ b/logger_test.go
@@ -360,23 +360,24 @@ func TestLoggerAddCallerFail(t *testing.T) {
 }
 
 func TestLoggerAddStacktrace(t *testing.T) {
-	assertHasStack := func(t testing.TB, obs observer.LoggedEntry) {
-		assert.Contains(t, obs.Entry.Stack, "zap.TestLoggerAddStacktrace", "Expected to find test function in stacktrace.")
-	}
+	withStacktraceIgnorePrefixes([]string{}, func() {
+		assertHasStack := func(t testing.TB, obs observer.LoggedEntry) {
+			assert.Contains(t, obs.Entry.Stack, "zap.TestLoggerAddStacktrace", "Expected to find test function in stacktrace.")
+		}
+		withLogger(t, DebugLevel, opts(AddStacktrace(InfoLevel)), func(logger *Logger, logs *observer.ObservedLogs) {
+			logger.Debug("")
+			assert.Empty(
+				t,
+				logs.AllUntimed()[0].Entry.Stack,
+				"Unexpected stacktrack at DebugLevel.",
+			)
 
-	withLogger(t, DebugLevel, opts(AddStacktrace(InfoLevel)), func(logger *Logger, logs *observer.ObservedLogs) {
-		logger.Debug("")
-		assert.Empty(
-			t,
-			logs.AllUntimed()[0].Entry.Stack,
-			"Unexpected stacktrack at DebugLevel.",
-		)
+			logger.Info("")
+			assertHasStack(t, logs.AllUntimed()[1])
 
-		logger.Info("")
-		assertHasStack(t, logs.AllUntimed()[1])
-
-		logger.Warn("")
-		assertHasStack(t, logs.AllUntimed()[2])
+			logger.Warn("")
+			assertHasStack(t, logs.AllUntimed()[2])
+		})
 	})
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -360,7 +360,7 @@ func TestLoggerAddCallerFail(t *testing.T) {
 }
 
 func TestLoggerAddStacktrace(t *testing.T) {
-	withStacktraceIgnorePrefixes([]string{}, func() {
+	withNoStacktraceIgnorePrefixes(func() {
 		assertHasStack := func(t testing.TB, obs observer.LoggedEntry) {
 			assert.Contains(t, obs.Entry.Stack, "zap.TestLoggerAddStacktrace", "Expected to find test function in stacktrace.")
 		}

--- a/logger_test.go
+++ b/logger_test.go
@@ -360,24 +360,22 @@ func TestLoggerAddCallerFail(t *testing.T) {
 }
 
 func TestLoggerAddStacktrace(t *testing.T) {
-	withNoStacktraceIgnorePrefixes(func() {
-		assertHasStack := func(t testing.TB, obs observer.LoggedEntry) {
-			assert.Contains(t, obs.Entry.Stack, "zap.TestLoggerAddStacktrace", "Expected to find test function in stacktrace.")
-		}
-		withLogger(t, DebugLevel, opts(AddStacktrace(InfoLevel)), func(logger *Logger, logs *observer.ObservedLogs) {
-			logger.Debug("")
-			assert.Empty(
-				t,
-				logs.AllUntimed()[0].Entry.Stack,
-				"Unexpected stacktrack at DebugLevel.",
-			)
+	assertHasStack := func(t testing.TB, obs observer.LoggedEntry) {
+		assert.Contains(t, obs.Entry.Stack, "zap.TestLoggerAddStacktrace", "Expected to find test function in stacktrace.")
+	}
+	withLogger(t, DebugLevel, opts(AddStacktrace(InfoLevel)), func(logger *Logger, logs *observer.ObservedLogs) {
+		logger.Debug("")
+		assert.Empty(
+			t,
+			logs.AllUntimed()[0].Entry.Stack,
+			"Unexpected stacktrack at DebugLevel.",
+		)
 
-			logger.Info("")
-			assertHasStack(t, logs.AllUntimed()[1])
+		logger.Info("")
+		assertHasStack(t, logs.AllUntimed()[1])
 
-			logger.Warn("")
-			assertHasStack(t, logs.AllUntimed()[2])
-		})
+		logger.Warn("")
+		assertHasStack(t, logs.AllUntimed()[2])
 	})
 }
 

--- a/options.go
+++ b/options.go
@@ -92,8 +92,7 @@ func AddCallerSkip(skip int) Option {
 }
 
 // AddStacktrace configures the Logger to record a stack trace for all messages at
-// or above a given level. Keep in mind that taking a stacktrace takes several
-// microseconds; relative to the cost of logging, this is quite slow.
+// or above a given level.
 func AddStacktrace(lvl zapcore.LevelEnabler) Option {
 	return optionFunc(func(log *Logger) {
 		log.addStack = lvl

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -30,7 +30,6 @@ import (
 
 var (
 	_stacktraceIgnorePrefixes = []string{
-		"go.uber.org/zap",
 		"runtime.goexit",
 		"runtime.main",
 	}

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -22,26 +22,12 @@ package zap
 
 import (
 	"testing"
-	"unicode/utf8"
-
-	"go.uber.org/zap/internal/bufferpool"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTakeStacktrace(t *testing.T) {
-	traceZero := takeStacktrace(bufferpool.Get(), 0)
-	for _, trace := range []string{traceZero} {
-		// The stacktrace should also its immediate caller.
-		assert.Contains(t, trace, "TestTakeStacktrace", "Stacktrace should contain the test function.")
-	}
-}
-
-func TestRunes(t *testing.T) {
-	// https://golang.org/src/bytes/buffer.go?s=8208:8261#L237
-	// I think this test might not be needed, because this might be checked
-	// implicitly by the fact that we can pass these as bytes to AppendByte
-	assert.True(t, '\n' < utf8.RuneSelf, `You can't cast '\n' to a byte, stop being silly`)
-	assert.True(t, '\t' < utf8.RuneSelf, `You can't cast '\t' to a byte, stop being silly`)
-	assert.True(t, ':' < utf8.RuneSelf, `You can't cast ':' to a byte, stop being silly`)
+	trace := takeStacktrace()
+	// The stacktrace should also its immediate caller.
+	assert.Contains(t, trace, "TestTakeStacktrace", "Stacktrace should contain the test function.")
 }


### PR DESCRIPTION
Remove `runtime.goexit`, `runtime.main`, and some zap frames from our stacktraces. Since we're now formatting our own traces, we also get a *big* performance win: nearly 5x faster and half the number of bytes allocated!

Current master:

```
BenchmarkStackField-4             200000              9587 ns/op             960 B/op          2 allocs/op
```

After this PR:

```
BenchmarkStackField-4             500000              2149 ns/op             448 B/op          2 allocs/op
```

Fixes #308.