### PR TITLE
Support construction of zap-backed log.Loggers

### DIFF
--- a/global.go
+++ b/global.go
@@ -72,15 +72,17 @@ func ReplaceGlobals(logger *Logger) func() {
 	return func() { ReplaceGlobals(prev) }
 }
 
-// NewStdLog returns a standard logger which writes to the supplied zap logger at InfoLevel.
+// NewStdLog returns a *log.Logger which writes to the supplied zap Logger at
+// InfoLevel. To redirect the standard library's package-global logging
+// functions, use RedirectStdLog instead.
 func NewStdLog(l *Logger) *log.Logger {
 	return log.New(&loggerWriter{l.WithOptions(
 		AddCallerSkip(_stdLogDefaultDepth + _loggerWriterDepth),
-	)}, "", 0)
+	)}, "" /* prefix */, 0 /* flags */)
 }
 
-// RedirectStdLog redirects output from the standard library's "log" package to
-// the supplied logger at InfoLevel. Since zap already handles caller
+// RedirectStdLog redirects output from the standard library's package-global
+// logger to the supplied logger at InfoLevel. Since zap already handles caller
 // annotations, timestamps, etc., it automatically disables the standard
 // library's annotations and prefixing.
 //

--- a/global_test.go
+++ b/global_test.go
@@ -92,6 +92,18 @@ func TestGlobalsConcurrentUse(t *testing.T) {
 	wg.Wait()
 }
 
+func TestNewStdLog(t *testing.T) {
+	withLogger(t, DebugLevel, nil, func(l *Logger, logs *observer.ObservedLogs) {
+		std := NewStdLog(l)
+		std.Print("redirected")
+
+		assert.Equal(t, []observer.LoggedEntry{{
+			Entry:   zapcore.Entry{Message: "redirected"},
+			Context: []zapcore.Field{},
+		}}, logs.AllUntimed(), "Unexpected new standard log output.")
+	})
+}
+
 func TestRedirectStdLog(t *testing.T) {
 	initialFlags := log.Flags()
 	initialPrefix := log.Prefix()


### PR DESCRIPTION
In addition to letting users redirect the output of the standard library's package-global log functions, we should also support wrapping a zap logger in a log.Logger.

This is the same PR as #344, which I somehow closed by mistake :/

Thanks to @flisky for the initial code and the suggestion.