### PR TITLE
 AddCallerSkip in RedirectStdLog (#320)

### DIFF
--- a/global.go
+++ b/global.go
@@ -59,16 +59,17 @@ func ReplaceGlobals(logger *Logger) func() {
 // It returns a function to restore the original prefix and flags and reset the
 // standard library's output to os.Stdout.
 func RedirectStdLog(l *Logger) func() {
+	const (
+		stdLogDefaultDepth = 4
+		loggerWriterDepth  = 1
+	)
 	flags := log.Flags()
 	prefix := log.Prefix()
 	log.SetFlags(0)
 	log.SetPrefix("")
-	if l.addCaller {
-		const stdLogDefaultDepth = 4
-		const loggerWriterDepth = 1
-		l = l.WithOptions(AddCallerSkip(stdLogDefaultDepth + loggerWriterDepth))
-	}
-	log.SetOutput(&loggerWriter{l})
+	log.SetOutput(&loggerWriter{l.WithOptions(
+		AddCallerSkip(stdLogDefaultDepth + loggerWriterDepth),
+	)})
 	return func() {
 		log.SetFlags(flags)
 		log.SetPrefix(prefix)

--- a/global.go
+++ b/global.go
@@ -63,6 +63,11 @@ func RedirectStdLog(l *Logger) func() {
 	prefix := log.Prefix()
 	log.SetFlags(0)
 	log.SetPrefix("")
+	if l.addCaller {
+		const stdLogDefaultDepth = 4
+		const loggerWriterDepth = 1
+		l = l.WithOptions(AddCallerSkip(stdLogDefaultDepth + loggerWriterDepth))
+	}
 	log.SetOutput(&loggerWriter{l})
 	return func() {
 		log.SetFlags(flags)

--- a/global_test.go
+++ b/global_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.uber.org/zap/internal/observer"
 	"go.uber.org/zap/zapcore"
@@ -75,4 +76,15 @@ func TestRedirectStdLog(t *testing.T) {
 
 	assert.Equal(t, initialFlags, log.Flags(), "Expected to reset initial flags.")
 	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
+}
+
+func TestRedirectStdLogCaller(t *testing.T) {
+	withLogger(t, DebugLevel, nil, func(l *Logger, logs *observer.ObservedLogs) {
+		l = l.WithOptions(AddCaller())
+		defer RedirectStdLog(l)()
+		log.Print("redirected")
+		entries := logs.All()
+		require.Len(t, entries, 1)
+		assert.Contains(t, entries[0].Entry.Caller.File, "global_test.go")
+	})
 }

--- a/global_test.go
+++ b/global_test.go
@@ -79,12 +79,11 @@ func TestRedirectStdLog(t *testing.T) {
 }
 
 func TestRedirectStdLogCaller(t *testing.T) {
-	withLogger(t, DebugLevel, nil, func(l *Logger, logs *observer.ObservedLogs) {
-		l = l.WithOptions(AddCaller())
+	withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
 		defer RedirectStdLog(l)()
 		log.Print("redirected")
 		entries := logs.All()
-		require.Len(t, entries, 1)
-		assert.Contains(t, entries[0].Entry.Caller.File, "global_test.go")
+		require.Len(t, entries, 1, "Unexpected number of logs.")
+		assert.Contains(t, entries[0].Entry.Caller.File, "global_test.go", "Unexpected caller annotation.")
 	})
 }


### PR DESCRIPTION
Make entries logged through log.Print have correct caller. Fixes #320.