### PR TITLE
Fix frame skip for standard library

### DIFF
--- a/global.go
+++ b/global.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	_stdLogDefaultDepth = 4
+	_stdLogDefaultDepth = 2
 	_loggerWriterDepth  = 1
 )
 

--- a/global_test.go
+++ b/global_test.go
@@ -101,7 +101,12 @@ func TestNewStdLog(t *testing.T) {
 		entry := logs.AllUntimed()[0]
 		assert.Equal(t, []zapcore.Field{}, entry.Context, "Unexpected entry context.")
 		assert.Equal(t, "redirected", entry.Entry.Message, "Unexpected entry message.")
-		assert.Contains(t, entry.Entry.Caller.File, "global_test.go", "Unexpected caller annotation.")
+		assert.Regexp(
+			t,
+			`go.uber.org/zap/global_test.go:\d+$`,
+			entry.Entry.Caller.String(),
+			"Unexpected caller annotation.",
+		)
 	})
 }
 


### PR DESCRIPTION
it should be same with `log.Output` calldepth.

The [test case](https://github.com/uber-go/zap/blob/master/global_test.go#L104) covers wrong position -

```
go.uber.org/zap.(*Logger).check(0xc42038eb40, 0x0, 0xc4204ec330, 0xa, 0xc4204ec330)
	/home/flisky/.gvm/pkgsets/go1.8/global/src/go.uber.org/zap/logger.go:269 +0x62f
go.uber.org/zap.(*Logger).Info(0xc42038eb40, 0xc4204ec330, 0xa, 0x0, 0x0, 0x0)
	/home/flisky/.gvm/pkgsets/go1.8/global/src/go.uber.org/zap/logger.go:160 +0x44
go.uber.org/zap.(*loggerWriter).Write(0xc42049e3a0, 0xc4204ec300, 0xa, 0x10, 0xa, 0xc4204ec300, 0x0)
	/home/flisky/.gvm/pkgsets/go1.8/global/src/go.uber.org/zap/global.go:112 +0xbd
log.(*Logger).Output(0xc42028b360, 0x2, 0xc4204ec2f0, 0xa, 0x0, 0x0)
	/home/flisky/.gvm/gos/go1.8/src/log/log.go:168 +0x210
log.(*Logger).Print(0xc42028b360, 0xc42012ee10, 0x1, 0x1)
	/home/flisky/.gvm/gos/go1.8/src/log/log.go:180 +0x6a
go.uber.org/zap.TestNewStdLog.func1(0xc42038eae0, 0xc42010a000)
	/home/flisky/.gvm/pkgsets/go1.8/global/src/go.uber.org/zap/global_test.go:98 +0xed
go.uber.org/zap.withLogger(0x944060, 0xc420060000, 0x93d9a0, 0xc4204ec295, 0xc420203f88, 0x1, 0x1, 0xc420203f78)
	/home/flisky/.gvm/pkgsets/go1.8/global/src/go.uber.org/zap/common_test.go:41 +0x12b
go.uber.org/zap.TestNewStdLog(0xc420060000)
	/home/flisky/.gvm/pkgsets/go1.8/global/src/go.uber.org/zap/global_test.go:105 +0xdd
testing.tRunner(0xc420060000, 0x7baf58)
	/home/flisky/.gvm/gos/go1.8/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
	/home/flisky/.gvm/gos/go1.8/src/testing/testing.go:697 +0x2ca
```

The old value 4 goes to 
```
go.uber.org/zap.TestNewStdLog(0xc420060000)
	/home/flisky/.gvm/pkgsets/go1.8/global/src/go.uber.org/zap/global_test.go:105 +0xdd
```

And the new one 2 goes to
```
go.uber.org/zap.TestNewStdLog.func1(0xc42038eae0, 0xc42010a000)
	/home/flisky/.gvm/pkgsets/go1.8/global/src/go.uber.org/zap/global_test.go:98 +0xed
```