### PR TITLE
Remove unused globals

### DIFF
--- a/field_test.go
+++ b/field_test.go
@@ -22,7 +22,6 @@ package zap
 
 import (
 	"errors"
-	"math"
 	"net"
 	"sync"
 	"testing"
@@ -30,11 +29,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
-)
-
-var (
-	// Compiler complains about constants overflowing, so store this in a variable.
-	maxUint64 = uint64(math.MaxUint64)
 )
 
 type username string

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -32,12 +32,8 @@ import (
 	"go.uber.org/zap/internal/bufferpool"
 )
 
-const (
-	// For JSON-escaping; see jsonEncoder.safeAddString below.
-	_hex = "0123456789abcdef"
-	// Initial buffer size for encoders.
-	_initialBufSize = 1024
-)
+// For JSON-escaping; see jsonEncoder.safeAddString below.
+const _hex = "0123456789abcdef"
 
 var _jsonPool = sync.Pool{New: func() interface{} {
 	return &jsonEncoder{}


### PR DESCRIPTION
The `_bufSize` and `maxUint64` globals were unused, so this PR removes them.