### PR TITLE
Sort benchmarks in readme by time

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,38 +59,38 @@ Log a message and 10 fields:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 730 ns/op | 705 B/op | 2 allocs/op |
-| :zap: zap (sugared) | 1376 ns/op | 1613 B/op | 20 allocs/op |
-| go-kit | 3444 ns/op | 2897 B/op | 66 allocs/op |
-| lion | 5049 ns/op | 5811 B/op | 63 allocs/op |
-| logrus | 5815 ns/op | 6100 B/op | 78 allocs/op |
-| apex/log | 13184 ns/op | 3834 B/op | 65 allocs/op |
-| log15 | 16300 ns/op | 5632 B/op | 93 allocs/op |
+| :zap: zap | 670 ns/op | 705 B/op | 2 allocs/op |
+| :zap: zap (sugared) | 1378 ns/op | 1613 B/op | 20 allocs/op |
+| go-kit | 3824 ns/op | 2897 B/op | 66 allocs/op |
+| lion | 5220 ns/op | 5811 B/op | 63 allocs/op |
+| logrus | 5468 ns/op | 6100 B/op | 78 allocs/op |
+| apex/log | 13576 ns/op | 3834 B/op | 65 allocs/op |
+| log15 | 16969 ns/op | 5633 B/op | 93 allocs/op |
 
 Log a message with a logger that already has 10 fields of context:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 245 ns/op | 0 B/op | 0 allocs/op |
-| :zap: zap (sugared) | 319 ns/op | 80 B/op | 2 allocs/op |
-| lion | 3164 ns/op | 4076 B/op | 38 allocs/op |
-| go-kit | 3598 ns/op | 3048 B/op | 52 allocs/op |
-| logrus | 5465 ns/op | 4568 B/op | 63 allocs/op |
-| apex/log | 11403 ns/op | 2898 B/op | 51 allocs/op |
-| log15 | 11789 ns/op | 2642 B/op | 44 allocs/op |
+| :zap: zap | 247 ns/op | 0 B/op | 0 allocs/op |
+| :zap: zap (sugared) | 346 ns/op | 80 B/op | 2 allocs/op |
+| lion | 3361 ns/op | 4076 B/op | 38 allocs/op |
+| go-kit | 3853 ns/op | 3048 B/op | 52 allocs/op |
+| logrus | 5161 ns/op | 4568 B/op | 63 allocs/op |
+| apex/log | 11464 ns/op | 2898 B/op | 51 allocs/op |
+| log15 | 12148 ns/op | 2642 B/op | 44 allocs/op |
 
 Log a static string, without any context or `printf`-style templating:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 250 ns/op | 0 B/op | 0 allocs/op |
-| :zap: zap (sugared) | 325 ns/op | 80 B/op | 2 allocs/op |
-| standard library | 586 ns/op | 80 B/op | 2 allocs/op |
-| go-kit | 589 ns/op | 656 B/op | 13 allocs/op |
-| lion | 921 ns/op | 1225 B/op | 10 allocs/op |
-| logrus | 1506 ns/op | 1507 B/op | 27 allocs/op |
-| apex/log | 2452 ns/op | 584 B/op | 11 allocs/op |
-| log15 | 4797 ns/op | 1592 B/op | 26 allocs/op |
+| :zap: zap | 252 ns/op | 0 B/op | 0 allocs/op |
+| :zap: zap (sugared) | 386 ns/op | 80 B/op | 2 allocs/op |
+| standard library | 611 ns/op | 80 B/op | 2 allocs/op |
+| go-kit | 636 ns/op | 656 B/op | 13 allocs/op |
+| lion | 912 ns/op | 1225 B/op | 10 allocs/op |
+| logrus | 1707 ns/op | 1507 B/op | 27 allocs/op |
+| apex/log | 2459 ns/op | 584 B/op | 11 allocs/op |
+| log15 | 5087 ns/op | 1592 B/op | 26 allocs/op |
 
 ## Development Status: Release Candidate 3
 The current release is `v1.0.0-rc.3`. No further breaking changes are *planned*

--- a/README.md
+++ b/README.md
@@ -59,38 +59,38 @@ Log a message and 10 fields:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 1309 ns/op | 705 B/op | 2 allocs/op |
-| :zap: zap (sugared) | 2669 ns/op | 1931 B/op | 21 allocs/op |
-| logrus | 12689 ns/op | 5783 B/op | 77 allocs/op |
-| go-kit | 8191 ns/op | 3119 B/op | 65 allocs/op |
-| log15 | 25390 ns/op | 5536 B/op | 91 allocs/op |
-| apex/log | 20171 ns/op | 4025 B/op | 64 allocs/op |
-| lion | 11189 ns/op | 5999 B/op | 62 allocs/op |
+| :zap: zap | 730 ns/op | 705 B/op | 2 allocs/op |
+| :zap: zap (sugared) | 1376 ns/op | 1613 B/op | 20 allocs/op |
+| go-kit | 3444 ns/op | 2897 B/op | 66 allocs/op |
+| lion | 5049 ns/op | 5811 B/op | 63 allocs/op |
+| logrus | 5815 ns/op | 6100 B/op | 78 allocs/op |
+| apex/log | 13184 ns/op | 3834 B/op | 65 allocs/op |
+| log15 | 16300 ns/op | 5632 B/op | 93 allocs/op |
 
 Log a message with a logger that already has 10 fields of context:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 449 ns/op | 0 B/op | 0 allocs/op |
-| :zap: zap (sugared) | 675 ns/op | 80 B/op | 2 allocs/op |
-| logrus | 9984 ns/op | 3967 B/op | 61 allocs/op |
-| go-kit | 7760 ns/op | 2950 B/op | 50 allocs/op |
-| log15 | 17967 ns/op | 2546 B/op | 42 allocs/op |
-| apex/log | 17526 ns/op | 2801 B/op | 49 allocs/op |
-| lion | 6109 ns/op | 3978 B/op | 36 allocs/op |
+| :zap: zap | 245 ns/op | 0 B/op | 0 allocs/op |
+| :zap: zap (sugared) | 319 ns/op | 80 B/op | 2 allocs/op |
+| lion | 3164 ns/op | 4076 B/op | 38 allocs/op |
+| go-kit | 3598 ns/op | 3048 B/op | 52 allocs/op |
+| logrus | 5465 ns/op | 4568 B/op | 63 allocs/op |
+| apex/log | 11403 ns/op | 2898 B/op | 51 allocs/op |
+| log15 | 11789 ns/op | 2642 B/op | 44 allocs/op |
 
 Log a static string, without any context or `printf`-style templating:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 437 ns/op | 0 B/op | 0 allocs/op |
-| :zap: zap (sugared) | 570 ns/op | 80 B/op | 2 allocs/op |
-| standard library | 615 ns/op | 80 B/op | 2 allocs/op |
-| logrus | 2807 ns/op | 1409 B/op | 25 allocs/op |
-| go-kit | 1177 ns/op | 656 B/op | 13 allocs/op |
-| log15 | 6737 ns/op | 1496 B/op | 24 allocs/op |
-| apex/log | 3342 ns/op | 584 B/op | 11 allocs/op |
-| lion | 1933 ns/op | 1224 B/op | 10 allocs/op |
+| :zap: zap | 250 ns/op | 0 B/op | 0 allocs/op |
+| :zap: zap (sugared) | 325 ns/op | 80 B/op | 2 allocs/op |
+| standard library | 586 ns/op | 80 B/op | 2 allocs/op |
+| go-kit | 589 ns/op | 656 B/op | 13 allocs/op |
+| lion | 921 ns/op | 1225 B/op | 10 allocs/op |
+| logrus | 1506 ns/op | 1507 B/op | 27 allocs/op |
+| apex/log | 2452 ns/op | 584 B/op | 11 allocs/op |
+| log15 | 4797 ns/op | 1592 B/op | 26 allocs/op |
 
 ## Development Status: Release Candidate 3
 The current release is `v1.0.0-rc.3`. No further breaking changes are *planned*

--- a/internal/readme/readme.go
+++ b/internal/readme/readme.go
@@ -27,21 +27,14 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"sort"
+	"strconv"
 	"strings"
 	"text/template"
+	"time"
 )
 
 var (
-	libraryNames = []string{
-		"Zap",
-		"Zap.Sugar",
-		"stdlib.Println",
-		"sirupsen/logrus",
-		"go-kit/kit/log",
-		"inconshreveable/log15",
-		"apex/log",
-		"go.pedge.io/lion",
-	}
 	libraryNameToMarkdownName = map[string]string{
 		"Zap":                   ":zap: zap",
 		"Zap.Sugar":             ":zap: zap (sugared)",
@@ -86,6 +79,17 @@ type tmplData struct {
 	BenchmarkWithoutFields      string
 }
 
+type benchmarkRow struct {
+	Name             string
+	Time             time.Duration
+	AllocatedBytes   int
+	AllocatedObjects int
+}
+
+func (b *benchmarkRow) String() string {
+	return fmt.Sprintf("| %s | %d ns/op | %d B/op | %d allocs/op |", b.Name, b.Time.Nanoseconds(), b.AllocatedBytes, b.AllocatedObjects)
+}
+
 func getTmplData() (*tmplData, error) {
 	tmplData := &tmplData{}
 	rows, err := getBenchmarkRows("BenchmarkAddingFields")
@@ -111,42 +115,60 @@ func getBenchmarkRows(benchmarkName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	var benchmarkRows []*benchmarkRow
+	for libraryName := range libraryNameToMarkdownName {
+		benchmarkRow, err := getBenchmarkRow(benchmarkOutput, benchmarkName, libraryName)
+		if err != nil {
+			return "", err
+		}
+		if benchmarkRow == nil {
+			continue
+		}
+		benchmarkRows = append(benchmarkRows, benchmarkRow)
+	}
+	sort.Slice(benchmarkRows, func(i int, j int) bool {
+		return benchmarkRows[i].Time.Nanoseconds() < benchmarkRows[j].Time.Nanoseconds()
+	})
 	rows := []string{
 		"| Library | Time | Bytes Allocated | Objects Allocated |",
 		"| :--- | :---: | :---: | :---: |",
 	}
-	for _, libraryName := range libraryNames {
-		row, err := getBenchmarkRow(benchmarkOutput, benchmarkName, libraryName)
-		if err != nil {
-			return "", err
-		}
-		if row == "" {
-			continue
-		}
-		rows = append(rows, row)
+	for _, benchmarkRow := range benchmarkRows {
+		rows = append(rows, benchmarkRow.String())
 	}
 	return strings.Join(rows, "\n"), nil
 }
 
-func getBenchmarkRow(input []string, benchmarkName string, libraryName string) (string, error) {
+func getBenchmarkRow(input []string, benchmarkName string, libraryName string) (*benchmarkRow, error) {
 	line, err := findUniqueSubstring(input, fmt.Sprintf("%s/%s-", benchmarkName, libraryName))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if line == "" {
-		return "", nil
+		return nil, nil
 	}
 	split := strings.Split(line, "\t")
 	if len(split) < 5 {
-		return "", fmt.Errorf("unknown benchmark line: %s", line)
+		return nil, fmt.Errorf("unknown benchmark line: %s", line)
 	}
-	return fmt.Sprintf(
-		"| %s | %s | %s | %s |",
+	duration, err := time.ParseDuration(strings.Replace(strings.TrimSuffix(strings.TrimSpace(split[2]), "/op"), " ", "", -1))
+	if err != nil {
+		return nil, err
+	}
+	allocatedBytes, err := strconv.Atoi(strings.TrimSuffix(strings.TrimSpace(split[3]), " B/op"))
+	if err != nil {
+		return nil, err
+	}
+	allocatedObjects, err := strconv.Atoi(strings.TrimSuffix(strings.TrimSpace(split[4]), " allocs/op"))
+	if err != nil {
+		return nil, err
+	}
+	return &benchmarkRow{
 		libraryNameToMarkdownName[libraryName],
-		strings.TrimSpace(split[2]),
-		strings.TrimSpace(split[3]),
-		strings.TrimSpace(split[4]),
-	), nil
+		duration,
+		allocatedBytes,
+		allocatedObjects,
+	}, nil
 }
 
 func findUniqueSubstring(input []string, substring string) (string, error) {


### PR DESCRIPTION
This sorts the benchmarks in the readme by time. It also adds a `benchmarkRow` struct that is parsed from the benchmark output to add some semantic representation to a benchmark row, which will make it easier to do such things in the future and/or make this into a more general tool.
