### PR TITLE
config: export DevelopmentEncoderConfig and ProductionEncoderConfig

### DIFF
--- a/config.go
+++ b/config.go
@@ -77,6 +77,22 @@ type Config struct {
 	InitialFields map[string]interface{} `json:"initialFields" yaml:"initialFields"`
 }
 
+// NewProductionEncoderConfig returns an opinionated EncoderConfig for
+// production environments.
+func NewProductionEncoderConfig() zapcore.EncoderConfig {
+	return zapcore.EncoderConfig{
+		TimeKey:        "ts",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		MessageKey:     "msg",
+		StacktraceKey:  "stacktrace",
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.EpochTimeEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
+	}
+}
+
 // NewProductionConfig is the recommended production configuration. Logging is
 // enabled at InfoLevel and above.
 //
@@ -90,20 +106,27 @@ func NewProductionConfig() Config {
 			Initial:    100,
 			Thereafter: 100,
 		},
-		Encoding: "json",
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:        "ts",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			MessageKey:     "msg",
-			StacktraceKey:  "stacktrace",
-			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     zapcore.EpochTimeEncoder,
-			EncodeDuration: zapcore.SecondsDurationEncoder,
-		},
+		Encoding:         "json",
+		EncoderConfig:    NewProductionEncoderConfig(),
 		OutputPaths:      []string{"stderr"},
 		ErrorOutputPaths: []string{"stderr"},
+	}
+}
+
+// NewDevelopmentEncoderConfig returns an opinionated EncoderConfig for
+// development environments.
+func NewDevelopmentEncoderConfig() zapcore.EncoderConfig {
+	return zapcore.EncoderConfig{
+		// Keys can be anything except the empty string.
+		TimeKey:        "T",
+		LevelKey:       "L",
+		NameKey:        "N",
+		CallerKey:      "C",
+		MessageKey:     "M",
+		StacktraceKey:  "S",
+		EncodeLevel:    zapcore.CapitalLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
 	}
 }
 
@@ -118,21 +141,10 @@ func NewDevelopmentConfig() Config {
 	dyn.SetLevel(DebugLevel)
 
 	return Config{
-		Level:       dyn,
-		Development: true,
-		Encoding:    "console",
-		EncoderConfig: zapcore.EncoderConfig{
-			// Keys can be anything except the empty string.
-			TimeKey:        "T",
-			LevelKey:       "L",
-			NameKey:        "N",
-			CallerKey:      "C",
-			MessageKey:     "M",
-			StacktraceKey:  "S",
-			EncodeLevel:    zapcore.CapitalLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.StringDurationEncoder,
-		},
+		Level:            dyn,
+		Development:      true,
+		Encoding:         "console",
+		EncoderConfig:    NewDevelopmentEncoderConfig(),
 		OutputPaths:      []string{"stderr"},
 		ErrorOutputPaths: []string{"stderr"},
 	}


### PR DESCRIPTION
This makes creating loggers with custom write paths easier.

For example

```go
var ws zapcore.WriteSync // probably obtained using zap.Open

core := zapcore.NewCore(
	zapcore.NewConsoleEncoder(zap.ProductionEncoderConfig),
	ws, zapcore.DebugLevel)

logger := zap.New(core)
```

instead of copying the entire `ProductionEncoderConfig` from source.

Before opening your pull request, please make sure that you've:

- [x] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [ ] added tests to cover your changes; (Not Applicable)
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).

Thanks for your contribution!
