### PR TITLE
Add zapgrpc package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export GO15VENDOREXPERIMENT=1
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 PKGS ?= $(shell glide novendor)
 # Many Go tools take file globs or directories as arguments instead of packages.
-PKG_FILES ?= *.go zapcore benchmarks buffer zaptest zaptest/observer internal/bufferpool internal/exit internal/multierror internal/color
+PKG_FILES ?= *.go zapcore benchmarks buffer zapgrpc zaptest zaptest/observer internal/bufferpool internal/exit internal/multierror internal/color
 
 COVERALLS_IGNORE := internal/readme/readme.go
 

--- a/zapgrpc/zapgrpc.go
+++ b/zapgrpc/zapgrpc.go
@@ -35,8 +35,6 @@ func WithDebug() LoggerOption {
 }
 
 // NewLogger returns a new Logger.
-//
-// Print statements will log at the Info level.
 func NewLogger(l *zap.Logger, options ...LoggerOption) *Logger {
 	loggerOptions := newLoggerOptions(options...)
 	return &Logger{

--- a/zapgrpc/zapgrpc.go
+++ b/zapgrpc/zapgrpc.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package zapgrpc provides a logger that is compatible with grpclog.
+package zapgrpc // import "go.uber.org/zap/zapgrpc"
+
+import "go.uber.org/zap"
+
+// Logger mimics grpclog's Logger interface.
+type Logger interface {
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Fatalln(args ...interface{})
+	Print(args ...interface{})
+	Printf(format string, args ...interface{})
+	Println(args ...interface{})
+}
+
+// NewLogger returns a new Logger that wraps the given *zap.Logger.
+//
+// Print statements will log at the Info level.
+func NewLogger(l *zap.Logger) Logger {
+	return &logger{l.Sugar()}
+}
+
+type logger struct {
+	*zap.SugaredLogger
+}
+
+func (l *logger) Fatalln(args ...interface{}) {
+	l.SugaredLogger.Fatal(args...)
+}
+
+func (l *logger) Print(args ...interface{}) {
+	l.SugaredLogger.Info(args...)
+}
+
+func (l *logger) Printf(format string, args ...interface{}) {
+	l.SugaredLogger.Infof(format, args...)
+}
+
+func (l *logger) Println(args ...interface{}) {
+	l.SugaredLogger.Info(args...)
+}

--- a/zapgrpc/zapgrpc_test.go
+++ b/zapgrpc/zapgrpc_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package zapgrpc
 
 import (

--- a/zapgrpc/zapgrpc_test.go
+++ b/zapgrpc/zapgrpc_test.go
@@ -1,0 +1,96 @@
+package zapgrpc
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggerInfoExpected(t *testing.T) {
+	checkMessages(t, zapcore.DebugLevel, nil, zapcore.InfoLevel, []string{
+		"hello",
+		"world",
+		"foo",
+	}, func(logger *Logger) {
+		logger.Print("hello")
+		logger.Printf("world")
+		logger.Println("foo")
+	})
+}
+
+func TestLoggerDebugExpected(t *testing.T) {
+	checkMessages(t, zapcore.DebugLevel, []LoggerOption{WithDebug()}, zapcore.DebugLevel, []string{
+		"hello",
+		"world",
+		"foo",
+	}, func(logger *Logger) {
+		logger.Print("hello")
+		logger.Printf("world")
+		logger.Println("foo")
+	})
+}
+
+func TestLoggerDebugSuppressed(t *testing.T) {
+	checkMessages(t, zapcore.InfoLevel, []LoggerOption{WithDebug()}, zapcore.DebugLevel, nil, func(logger *Logger) {
+		logger.Print("hello")
+		logger.Printf("world")
+		logger.Println("foo")
+	})
+}
+
+func TestLoggerFatalExpected(t *testing.T) {
+	checkMessages(t, zapcore.DebugLevel, nil, zapcore.FatalLevel, []string{
+		"hello",
+		"world",
+		"foo",
+	}, func(logger *Logger) {
+		logger.Fatal("hello")
+		logger.Fatalf("world")
+		logger.Fatalln("foo")
+	})
+}
+
+func checkMessages(
+	t testing.TB,
+	levelEnabler zapcore.LevelEnabler,
+	loggerOptions []LoggerOption,
+	expectedLevel zapcore.Level,
+	expectedMessages []string,
+	f func(*Logger),
+) {
+	if expectedLevel == zapcore.FatalLevel {
+		expectedLevel = zapcore.WarnLevel
+	}
+	withLogger(levelEnabler, loggerOptions, func(logger *Logger, observedLogs *observer.ObservedLogs) {
+		f(logger)
+		logEntries := observedLogs.All()
+		require.Equal(t, len(expectedMessages), len(logEntries))
+		for i, logEntry := range logEntries {
+			require.Equal(t, expectedLevel, logEntry.Level)
+			require.Equal(t, expectedMessages[i], logEntry.Message)
+		}
+	})
+}
+
+func withLogger(
+	levelEnabler zapcore.LevelEnabler,
+	loggerOptions []LoggerOption,
+	f func(*Logger, *observer.ObservedLogs),
+) {
+	core, observedLogs := observer.New(levelEnabler)
+	f(NewLogger(zap.New(core), append(loggerOptions, withWarn())...), observedLogs)
+}
+
+// withWarn redirects the fatal level to the warn level.
+//
+// This is used for testing.
+func withWarn() LoggerOption {
+	return func(logger *Logger) {
+		logger.fatalFunc = (*zap.SugaredLogger).Warn
+		logger.fatalfFunc = (*zap.SugaredLogger).Warnf
+	}
+}


### PR DESCRIPTION
I'm not sure if we want this, so feel free to close this otherwise, but I was adding it in https://github.com/yarpc/yarpc-go/pull/863 and thought it might make more sense here.

https://github.com/grpc/grpc-go has a global internal logger it uses, and https://github.com/grpc/grpc-go/tree/master/grpclog defines what logger is used. If a logger is not set, the default golang logger is used, which could mean lost logs for applications that use zap and grpc. This package defines a simple wrapper for a `*zap.Logger` that is compatible with `grpclog.Logger`. To use it, one would do:

```go
grpclog.SetLogger(zapgrpc.NewLogger(zap.L())
```