### PR TITLE
Disable testing on tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 go:
   - 1.7
   - 1.8
-  - tip
 go_import_path: go.uber.org/zap
 env:
   global:


### PR DESCRIPTION
Since we're in the "merge all the things" phase of the Go 1.9 development cycle,
we're running into some compiler errors on tip. Rather than having portions of
the build fail, let's stop testing on tip until we have 1.9 release candidates.