### PR TITLE
Extend bufferpool test

### DIFF
--- a/internal/bufferpool/bufferpool_test.go
+++ b/internal/bufferpool/bufferpool_test.go
@@ -21,6 +21,7 @@
 package bufferpool
 
 import (
+	"math/rand"
 	"sync"
 	"testing"
 
@@ -36,10 +37,23 @@ func TestBuffers(t *testing.T) {
 				buf := Get()
 				assert.Zero(t, buf.Len(), "Expected truncated buffer")
 				assert.NotZero(t, buf.Cap(), "Expected non-zero capacity")
+
+				b := getRandBytes()
+				_, err := buf.Write(b)
+				assert.NoError(t, err, "Unexpected error from buffer.Write")
+
+				assert.Equal(t, buf.Len(), len(b), "Expected same buffer size")
+
 				Put(buf)
 			}
 			wg.Done()
 		}()
 	}
 	wg.Wait()
+}
+
+func getRandBytes() []byte {
+	b := make([]byte, rand.Intn(5000))
+	rand.Read(b)
+	return b
 }

--- a/internal/bufferpool/bufferpool_test.go
+++ b/internal/bufferpool/bufferpool_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const dummyData = "dummy data"
-
 func TestBuffers(t *testing.T) {
+	const dummyData = "dummy data"
+
 	var wg sync.WaitGroup
 	for g := 0; g < 10; g++ {
 		wg.Add(1)

--- a/internal/bufferpool/bufferpool_test.go
+++ b/internal/bufferpool/bufferpool_test.go
@@ -21,12 +21,13 @@
 package bufferpool
 
 import (
-	"math/rand"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+const dummyData = "dummy data"
 
 func TestBuffers(t *testing.T) {
 	var wg sync.WaitGroup
@@ -38,11 +39,8 @@ func TestBuffers(t *testing.T) {
 				assert.Zero(t, buf.Len(), "Expected truncated buffer")
 				assert.NotZero(t, buf.Cap(), "Expected non-zero capacity")
 
-				b := getRandBytes()
-				_, err := buf.Write(b)
-				assert.NoError(t, err, "Unexpected error from buffer.Write")
-
-				assert.Equal(t, buf.Len(), len(b), "Expected same buffer size")
+				buf.AppendString(dummyData)
+				assert.Equal(t, buf.Len(), len(dummyData), "Expected buffer to contain dummy data")
 
 				Put(buf)
 			}
@@ -50,10 +48,4 @@ func TestBuffers(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-}
-
-func getRandBytes() []byte {
-	b := make([]byte, rand.Intn(5000))
-	rand.Read(b)
-	return b
 }


### PR DESCRIPTION
Summary: Adds on to the bufferpool test to write random bytes into
the buffers before putting them back into the sync.Pool