### PR TITLE
Rename testutils to zaptest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export GO15VENDOREXPERIMENT=1
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 PKGS ?= $(shell glide novendor)
 # Many Go tools take file globs or directories as arguments instead of packages.
-PKG_FILES ?= *.go zapcore benchmarks buffer testutils internal/bufferpool internal/exit internal/multierror internal/observer internal/color
+PKG_FILES ?= *.go zapcore benchmarks buffer zaptest internal/bufferpool internal/exit internal/multierror internal/observer internal/color
 
 COVERALLS_IGNORE := internal/readme/readme.go
 

--- a/benchmarks/zap_test.go
+++ b/benchmarks/zap_test.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/testutils"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 )
 
 var (
@@ -73,7 +73,7 @@ func newZapLogger(lvl zapcore.Level) *zap.Logger {
 	enc := zapcore.NewJSONEncoder(cfg.EncoderConfig)
 	return zap.New(zapcore.NewCore(
 		enc,
-		&testutils.Discarder{},
+		&zaptest.Discarder{},
 		lvl,
 	))
 }

--- a/global_test.go
+++ b/global_test.go
@@ -27,8 +27,8 @@ import (
 	"time"
 
 	"go.uber.org/zap/internal/observer"
-	"go.uber.org/zap/testutils"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -87,7 +87,7 @@ func TestGlobalsConcurrentUse(t *testing.T) {
 		}()
 	}
 
-	testutils.Sleep(100 * time.Millisecond)
+	zaptest.Sleep(100 * time.Millisecond)
 	stop.Toggle()
 	wg.Wait()
 }

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/testutils"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 )
 
 type user struct {
@@ -52,7 +52,7 @@ func withBenchedLogger(b *testing.B, f func(*Logger)) {
 	logger := New(
 		zapcore.NewCore(
 			zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
-			&testutils.Discarder{},
+			&zaptest.Discarder{},
 			DebugLevel,
 		))
 	b.ResetTimer()
@@ -159,7 +159,7 @@ func BenchmarkAddCallerHook(b *testing.B) {
 	logger := New(
 		zapcore.NewCore(
 			zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
-			&testutils.Discarder{},
+			&zaptest.Discarder{},
 			InfoLevel,
 		),
 		AddCaller(),
@@ -193,7 +193,7 @@ func Benchmark100Fields(b *testing.B) {
 	const batchSize = 50
 	logger := New(zapcore.NewCore(
 		zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
-		&testutils.Discarder{},
+		&zaptest.Discarder{},
 		DebugLevel,
 	))
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -27,8 +27,8 @@ import (
 
 	"go.uber.org/zap/internal/exit"
 	"go.uber.org/zap/internal/observer"
-	"go.uber.org/zap/testutils"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -298,11 +298,11 @@ func TestLoggerNames(t *testing.T) {
 }
 
 func TestLoggerWriteFailure(t *testing.T) {
-	errSink := &testutils.Buffer{}
+	errSink := &zaptest.Buffer{}
 	logger := New(
 		zapcore.NewCore(
 			zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
-			zapcore.Lock(zapcore.AddSync(testutils.FailWriter{})),
+			zapcore.Lock(zapcore.AddSync(zaptest.FailWriter{})),
 			DebugLevel,
 		),
 		ErrorOutput(errSink),
@@ -322,7 +322,7 @@ func TestLoggerSync(t *testing.T) {
 }
 
 func TestLoggerSyncFail(t *testing.T) {
-	noSync := &testutils.Buffer{}
+	noSync := &zaptest.Buffer{}
 	err := errors.New("fail")
 	noSync.SetError(err)
 	logger := New(zapcore.NewCore(
@@ -362,7 +362,7 @@ func TestLoggerAddCaller(t *testing.T) {
 }
 
 func TestLoggerAddCallerFail(t *testing.T) {
-	errBuf := &testutils.Buffer{}
+	errBuf := &zaptest.Buffer{}
 	withLogger(t, DebugLevel, opts(AddCaller(), ErrorOutput(errBuf)), func(log *Logger, logs *observer.ObservedLogs) {
 		log.callerSkip = 1e3
 		log.Info("Failure.")

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -28,8 +28,8 @@ import (
 
 	"go.uber.org/zap/internal/exit"
 	"go.uber.org/zap/internal/observer"
-	"go.uber.org/zap/testutils"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestSugarWith(t *testing.T) {
@@ -356,7 +356,7 @@ func TestSugarAddCaller(t *testing.T) {
 }
 
 func TestSugarAddCallerFail(t *testing.T) {
-	errBuf := &testutils.Buffer{}
+	errBuf := &zaptest.Buffer{}
 	withSugar(t, DebugLevel, opts(AddCaller(), AddCallerSkip(1e3), ErrorOutput(errBuf)), func(log *SugaredLogger, logs *observer.ObservedLogs) {
 		log.Info("Failure.")
 		assert.Regexp(

--- a/zapcore/core_test.go
+++ b/zapcore/core_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/testutils"
 	. "go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,7 +106,7 @@ func TestIOCore(t *testing.T) {
 }
 
 func TestIOCoreSyncFail(t *testing.T) {
-	sink := &testutils.Discarder{}
+	sink := &zaptest.Discarder{}
 	err := errors.New("failed")
 	sink.SetError(err)
 
@@ -139,7 +139,7 @@ func TestIOCoreSyncsOutput(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		sink := &testutils.Discarder{}
+		sink := &zaptest.Discarder{}
 		core := NewCore(
 			NewJSONEncoder(testEncoderConfig()),
 			sink,
@@ -154,7 +154,7 @@ func TestIOCoreSyncsOutput(t *testing.T) {
 func TestIOCoreWriteFailure(t *testing.T) {
 	core := NewCore(
 		NewJSONEncoder(testEncoderConfig()),
-		Lock(&testutils.FailWriter{}),
+		Lock(&zaptest.FailWriter{}),
 		DebugLevel,
 	)
 	err := core.Write(Entry{}, nil)

--- a/zapcore/sampler_bench_test.go
+++ b/zapcore/sampler_bench_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/testutils"
 	. "go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 )
 
 var counterTestCases = [][]string{
@@ -206,7 +206,7 @@ func BenchmarkSampler_Check(b *testing.B) {
 			fac := NewSampler(
 				NewCore(
 					NewJSONEncoder(testEncoderConfig()),
-					&testutils.Discarder{},
+					&zaptest.Discarder{},
 					DebugLevel,
 				),
 				time.Millisecond, 1, 1000)

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -31,8 +31,8 @@ import (
 
 	"go.uber.org/atomic"
 	"go.uber.org/zap/internal/observer"
-	"go.uber.org/zap/testutils"
 	. "go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 )
 
 func fakeSampler(lvl LevelEnabler, tick time.Duration, first, thereafter int) (Core, *observer.ObservedLogs) {
@@ -106,7 +106,7 @@ func TestSamplerTicking(t *testing.T) {
 		for i := 1; i <= 5; i++ {
 			writeSequence(sampler, i, InfoLevel)
 		}
-		testutils.Sleep(15 * time.Millisecond)
+		zaptest.Sleep(15 * time.Millisecond)
 	}
 	assertSequence(
 		t,
@@ -122,7 +122,7 @@ func TestSamplerTicking(t *testing.T) {
 		for i := 1; i < 18; i++ {
 			writeSequence(sampler, i, InfoLevel)
 		}
-		testutils.Sleep(10 * time.Millisecond)
+		zaptest.Sleep(10 * time.Millisecond)
 	}
 
 	assertSequence(
@@ -161,7 +161,7 @@ func TestSamplerConcurrent(t *testing.T) {
 		expectedCount = numMessages * logsPerTick * numTicks
 	)
 
-	tick := testutils.Timeout(10 * time.Millisecond)
+	tick := zaptest.Timeout(10 * time.Millisecond)
 	cc := &countingCore{}
 	sampler := NewSampler(cc, tick, logsPerTick, 100000)
 

--- a/zapcore/tee_logger_bench_test.go
+++ b/zapcore/tee_logger_bench_test.go
@@ -23,14 +23,14 @@ package zapcore_test
 import (
 	"testing"
 
-	"go.uber.org/zap/testutils"
 	. "go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 )
 
 func withBenchedTee(b *testing.B, f func(Core)) {
 	fac := NewTee(
-		NewCore(NewJSONEncoder(testEncoderConfig()), &testutils.Discarder{}, DebugLevel),
-		NewCore(NewJSONEncoder(testEncoderConfig()), &testutils.Discarder{}, InfoLevel),
+		NewCore(NewJSONEncoder(testEncoderConfig()), &zaptest.Discarder{}, DebugLevel),
+		NewCore(NewJSONEncoder(testEncoderConfig()), &zaptest.Discarder{}, InfoLevel),
 	)
 	b.ResetTimer()
 	f(fac)

--- a/zapcore/tee_test.go
+++ b/zapcore/tee_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 
 	"go.uber.org/zap/internal/observer"
-	"go.uber.org/zap/testutils"
 	. "go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -143,7 +143,7 @@ func TestTeeSync(t *testing.T) {
 	)
 	assert.NoError(t, tee.Sync(), "Unexpected error from Syncing a tee.")
 
-	sink := &testutils.Discarder{}
+	sink := &zaptest.Discarder{}
 	err := errors.New("failed")
 	sink.SetError(err)
 

--- a/zapcore/write_syncer_bench_test.go
+++ b/zapcore/write_syncer_bench_test.go
@@ -23,14 +23,14 @@ package zapcore
 import (
 	"testing"
 
-	"go.uber.org/zap/testutils"
+	"go.uber.org/zap/zaptest"
 )
 
 func BenchmarkMultiWriteSyncer(b *testing.B) {
 	b.Run("2", func(b *testing.B) {
 		w := NewMultiWriteSyncer(
-			&testutils.Discarder{},
-			&testutils.Discarder{},
+			&zaptest.Discarder{},
+			&zaptest.Discarder{},
 		)
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
@@ -41,10 +41,10 @@ func BenchmarkMultiWriteSyncer(b *testing.B) {
 	})
 	b.Run("4", func(b *testing.B) {
 		w := NewMultiWriteSyncer(
-			&testutils.Discarder{},
-			&testutils.Discarder{},
-			&testutils.Discarder{},
-			&testutils.Discarder{},
+			&zaptest.Discarder{},
+			&zaptest.Discarder{},
+			&zaptest.Discarder{},
+			&zaptest.Discarder{},
 		)
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {

--- a/zapcore/write_syncer_test.go
+++ b/zapcore/write_syncer_test.go
@@ -29,12 +29,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/testutils"
+	"go.uber.org/zap/zaptest"
 )
 
 type writeSyncSpy struct {
 	io.Writer
-	testutils.Syncer
+	zaptest.Syncer
 }
 
 func requireWriteWorks(t testing.TB, ws WriteSyncer) {
@@ -66,7 +66,7 @@ func TestAddSyncWriter(t *testing.T) {
 }
 
 func TestNewMultiWriteSyncerWorksForSingleWriter(t *testing.T) {
-	w := &testutils.Buffer{}
+	w := &zaptest.Buffer{}
 
 	ws := NewMultiWriteSyncer(w)
 	assert.Equal(t, w, ws, "Expected NewMultiWriteSyncer to return the same WriteSyncer object for a single argument.")
@@ -90,20 +90,20 @@ func TestMultiWriteSyncerWritesBoth(t *testing.T) {
 }
 
 func TestMultiWriteSyncerFailsWrite(t *testing.T) {
-	ws := NewMultiWriteSyncer(AddSync(&testutils.FailWriter{}))
+	ws := NewMultiWriteSyncer(AddSync(&zaptest.FailWriter{}))
 	_, err := ws.Write([]byte("test"))
 	assert.Error(t, err, "Write error should propagate")
 }
 
 func TestMultiWriteSyncerFailsShortWrite(t *testing.T) {
-	ws := NewMultiWriteSyncer(AddSync(&testutils.ShortWriter{}))
+	ws := NewMultiWriteSyncer(AddSync(&zaptest.ShortWriter{}))
 	n, err := ws.Write([]byte("test"))
 	assert.NoError(t, err, "Expected fake-success from short write")
 	assert.Equal(t, 3, n, "Expected byte count to return from underlying writer")
 }
 
 func TestWritestoAllSyncs_EvenIfFirstErrors(t *testing.T) {
-	failer := &testutils.FailWriter{}
+	failer := &zaptest.FailWriter{}
 	second := &bytes.Buffer{}
 	ws := NewMultiWriteSyncer(AddSync(failer), AddSync(second))
 
@@ -113,20 +113,20 @@ func TestWritestoAllSyncs_EvenIfFirstErrors(t *testing.T) {
 }
 
 func TestMultiWriteSyncerSync_PropagatesErrors(t *testing.T) {
-	badsink := &testutils.Buffer{}
+	badsink := &zaptest.Buffer{}
 	badsink.SetError(errors.New("sink is full"))
-	ws := NewMultiWriteSyncer(&testutils.Discarder{}, badsink)
+	ws := NewMultiWriteSyncer(&zaptest.Discarder{}, badsink)
 
 	assert.Error(t, ws.Sync(), "Expected sync error to propagate")
 }
 
 func TestMultiWriteSyncerSync_NoErrorsOnDiscard(t *testing.T) {
-	ws := NewMultiWriteSyncer(&testutils.Discarder{})
+	ws := NewMultiWriteSyncer(&zaptest.Discarder{})
 	assert.NoError(t, ws.Sync(), "Expected error-free sync to /dev/null")
 }
 
 func TestMultiWriteSyncerSync_AllCalled(t *testing.T) {
-	failed, second := &testutils.Buffer{}, &testutils.Buffer{}
+	failed, second := &zaptest.Buffer{}, &zaptest.Buffer{}
 
 	failed.SetError(errors.New("disposal broken"))
 	ws := NewMultiWriteSyncer(failed, second)

--- a/zaptest/timeout.go
+++ b/zaptest/timeout.go
@@ -18,9 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package testutils provides some simple testing helpers (most of which aren't
-// specifically logging-related).
-package testutils
+// Package zaptest provides helpers for testing logs.
+package zaptest
 
 import (
 	"log"

--- a/zaptest/writer.go
+++ b/zaptest/writer.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package testutils
+package zaptest
 
 import (
 	"bytes"


### PR DESCRIPTION
The `testutils` package name is too generic, and frequently conflicts with application-level testing helpers. We should instead follow the example of the standard lib's `httptest`.