### PR TITLE
Use fixed-width ISO8601 formatting

### DIFF
--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -107,7 +107,7 @@ func EpochNanosTimeEncoder(t time.Time, enc PrimitiveArrayEncoder) {
 // ISO8601TimeEncoder serializes a time.Time to an ISO8601-formatted string
 // with millisecond precision.
 func ISO8601TimeEncoder(t time.Time, enc PrimitiveArrayEncoder) {
-	enc.AppendString(t.Format("2006-01-02T15:04:05.999Z0700"))
+	enc.AppendString(t.Format("2006-01-02T15:04:05.000Z0700"))
 }
 
 // UnmarshalText unmarshals text to a TimeEncoder. "iso8601" and "ISO8601" are

--- a/zapcore/encoder_test.go
+++ b/zapcore/encoder_test.go
@@ -403,17 +403,17 @@ func TestLevelEncoders(t *testing.T) {
 }
 
 func TestTimeEncoders(t *testing.T) {
-	moment := time.Unix(100, 5000500).UTC()
+	moment := time.Unix(100, 50005000).UTC()
 	tests := []struct {
 		name     string
 		expected interface{} // output of serializing moment
 	}{
-		{"iso8601", "1970-01-01T00:01:40.005Z"},
-		{"ISO8601", "1970-01-01T00:01:40.005Z"},
-		{"millis", 100005.0005},
-		{"nanos", int64(100005000500)},
-		{"", 100.0050005},
-		{"something-random", 100.0050005},
+		{"iso8601", "1970-01-01T00:01:40.050Z"},
+		{"ISO8601", "1970-01-01T00:01:40.050Z"},
+		{"millis", 100050.005},
+		{"nanos", int64(100050005000)},
+		{"", 100.050005},
+		{"something-random", 100.050005},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This is a minimal change of how the milliseconds part in iso8601 strings is formatted. Currently any trailing zeroes are removed, which produces different length time strings. Depending on tab size settings in terminal, this may results in level and message columns getting out of alignment (not observed in the example below, but happens in terminal if tab size is set to 4).
```
2017-03-09T17:47:10.499+0100	INFO	msg1
2017-03-09T17:47:10.5+0100	INFO	msg2
2017-03-09T17:47:10.501+0100	INFO	msg3
2017-03-09T17:47:10.51+0100	INFO	msg4
```
Keeping the trailing zeroes, preserves the alignment of log messages and makes it a bit easier on the eyes.
```
2017-03-09T17:47:10.499+0100	INFO	msg1
2017-03-09T17:47:10.500+0100	INFO	msg2
2017-03-09T17:47:10.501+0100	INFO	msg3
2017-03-09T17:47:10.510+0100	INFO	msg4
```

~~I'm not sure if such a change needs a test, but I'll write one if indeed required.~~ Updated existing test to check for trailing zeroes.

Before opening your pull request, please make sure that you've:

- [x] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [x] added tests to cover your changes;
- [x] run the test suite locally (`make test`); and finally,
- [x] run the linters locally (`make lint`).

Thanks for your contribution!
