### PR TITLE
zaptest/observer: Support filtering by message or field

### DIFF
--- a/zaptest/observer/observer.go
+++ b/zaptest/observer/observer.go
@@ -91,10 +91,9 @@ func (o *ObservedLogs) FilterMessage(msg string) *ObservedLogs {
 func (o *ObservedLogs) FilterField(field zapcore.Field) *ObservedLogs {
 	return o.filter(func(e LoggedEntry) bool {
 		for _, ctxField := range e.Context {
-			if ctxField.Key != field.Key {
-				continue
+			if ctxField == field {
+				return true
 			}
-			return ctxField == field
 		}
 		return false
 	})

--- a/zaptest/observer/observer_test.go
+++ b/zaptest/observer/observer_test.go
@@ -133,6 +133,10 @@ func TestFilters(t *testing.T) {
 			Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "log b"},
 			Context: []zapcore.Field{zap.Int("a", 1), zap.Int("b", 2)},
 		},
+		{
+			Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "log c"},
+			Context: []zapcore.Field{zap.Int("a", 1), zap.Namespace("ns"), zap.Int("a", 2)},
+		},
 	}
 
 	logger, sink := New(zap.InfoLevel)
@@ -159,6 +163,11 @@ func TestFilters(t *testing.T) {
 			msg:      "filter by message and field",
 			filtered: sink.FilterMessage("log a").FilterField(zap.Int("b", 2)),
 			want:     logs[1:2],
+		},
+		{
+			msg:      "filter by field with duplicate fields",
+			filtered: sink.FilterField(zap.Int("a", 2)),
+			want:     logs[3:4],
 		},
 		{
 			msg:      "filter doesn't match any messages",


### PR DESCRIPTION
Add `Filter*` functions to filter a set of ObservedLogs and return
a new set of ObservedLogs. This allows chaining of multiple filters
such as `sink.FilterMessage(..).FilterField(..)` for easier use in
tests.

Fixes #383