### PR TITLE
Make caller path trimming Windows-compatible

### DIFF
--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -22,7 +22,6 @@ package zapcore
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -102,13 +101,25 @@ func (ec EntryCaller) TrimmedPath() string {
 	if !ec.Defined {
 		return "undefined"
 	}
+	// nb. To make sure we trim the path correctly on Windows too, we
+	// counter-intuitively need to use '/' and *not* os.PathSeparator here,
+	// because the path given originates from Go stdlib, specifically
+	// runtime.Caller() which (as of Mar/17) returns forward slashes even on
+	// Windows.
+	//
+	// See https://github.com/golang/go/issues/3335
+	// and https://github.com/golang/go/issues/18151
+	//
+	// for discussion on the issue on Go side.
+	//
 	// Find the last separator.
-	idx := strings.LastIndexByte(ec.File, os.PathSeparator)
+	//
+	idx := strings.LastIndexByte(ec.File, '/')
 	if idx == -1 {
 		return ec.FullPath()
 	}
 	// Find the penultimate separator.
-	idx = strings.LastIndexByte(ec.File[:idx], os.PathSeparator)
+	idx = strings.LastIndexByte(ec.File[:idx], '/')
 	if idx == -1 {
 		return ec.FullPath()
 	}


### PR DESCRIPTION
Go stdlib runtime.Caller() currently returns forward slashes on Windows (see golang/go#3335) which causes EntryCaller.TrimmedPath() to return full paths instead of the expected trimmed paths on Windows. This is because EntryCaller.TrimmedPath() uses os.PathSeparator to trim the path which is '\' on Windows. According to the discussion on the Go bug, it seems like os.PathSeparator might be '' in some cases on Unix too so might cause issues on non-Windows platforms too.

This PR replaces the two occurrences of os.PathSeparator with ''/' as that is what runtime.Caller() currently produces on all platforms.

Did not add tests, as the existing tests for TrimmedPath() failed on Windows with master and work with this PR. 

(TestOpen still fails on Windows but doesn't look like it's caused by this; Windows is returning errors in a different format than the test expects.)

make lint (ran from msys2 bash) fails (every single diff fails on every single line even though they look identical; maybe a newline issue?) but golint on entry.go is succesful.

Fixes: #382
See also: golang/go#18151

Before opening your pull request, please make sure that you've:

- [X] [signed Uber's Contributor License Agreement](https://docs.google.com/a/uber.com/forms/d/1pAwS_-dA1KhPlfxzYLBqK6rsSWwRwH95OCCZrcsY5rk/viewform);
- [ ] added tests to cover your changes;
- [X] run the test suite locally (`make test`); and finally,
- [ ] run the linters locally (`make lint`).

Thanks for your contribution!
