### PR TITLE
Add syslog pusher implementation

### DIFF
--- a/syslog/logger.go
+++ b/syslog/logger.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package syslog
+
+import "log/syslog"
+
+var (
+	// TODO(pedge): verify all severity levels are covered in a test
+	severityToLogFunc = map[Severity]func(*syslog.Writer, string) error{
+		EmergSeverity:   (*syslog.Writer).Emerg,
+		AlertSeverity:   (*syslog.Writer).Alert,
+		CritSeverity:    (*syslog.Writer).Crit,
+		ErrSeverity:     (*syslog.Writer).Err,
+		WarningSeverity: (*syslog.Writer).Warning,
+		NoticeSeverity:  (*syslog.Writer).Notice,
+		InfoSeverity:    (*syslog.Writer).Info,
+		DebugSeverity:   (*syslog.Writer).Debug,
+	}
+)
+
+type logger struct {
+	delegate *syslog.Writer
+}
+
+func newLogger(delegate *syslog.Writer) *logger {
+	return &logger{delegate}
+}
+
+func (l *logger) Write(severity Severity, message string) error {
+	return severityToLogFunc[severity](l.delegate, message)
+}
+
+func (l *logger) Close() error {
+	return l.delegate.Close()
+}

--- a/syslog/pusher.go
+++ b/syslog/pusher.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package syslog
+
+import "go.uber.org/zap/zapcore"
+
+var (
+	// TODO(pedge): verify all zapcore levels are covered in a test
+	levelToSeverity = map[zapcore.Level]Severity{
+		zapcore.DebugLevel:  DebugSeverity,
+		zapcore.InfoLevel:   InfoSeverity,
+		zapcore.WarnLevel:   WarningSeverity,
+		zapcore.ErrorLevel:  ErrSeverity,
+		zapcore.DPanicLevel: AlertSeverity,
+		zapcore.PanicLevel:  AlertSeverity,
+		zapcore.FatalLevel:  CritSeverity,
+	}
+)
+
+type pusher struct {
+	logger Logger
+}
+
+func newPusher(logger Logger) *pusher {
+	return &pusher{logger}
+}
+
+func (l *pusher) Push(level zapcore.Level, data []byte) error {
+	// TODO(pedge): doesn't casting to string make a complete copy?
+	return l.logger.Write(levelToSeverity[level], string(data))
+}
+
+func (l *pusher) Sync() error {
+	return nil
+}

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/*
+Package syslog implements syslog functionality for zap.
+*/
+package syslog
+
+import (
+	"log/syslog"
+
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	EmergSeverity Severity = iota
+	AlertSeverity
+	CritSeverity
+	ErrSeverity
+	WarningSeverity
+	NoticeSeverity
+	InfoSeverity
+	DebugSeverity
+)
+
+// Severity is a syslog severity.
+type Severity int
+
+// Logger logs to Syslog.
+type Logger interface {
+	Write(severity Severity, message string) error
+	Close() error
+}
+
+// NewLogger returns a new Logger that wraps the standard syslog.Logger.
+//
+// Note the log/syslog package is frozen now, and we may want to switch
+// to another potential implementation in the future (hence the interface).
+func NewLogger(delegate *syslog.Writer) Logger {
+	return newLogger(delegate)
+}
+
+// Pusher pushes log entries.
+type Pusher interface {
+	Push(level zapcore.Level, data []byte) error
+	Sync() error
+}
+
+// NewPusher returns a new Pusher for the given Logger.
+func NewPusher(logger Logger) Pusher {
+	return newPusher(logger)
+}


### PR DESCRIPTION
This adds a syslog implementation. This uses the Pusher concept in https://github.com/uber-go/zap/pull/313.
