### PR TITLE
Add APIs to support buffering

### DIFF
--- a/internal/observer/observer.go
+++ b/internal/observer/observer.go
@@ -124,6 +124,10 @@ func (o *observer) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 	return o.sink(LoggedEntry{ent, fields})
 }
 
+func (o *observer) Sync() error {
+	return nil
+}
+
 type contextObserver struct {
 	zapcore.LevelEnabler
 	sink    func(LoggedEntry) error
@@ -150,4 +154,8 @@ func (co *contextObserver) Write(ent zapcore.Entry, fields []zapcore.Field) erro
 	all = append(all, co.context...)
 	all = append(all, fields...)
 	return co.sink(LoggedEntry{ent, all})
+}
+
+func (co *contextObserver) Sync() error {
+	return nil
 }

--- a/logger.go
+++ b/logger.go
@@ -210,6 +210,11 @@ func (log *Logger) Fatal(msg string, fields ...zapcore.Field) {
 	}
 }
 
+// Sync flushes any buffered log entries.
+func (log *Logger) Sync() error {
+	return log.core.Sync()
+}
+
 // Core returns the underlying zapcore.Core.
 func (log *Logger) Core() zapcore.Core {
 	return log.core

--- a/logger_test.go
+++ b/logger_test.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -311,6 +312,26 @@ func TestLoggerWriteFailure(t *testing.T) {
 	// Should log the error.
 	assert.Regexp(t, `write error: failed`, errSink.Stripped(), "Expected to log the error to the error output.")
 	assert.True(t, errSink.Called(), "Expected logging an internal error to call Sync the error sink.")
+}
+
+func TestLoggerSync(t *testing.T) {
+	withLogger(t, DebugLevel, nil, func(logger *Logger, _ *observer.ObservedLogs) {
+		assert.NoError(t, logger.Sync(), "Expected syncing a test logger to succeed.")
+		assert.NoError(t, logger.Sugar().Sync(), "Expected syncing a sugared logger to succeed.")
+	})
+}
+
+func TestLoggerSyncFail(t *testing.T) {
+	noSync := &testutils.Buffer{}
+	err := errors.New("fail")
+	noSync.SetError(err)
+	logger := New(zapcore.NewCore(
+		zapcore.NewJSONEncoder(zapcore.EncoderConfig{}),
+		noSync,
+		DebugLevel,
+	))
+	assert.Equal(t, err, logger.Sync(), "Expected Logger.Sync to propagate errors.")
+	assert.Equal(t, err, logger.Sugar().Sync(), "Expected SugaredLogger.Sync to propagate errors.")
 }
 
 func TestLoggerAddCaller(t *testing.T) {

--- a/sugar.go
+++ b/sugar.go
@@ -200,6 +200,11 @@ func (s *SugaredLogger) Fatalw(msg string, keysAndValues ...interface{}) {
 	s.log(FatalLevel, msg, nil, keysAndValues)
 }
 
+// Sync flushes any buffered log entries.
+func (s *SugaredLogger) Sync() error {
+	return s.base.Sync()
+}
+
 func (s *SugaredLogger) log(lvl zapcore.Level, template string, fmtArgs []interface{}, context []interface{}) {
 	// If logging at this level is completely disabled, skip the overhead of
 	// string formatting.

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -139,10 +139,6 @@ type countingCore struct {
 	logs atomic.Uint32
 }
 
-func (c *countingCore) Enabled(Level) bool {
-	return true
-}
-
 func (c *countingCore) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
 	return ce.AddCore(ent, c)
 }
@@ -152,9 +148,9 @@ func (c *countingCore) Write(Entry, []Field) error {
 	return nil
 }
 
-func (c *countingCore) With([]Field) Core {
-	return c
-}
+func (c *countingCore) With([]Field) Core { return c }
+func (*countingCore) Enabled(Level) bool  { return true }
+func (*countingCore) Sync() error         { return nil }
 
 func TestSamplerConcurrent(t *testing.T) {
 	const (

--- a/zapcore/tee.go
+++ b/zapcore/tee.go
@@ -71,3 +71,11 @@ func (mc multiCore) Write(ent Entry, fields []Field) error {
 	}
 	return errs.AsError()
 }
+
+func (mc multiCore) Sync() error {
+	var errs multierror.Error
+	for i := range mc {
+		errs = errs.Append(mc[i].Sync())
+	}
+	return errs.AsError()
+}


### PR DESCRIPTION
This is a breaking change that adds a `Sync` method to `zapcore.Core`. The
intention here is to expose `Sync` all the way up to the loggers themselves;
this lets implementations buffer I/O, since the end user can `Sync` at the end
of main.

(Of course, nothing can save users if they directly panic or os.Exit from a
different goroutine.)

This fixes #355.