### PR TITLE
Don't panic when invalid paths are configured

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -93,7 +93,7 @@ func TestConfigWithInvalidPaths(t *testing.T) {
 	}{
 		{"output directory doesn't exist", "/tmp/not-there/foo.log", "stderr"},
 		{"error output directory doesn't exist", "stdout", "/tmp/not-there/foo-errors.log"},
-		{"both output directories don't exist", "/tmp/not-there/foo.log", "/tmp/not-there/foo-errors.log"},
+		{"neither output directory exists", "/tmp/not-there/foo.log", "/tmp/not-there/foo-errors.log"},
 	}
 
 	for _, tt := range tests {

--- a/config_test.go
+++ b/config_test.go
@@ -84,3 +84,25 @@ func TestConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigWithInvalidPaths(t *testing.T) {
+	tests := []struct {
+		desc      string
+		output    string
+		errOutput string
+	}{
+		{"output directory doesn't exist", "/tmp/not-there/foo.log", "stderr"},
+		{"error output directory doesn't exist", "stdout", "/tmp/not-there/foo-errors.log"},
+		{"both output directories don't exist", "/tmp/not-there/foo.log", "/tmp/not-there/foo-errors.log"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			cfg := NewProductionConfig()
+			cfg.OutputPaths = []string{tt.output}
+			cfg.ErrorOutputPaths = []string{tt.errOutput}
+			_, err := cfg.Build()
+			assert.Error(t, err, "Expected an error opening a non-existent directory.")
+		})
+	}
+}

--- a/writer.go
+++ b/writer.go
@@ -38,7 +38,7 @@ import (
 func Open(paths ...string) (zapcore.WriteSyncer, func(), error) {
 	writers, close, err := open(paths)
 	if err != nil {
-		return nil, nil, err
+		return nil, close, err
 	}
 
 	writer := CombineWriteSyncers(writers...)


### PR DESCRIPTION
If the config struct includes invalid output paths, make sure that we don't try
to execute a nil function pointer.

Fixes #390.