### PR TITLE
Add RegisterEncoder functionality

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,7 +21,6 @@
 package zap
 
 import (
-	"fmt"
 	"sort"
 	"time"
 
@@ -229,11 +228,5 @@ func (cfg Config) openSinks() (zapcore.WriteSyncer, zapcore.WriteSyncer, error) 
 }
 
 func (cfg Config) buildEncoder() (zapcore.Encoder, error) {
-	switch cfg.Encoding {
-	case "json":
-		return zapcore.NewJSONEncoder(cfg.EncoderConfig), nil
-	case "console":
-		return zapcore.NewConsoleEncoder(cfg.EncoderConfig), nil
-	}
-	return nil, fmt.Errorf("unknown encoding %q", cfg.Encoding)
+	return newEncoder(cfg.Encoding, cfg.EncoderConfig)
 }

--- a/encoder.go
+++ b/encoder.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap/zapcore"
+)
+
+var (
+	errNoEncoderNameSpecified = errors.New("no encoder name specified ")
+	encoderNameToConstructor  = make(map[string]func(zapcore.EncoderConfig) zapcore.Encoder)
+	encoderMutex              sync.RWMutex
+)
+
+func init() {
+	registerDefaultEncoders()
+}
+
+// RegisterEncoder registers an encoder constructor for the given name.
+//
+// If an encoder with the same name already exists, this will panic.
+// By default, the encoders "json" and "console" are registered.
+func MustRegisterEncoder(name string, constructor func(zapcore.EncoderConfig) zapcore.Encoder) {
+	if err := RegisterEncoder(name, constructor); err != nil {
+		panic(err.Error())
+	}
+}
+
+// RegisterEncoder registers an encoder constructor for the given name.
+//
+// If an encoder with the same name already exists, this will return an error.
+// By default, the encoders "json" and "console" are registered.
+func RegisterEncoder(name string, constructor func(zapcore.EncoderConfig) zapcore.Encoder) error {
+	encoderMutex.Lock()
+	defer encoderMutex.Unlock()
+	if name == "" {
+		return errNoEncoderNameSpecified
+	}
+	if _, ok := encoderNameToConstructor[name]; ok {
+		return fmt.Errorf("encoder already registered for name %s", name)
+	}
+	encoderNameToConstructor[name] = constructor
+	return nil
+}
+
+func registerDefaultEncoders() {
+	MustRegisterEncoder("console", zapcore.NewConsoleEncoder)
+	MustRegisterEncoder("json", zapcore.NewJSONEncoder)
+}
+
+func newEncoder(name string, encoderConfig zapcore.EncoderConfig) (zapcore.Encoder, error) {
+	encoderMutex.RLock()
+	defer encoderMutex.RUnlock()
+	if name == "" {
+		return nil, errNoEncoderNameSpecified
+	}
+	constructor, ok := encoderNameToConstructor[name]
+	if !ok {
+		return nil, fmt.Errorf("no encoder registered for name %s", name)
+	}
+	return constructor(encoderConfig), nil
+}

--- a/encoder.go
+++ b/encoder.go
@@ -38,7 +38,7 @@ func init() {
 	registerDefaultEncoders()
 }
 
-// RegisterEncoder registers an encoder constructor for the given name.
+// MustRegisterEncoder registers an encoder constructor for the given name.
 //
 // If an encoder with the same name already exists, this will panic.
 // By default, the encoders "json" and "console" are registered.

--- a/encoder.go
+++ b/encoder.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	errNoEncoderNameSpecified = errors.New("no encoder name specified ")
+	errNoEncoderNameSpecified = errors.New("no encoder name specified")
 
 	_encoderNameToConstructor = defaultEncoders()
 	_encoderMutex             sync.RWMutex

--- a/encoder.go
+++ b/encoder.go
@@ -31,8 +31,15 @@ import (
 var (
 	errNoEncoderNameSpecified = errors.New("no encoder name specified")
 
-	_encoderNameToConstructor = defaultEncoders()
-	_encoderMutex             sync.RWMutex
+	_encoderNameToConstructor = map[string]func(zapcore.EncoderConfig) (zapcore.Encoder, error){
+		"console": func(encoderConfig zapcore.EncoderConfig) (zapcore.Encoder, error) {
+			return zapcore.NewConsoleEncoder(encoderConfig), nil
+		},
+		"json": func(encoderConfig zapcore.EncoderConfig) (zapcore.Encoder, error) {
+			return zapcore.NewJSONEncoder(encoderConfig), nil
+		},
+	}
+	_encoderMutex sync.RWMutex
 )
 
 // RegisterEncoder registers an encoder constructor for the given name.
@@ -63,15 +70,4 @@ func newEncoder(name string, encoderConfig zapcore.EncoderConfig) (zapcore.Encod
 		return nil, fmt.Errorf("no encoder registered for name %q", name)
 	}
 	return constructor(encoderConfig)
-}
-
-func defaultEncoders() map[string]func(zapcore.EncoderConfig) (zapcore.Encoder, error) {
-	return map[string]func(zapcore.EncoderConfig) (zapcore.Encoder, error){
-		"console": func(encoderConfig zapcore.EncoderConfig) (zapcore.Encoder, error) {
-			return zapcore.NewConsoleEncoder(encoderConfig), nil
-		},
-		"json": func(encoderConfig zapcore.EncoderConfig) (zapcore.Encoder, error) {
-			return zapcore.NewJSONEncoder(encoderConfig), nil
-		},
-	}
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -52,6 +52,15 @@ func TestDuplicateRegisterEncoder(t *testing.T) {
 	})
 }
 
+func TestDuplicateMustRegisterEncoder(t *testing.T) {
+	testEncoders(func() {
+		RegisterEncoder("foo", newNilEncoder)
+		assert.Panics(t, func() {
+			MustRegisterEncoder("foo", newNilEncoder)
+		})
+	})
+}
+
 func TestRegisterEncoderNoName(t *testing.T) {
 	assert.Equal(t, errNoEncoderNameSpecified, RegisterEncoder("", newNilEncoder))
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zap
+
+import (
+	"testing"
+
+	"go.uber.org/zap/zapcore"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	newNilEncoder = func(_ zapcore.EncoderConfig) zapcore.Encoder {
+		return nil
+	}
+)
+
+func TestRegisterDefaultEncoders(t *testing.T) {
+	testEncodersRegistered(t, "console", "json")
+}
+
+func TestRegisterEncoder(t *testing.T) {
+	testEncoders(func() {
+		assert.NoError(t, RegisterEncoder("foo", newNilEncoder))
+		testEncodersRegistered(t, "foo")
+	})
+}
+
+func TestDuplicateRegisterEncoder(t *testing.T) {
+	testEncoders(func() {
+		RegisterEncoder("foo", newNilEncoder)
+		assert.Error(t, RegisterEncoder("foo", newNilEncoder))
+	})
+}
+
+func TestRegisterEncoderNoName(t *testing.T) {
+	assert.Equal(t, errNoEncoderNameSpecified, RegisterEncoder("", newNilEncoder))
+}
+
+func TestNewEncoder(t *testing.T) {
+	testEncoders(func() {
+		RegisterEncoder("foo", newNilEncoder)
+		encoder, err := newEncoder("foo", zapcore.EncoderConfig{})
+		assert.NoError(t, err)
+		assert.Nil(t, encoder)
+	})
+}
+
+func TestNewEncoderNotRegistered(t *testing.T) {
+	_, err := newEncoder("foo", zapcore.EncoderConfig{})
+	assert.Error(t, err)
+}
+
+func TestNewEncoderNoName(t *testing.T) {
+	_, err := newEncoder("", zapcore.EncoderConfig{})
+	assert.Equal(t, errNoEncoderNameSpecified, err)
+}
+
+func testEncoders(f func()) {
+	encoderNameToConstructor = make(map[string]func(zapcore.EncoderConfig) zapcore.Encoder)
+	defer func() {
+		encoderNameToConstructor = make(map[string]func(zapcore.EncoderConfig) zapcore.Encoder)
+		registerDefaultEncoders()
+	}()
+	f()
+}
+
+func testEncodersRegistered(t *testing.T, names ...string) {
+	assert.Len(t, encoderNameToConstructor, len(names))
+	for _, name := range names {
+		assert.NotNil(t, encoderNameToConstructor[name])
+	}
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -34,7 +34,7 @@ func TestRegisterDefaultEncoders(t *testing.T) {
 
 func TestRegisterEncoder(t *testing.T) {
 	testEncoders(func() {
-		assert.NoError(t, RegisterEncoder("foo", newNilEncoder))
+		assert.NoError(t, RegisterEncoder("foo", newNilEncoder), "expected to be able to register the encoder foo")
 		testEncodersRegistered(t, "foo")
 	})
 }
@@ -42,31 +42,31 @@ func TestRegisterEncoder(t *testing.T) {
 func TestDuplicateRegisterEncoder(t *testing.T) {
 	testEncoders(func() {
 		RegisterEncoder("foo", newNilEncoder)
-		assert.Error(t, RegisterEncoder("foo", newNilEncoder))
+		assert.Error(t, RegisterEncoder("foo", newNilEncoder), "expected an error when registering an encoder with the same name twice")
 	})
 }
 
 func TestRegisterEncoderNoName(t *testing.T) {
-	assert.Equal(t, errNoEncoderNameSpecified, RegisterEncoder("", newNilEncoder))
+	assert.Equal(t, errNoEncoderNameSpecified, RegisterEncoder("", newNilEncoder), "expected an error when registering an encoder with no name")
 }
 
 func TestNewEncoder(t *testing.T) {
 	testEncoders(func() {
 		RegisterEncoder("foo", newNilEncoder)
 		encoder, err := newEncoder("foo", zapcore.EncoderConfig{})
-		assert.NoError(t, err)
-		assert.Nil(t, encoder)
+		assert.NoError(t, err, "could not create an encoder for the registered name foo")
+		assert.Nil(t, encoder, "the encoder from newNilEncoder is not nil")
 	})
 }
 
 func TestNewEncoderNotRegistered(t *testing.T) {
 	_, err := newEncoder("foo", zapcore.EncoderConfig{})
-	assert.Error(t, err)
+	assert.Error(t, err, "expected an error when trying to create an encoder of an unregistered name")
 }
 
 func TestNewEncoderNoName(t *testing.T) {
 	_, err := newEncoder("", zapcore.EncoderConfig{})
-	assert.Equal(t, errNoEncoderNameSpecified, err)
+	assert.Equal(t, errNoEncoderNameSpecified, err, "expected an error when creating an encoder with no name")
 }
 
 func testEncoders(f func()) {
@@ -77,9 +77,9 @@ func testEncoders(f func()) {
 }
 
 func testEncodersRegistered(t *testing.T, names ...string) {
-	assert.Len(t, _encoderNameToConstructor, len(names))
+	assert.Len(t, _encoderNameToConstructor, len(names), "the expected number of registered encoders does not match the actual number")
 	for _, name := range names {
-		assert.NotNil(t, _encoderNameToConstructor[name])
+		assert.NotNil(t, _encoderNameToConstructor[name], "no encoder is registered for name %s", name)
 	}
 }
 

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -46,15 +46,6 @@ func TestDuplicateRegisterEncoder(t *testing.T) {
 	})
 }
 
-func TestDuplicateMustRegisterEncoder(t *testing.T) {
-	testEncoders(func() {
-		RegisterEncoder("foo", newNilEncoder)
-		assert.Panics(t, func() {
-			MustRegisterEncoder("foo", newNilEncoder)
-		})
-	})
-}
-
 func TestRegisterEncoderNoName(t *testing.T) {
 	assert.Equal(t, errNoEncoderNameSpecified, RegisterEncoder("", newNilEncoder))
 }
@@ -79,16 +70,16 @@ func TestNewEncoderNoName(t *testing.T) {
 }
 
 func testEncoders(f func()) {
-	existing := encoderNameToConstructor
-	encoderNameToConstructor = make(map[string]func(zapcore.EncoderConfig) (zapcore.Encoder, error))
-	defer func() { encoderNameToConstructor = existing }()
+	existing := _encoderNameToConstructor
+	_encoderNameToConstructor = make(map[string]func(zapcore.EncoderConfig) (zapcore.Encoder, error))
+	defer func() { _encoderNameToConstructor = existing }()
 	f()
 }
 
 func testEncodersRegistered(t *testing.T, names ...string) {
-	assert.Len(t, encoderNameToConstructor, len(names))
+	assert.Len(t, _encoderNameToConstructor, len(names))
 	for _, name := range names {
-		assert.NotNil(t, encoderNameToConstructor[name])
+		assert.NotNil(t, _encoderNameToConstructor[name])
 	}
 }
 

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -28,12 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	newNilEncoder = func(_ zapcore.EncoderConfig) zapcore.Encoder {
-		return nil
-	}
-)
-
 func TestRegisterDefaultEncoders(t *testing.T) {
 	testEncodersRegistered(t, "console", "json")
 }
@@ -85,11 +79,9 @@ func TestNewEncoderNoName(t *testing.T) {
 }
 
 func testEncoders(f func()) {
-	encoderNameToConstructor = make(map[string]func(zapcore.EncoderConfig) zapcore.Encoder)
-	defer func() {
-		encoderNameToConstructor = make(map[string]func(zapcore.EncoderConfig) zapcore.Encoder)
-		registerDefaultEncoders()
-	}()
+	existing := encoderNameToConstructor
+	encoderNameToConstructor = make(map[string]func(zapcore.EncoderConfig) (zapcore.Encoder, error))
+	defer func() { encoderNameToConstructor = existing }()
 	f()
 }
 
@@ -98,4 +90,8 @@ func testEncodersRegistered(t *testing.T, names ...string) {
 	for _, name := range names {
 		assert.NotNil(t, encoderNameToConstructor[name])
 	}
+}
+
+func newNilEncoder(_ zapcore.EncoderConfig) (zapcore.Encoder, error) {
+	return nil, nil
 }


### PR DESCRIPTION
For https://github.com/uber-go/zap/issues/330

This is just a pass at this, let me know of any changes obviously. I purposefully didn't do the underscores in front of private variables (I don't want to do this anymore) but I can add this for consistency. We could reuse the global mutex in global.go as well.
