### PR TITLE
README: Note lack of support for old Go versions

### DIFF
--- a/.readme.tmpl
+++ b/.readme.tmpl
@@ -6,6 +6,8 @@ Blazing fast, structured, leveled logging in Go.
 
 `go get -u go.uber.org/zap`
 
+Note that zap only supports the two most recent minor versions of Go.
+
 ## Quick Start
 
 In contexts where performance is nice, but not critical, use the

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Blazing fast, structured, leveled logging in Go.
 
 `go get -u go.uber.org/zap`
 
+Note that zap only supports the two most recent minor versions of Go.
+
 ## Quick Start
 
 In contexts where performance is nice, but not critical, use the
@@ -59,38 +61,38 @@ Log a message and 10 fields:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 1466 ns/op | 705 B/op | 2 allocs/op |
-| :zap: zap (sugared) | 2893 ns/op | 1931 B/op | 21 allocs/op |
-| go-kit | 8183 ns/op | 3119 B/op | 65 allocs/op |
-| lion | 12259 ns/op | 5999 B/op | 62 allocs/op |
-| logrus | 12862 ns/op | 5783 B/op | 77 allocs/op |
-| apex/log | 20317 ns/op | 4024 B/op | 64 allocs/op |
-| log15 | 31855 ns/op | 5536 B/op | 91 allocs/op |
+| :zap: zap | 1758 ns/op | 705 B/op | 2 allocs/op |
+| :zap: zap (sugared) | 3301 ns/op | 1610 B/op | 20 allocs/op |
+| go-kit | 8923 ns/op | 2895 B/op | 66 allocs/op |
+| lion | 10449 ns/op | 5807 B/op | 63 allocs/op |
+| logrus | 14566 ns/op | 6092 B/op | 78 allocs/op |
+| apex/log | 21129 ns/op | 3833 B/op | 65 allocs/op |
+| log15 | 24687 ns/op | 5632 B/op | 93 allocs/op |
 
 Log a message with a logger that already has 10 fields of context:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 536 ns/op | 0 B/op | 0 allocs/op |
-| :zap: zap (sugared) | 734 ns/op | 80 B/op | 2 allocs/op |
-| lion | 6784 ns/op | 3978 B/op | 36 allocs/op |
-| go-kit | 8316 ns/op | 2950 B/op | 50 allocs/op |
-| logrus | 10160 ns/op | 3967 B/op | 61 allocs/op |
-| apex/log | 17095 ns/op | 2801 B/op | 49 allocs/op |
-| log15 | 19112 ns/op | 2545 B/op | 42 allocs/op |
+| :zap: zap | 519 ns/op | 0 B/op | 0 allocs/op |
+| :zap: zap (sugared) | 690 ns/op | 80 B/op | 2 allocs/op |
+| lion | 6012 ns/op | 4074 B/op | 38 allocs/op |
+| go-kit | 7777 ns/op | 3046 B/op | 52 allocs/op |
+| logrus | 9013 ns/op | 4564 B/op | 63 allocs/op |
+| apex/log | 15824 ns/op | 2897 B/op | 51 allocs/op |
+| log15 | 16194 ns/op | 2642 B/op | 44 allocs/op |
 
 Log a static string, without any context or `printf`-style templating:
 
 | Library | Time | Bytes Allocated | Objects Allocated |
 | :--- | :---: | :---: | :---: |
-| :zap: zap | 521 ns/op | 0 B/op | 0 allocs/op |
-| standard library | 580 ns/op | 80 B/op | 2 allocs/op |
-| :zap: zap (sugared) | 885 ns/op | 80 B/op | 2 allocs/op |
-| go-kit | 1384 ns/op | 656 B/op | 13 allocs/op |
-| lion | 2009 ns/op | 1224 B/op | 10 allocs/op |
-| logrus | 2925 ns/op | 1409 B/op | 25 allocs/op |
-| apex/log | 3723 ns/op | 584 B/op | 11 allocs/op |
-| log15 | 6349 ns/op | 1496 B/op | 24 allocs/op |
+| :zap: zap | 594 ns/op | 0 B/op | 0 allocs/op |
+| standard library | 633 ns/op | 80 B/op | 2 allocs/op |
+| :zap: zap (sugared) | 702 ns/op | 80 B/op | 2 allocs/op |
+| go-kit | 1004 ns/op | 656 B/op | 13 allocs/op |
+| lion | 1543 ns/op | 1224 B/op | 10 allocs/op |
+| logrus | 2476 ns/op | 1505 B/op | 27 allocs/op |
+| apex/log | 3311 ns/op | 584 B/op | 11 allocs/op |
+| log15 | 6159 ns/op | 1592 B/op | 26 allocs/op |
 
 ## Development Status: Stable
 All APIs are finalized, and no breaking changes will be made in the 1.x series


### PR DESCRIPTION
Given the Go 1.x compatibility guarantee, there's no reason for zap to support
old Go compilers indefinitely. Add a note to the README that we only support the
two most recent minor Go versions.

This was brought up in #389.