### PR TITLE
writer: add CombineWriteSyncers

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -37,13 +37,12 @@ import (
 // "stderr" are interpreted as os.Stdout and os.Stderr, respectively.
 func Open(paths ...string) (zapcore.WriteSyncer, func(), error) {
 	writers, close, err := open(paths)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
-	writer, err := OpenWriteSyncers(writers...)
-	return writer, close, err
+	writer := CombineWriteSyncers(writers...)
+	return writer, close, nil
 }
 
 func open(paths []string) ([]zapcore.WriteSyncer, func(), error) {
@@ -76,11 +75,11 @@ func open(paths []string) ([]zapcore.WriteSyncer, func(), error) {
 	return writers, close, errs.AsError()
 }
 
-// OpenWriteSyncers combines the passed set of WriteSyncer objects into a locked
-// WriteSyncer. It returns any error encountered.
-func OpenWriteSyncers(writers ...zapcore.WriteSyncer) (zapcore.WriteSyncer, error) {
+// CombineWriteSyncers combines the passed set of WriteSyncer objects into a
+// locked WriteSyncer.
+func CombineWriteSyncers(writers ...zapcore.WriteSyncer) zapcore.WriteSyncer {
 	if len(writers) == 0 {
-		return zapcore.AddSync(ioutil.Discard), nil
+		return zapcore.AddSync(ioutil.Discard)
 	}
-	return zapcore.Lock(zapcore.NewMultiWriteSyncer(writers...)), nil
+	return zapcore.Lock(zapcore.NewMultiWriteSyncer(writers...))
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -81,3 +81,28 @@ func TestOpen(t *testing.T) {
 		assert.Equal(t, tt.filenames, names, "Opened unexpected files given paths %v.", tt.paths)
 	}
 }
+
+type testWriter struct {
+	expected []byte
+	t        testing.TB
+}
+
+func (w *testWriter) Write(actual []byte) (int, error) {
+	assert.Equal(w.t, w.expected, actual, "expected writer to write %v, wrote %v", string(w.expected), string(actual))
+	return 0, nil
+}
+
+func (w *testWriter) Sync() error {
+	return nil
+}
+
+func TestOpenWriteSyncers(t *testing.T) {
+	tw := &testWriter{[]byte("test"), t}
+
+	w, err := OpenWriteSyncers(tw)
+	if err != nil {
+		require.NoError(t, err, "OpenWriters Failed.")
+	}
+
+	w.Write([]byte("test"))
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -83,13 +83,13 @@ func TestOpen(t *testing.T) {
 }
 
 type testWriter struct {
-	expected []byte
+	expected string
 	t        testing.TB
 }
 
 func (w *testWriter) Write(actual []byte) (int, error) {
-	assert.Equal(w.t, w.expected, actual, "expected writer to write %v, wrote %v", string(w.expected), string(actual))
-	return 0, nil
+	assert.Equal(w.t, []byte(w.expected), actual, "Unexpected write error.")
+	return len(actual), nil
 }
 
 func (w *testWriter) Sync() error {
@@ -97,12 +97,7 @@ func (w *testWriter) Sync() error {
 }
 
 func TestOpenWriteSyncers(t *testing.T) {
-	tw := &testWriter{[]byte("test"), t}
-
-	w, err := OpenWriteSyncers(tw)
-	if err != nil {
-		require.NoError(t, err, "OpenWriters Failed.")
-	}
-
+	tw := &testWriter{"test", t}
+	w := CombineWriteSyncers(tw)
 	w.Write([]byte("test"))
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -96,7 +96,7 @@ func (w *testWriter) Sync() error {
 	return nil
 }
 
-func TestOpenWriteSyncers(t *testing.T) {
+func TestCombineWriteSyncers(t *testing.T) {
 	tw := &testWriter{"test", t}
 	w := CombineWriteSyncers(tw)
 	w.Write([]byte("test"))

--- a/zapcore/write_syncer.go
+++ b/zapcore/write_syncer.go
@@ -88,6 +88,9 @@ type multiWriteSyncer []WriteSyncer
 // NewMultiWriteSyncer creates a WriteSyncer that duplicates its writes
 // and sync calls, much like io.MultiWriter.
 func NewMultiWriteSyncer(ws ...WriteSyncer) WriteSyncer {
+	if len(ws) == 1 {
+		return ws[0]
+	}
 	// Copy to protect against https://github.com/golang/go/issues/7809
 	return multiWriteSyncer(append([]WriteSyncer(nil), ws...))
 }

--- a/zapcore/write_syncer_test.go
+++ b/zapcore/write_syncer_test.go
@@ -66,9 +66,13 @@ func TestAddSyncWriter(t *testing.T) {
 }
 
 func TestNewMultiWriteSyncerWorksForSingleWriter(t *testing.T) {
-	w := AddSync(&bytes.Buffer{})
+	w := &testutils.Buffer{}
+
 	ws := NewMultiWriteSyncer(w)
 	assert.Equal(t, w, ws, "Expected NewMultiWriteSyncer to return the same WriteSyncer object for a single argument.")
+
+	ws.Sync()
+	assert.True(t, w.Called(), "Expected Sync to be called on the created WriteSyncer")
 }
 
 func TestMultiWriteSyncerWritesBoth(t *testing.T) {

--- a/zapcore/write_syncer_test.go
+++ b/zapcore/write_syncer_test.go
@@ -65,6 +65,12 @@ func TestAddSyncWriter(t *testing.T) {
 	assert.NoError(t, ws.Sync(), "Unexpected error calling a no-op Sync method.")
 }
 
+func TestNewMultiWriteSyncerWorksForSingleWriter(t *testing.T) {
+	w := AddSync(&bytes.Buffer{})
+	ws := NewMultiWriteSyncer(w)
+	assert.Equal(t, w, ws, "Expected NewMultiWriteSyncer to return the same WriteSyncer object for a single argument.")
+}
+
 func TestMultiWriteSyncerWritesBoth(t *testing.T) {
 	first := &bytes.Buffer{}
 	second := &bytes.Buffer{}


### PR DESCRIPTION
Allowing functions to take interfaces as parameters allows for better
customization.

For example, to have a writer that also counts the number of writes
specifically made to its instance

```go
type MyWriter struct {
	*os.File
	logcount int
}

func (w *MyWriter) Write(data []byte) (int, error) {
	w.logcount++
	return w.File.Write(data)
}

func (w *MyWriter) Sync() error {
	return w.File.Sync()
}

...

func main() {
	f, err := os.Create(...)
	if err != nil {
		log.Fatal(err)
	}
	defer f.Close()

	w := &MyWriter{f, 0}
	ws, err := zap.OpenWriters(os.Stdout, w)
	if err != nil {
		log.Fatal(err)
	}

	core := zapcore.NewCore(
		zapcore.NewConsoleEncoder(zap.NewProductionEncoderConfig()),
		ws, zapcore.DebugLevel)

	logger := zap.New(core)

	...

	fmt.Printf("logged %v times to MyWriter", w.logcount)
}
```

Before opening your pull request, please make sure that you've:

- [x] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [x] added tests to cover your changes;
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).

Thanks for your contribution!
