### PR TITLE
Do not special case stdout and stderr in Open

### DIFF
--- a/config.go
+++ b/config.go
@@ -214,12 +214,12 @@ func (cfg Config) buildOptions(errSink zapcore.WriteSyncer) []Option {
 }
 
 func (cfg Config) openSinks() (zapcore.WriteSyncer, zapcore.WriteSyncer, error) {
-	sink, closeOut, err := Open(cfg.OutputPaths...)
+	sink, closeOut, err := openOrGetStd(cfg.OutputPaths...)
 	if err != nil {
 		closeOut()
 		return nil, nil, err
 	}
-	errSink, closeErr, err := Open(cfg.ErrorOutputPaths...)
+	errSink, closeErr, err := openOrGetStd(cfg.ErrorOutputPaths...)
 	if err != nil {
 		closeOut()
 		closeErr()

--- a/writer_test.go
+++ b/writer_test.go
@@ -53,13 +53,11 @@ func TestOpen(t *testing.T) {
 		filenames []string
 		error     string
 	}{
-		{[]string{"stdout"}, []string{os.Stdout.Name()}, ""},
-		{[]string{"stderr"}, []string{os.Stderr.Name()}, ""},
 		{[]string{temp.Name()}, []string{temp.Name()}, ""},
 		{[]string{"/foo/bar/baz"}, []string{}, "open /foo/bar/baz: no such file or directory"},
 		{
-			paths:     []string{"stdout", "/foo/bar/baz", temp.Name(), "/baz/quux"},
-			filenames: []string{os.Stdout.Name(), temp.Name()},
+			paths:     []string{"/foo/bar/baz", temp.Name(), "/baz/quux"},
+			filenames: []string{temp.Name()},
 			error:     "open /foo/bar/baz: no such file or directory; open /baz/quux: no such file or directory",
 		},
 	}


### PR DESCRIPTION
You can close this if you don't want it, but I don't like how stdout and stderr are special cased in Open - you aren't actually opening them. I don't like my code here either, but this is a first pass.