### PR TITLE
Add a more-explicit NewNop constructor

### DIFF
--- a/global.go
+++ b/global.go
@@ -32,7 +32,7 @@ var (
 	//
 	// Both L and S are unsynchronized, so replacing them while they're in
 	// use isn't safe.
-	L = New(nil)
+	L = NewNop()
 	// S is a global SugaredLogger, similar to L. It also defaults to a no-op
 	// implementation.
 	S = L.Sugar()

--- a/logger.go
+++ b/logger.go
@@ -22,6 +22,7 @@ package zap
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -56,7 +57,7 @@ type Logger struct {
 // convenient.
 func New(core zapcore.Core, options ...Option) *Logger {
 	if core == nil {
-		core = zapcore.NewNopCore()
+		return NewNop()
 	}
 	log := &Logger{
 		core:        core,
@@ -64,6 +65,19 @@ func New(core zapcore.Core, options ...Option) *Logger {
 		addStack:    zapcore.FatalLevel + 1,
 	}
 	return log.WithOptions(options...)
+}
+
+// NewNop returns a no-op Logger. It never writes out logs or internal errors,
+// and it never runs user-defined hooks.
+//
+// Using WithOptions to replace the Core or error output of a no-op Logger can
+// re-enable logging.
+func NewNop() *Logger {
+	return &Logger{
+		core:        zapcore.NewNopCore(),
+		errorOutput: zapcore.AddSync(ioutil.Discard),
+		addStack:    zapcore.FatalLevel + 1,
+	}
 }
 
 // NewProduction builds a sensible production Logger that writes InfoLevel and


### PR DESCRIPTION
`New` already takes a variadic number of options, so we can't also take a
variadic number of cores. Instead, add a niladic `NewNop` constructor that
returns a no-op Logger.

This is already covered by tests, and is also backwards-compatible.

@sectioneight, this should fix one of your comments on the UberFX logging
upgrade PR.