### PR TITLE
[breaking] Fix spelling of config JSON key

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ import (
 // Values configured here are per-second. See zapcore.NewSampler for details.
 type SamplingConfig struct {
 	Initial    int `json:"initial" yaml:"initial"`
-	Thereafter int `json:"therafter" yaml:"thereafter"`
+	Thereafter int `json:"thereafter" yaml:"thereafter"`
 }
 
 // Config offers a declarative way to construct a logger.


### PR DESCRIPTION
Like a dummy, I misspelled "thereafter" in the JSON config key. Fixing this is
technically a breaking change, but I think it's worthwhile.