### PR TITLE
Make global loggers safe for concurrent use

### DIFF
--- a/global.go
+++ b/global.go
@@ -59,8 +59,6 @@ func S() *SugaredLogger {
 //
 // It's safe for concurrent use.
 func ReplaceGlobals(logger *Logger) func() {
-	// This doesn't require synchronization to be safe, since pointers are a
-	// single word.
 	_globalMu.Lock()
 	prev := _globalL
 	_globalL = logger

--- a/global_test.go
+++ b/global_test.go
@@ -26,13 +26,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
-
 	"go.uber.org/zap/internal/observer"
 	"go.uber.org/zap/testutils"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func TestReplaceGlobals(t *testing.T) {


### PR DESCRIPTION
This PR adds tests to verify that the global loggers are safe to use and
reconfigure concurrently, and it converts the global variables to (short)
functions.

Users can update their code with a simple gofmt rewrite (which I'll
include in the RC 2 release notes).