### PR TITLE
Add MarshalText to AtomicLevel and FilterMessageSnippet to observer

### DIFF
--- a/level.go
+++ b/level.go
@@ -21,9 +21,13 @@
 package zap
 
 import (
+	"errors"
+
 	"go.uber.org/atomic"
 	"go.uber.org/zap/zapcore"
 )
+
+var errMarshalNilLevel = errors.New("can't marshal a nil *AtomicLevel to text")
 
 const (
 	// DebugLevel logs are typically voluminous, and are usually disabled in
@@ -105,4 +109,16 @@ func (lvl *AtomicLevel) UnmarshalText(text []byte) error {
 
 	lvl.SetLevel(l)
 	return nil
+}
+
+// MarshalText marshals the AtomicLevel to a byte slice. It uses the same
+// text representation as the static zapcore.Levels ("debug", "info", "warn",
+// "error", "dpanic", "panic", and "fatal").
+func (lvl *AtomicLevel) MarshalText() (text []byte, err error) {
+	if lvl == nil {
+		return nil, errMarshalNilLevel
+	}
+
+	l := lvl.Level()
+	return l.MarshalText()
 }

--- a/level_test.go
+++ b/level_test.go
@@ -73,7 +73,7 @@ func TestAtomicLevelMutation(t *testing.T) {
 	wg.Wait()
 }
 
-func TestAtomicLevelUnmarshalText(t *testing.T) {
+func TestAtomicLevelText(t *testing.T) {
 	tests := []struct {
 		text   string
 		expect zapcore.Level
@@ -101,6 +101,14 @@ func TestAtomicLevelUnmarshalText(t *testing.T) {
 			}
 			assert.Equal(t, tt.expect, lvl.Level(), "Unexpected level after unmarshaling.")
 			lvl.SetLevel(InfoLevel)
+		}
+
+		// Test marshalling
+		if tt.text != "" && !tt.err {
+			lvl.SetLevel(tt.expect)
+			marshaled, err := lvl.MarshalText()
+			assert.NoError(t, err, `Unexpected error marshalling level "%v" to text.`, tt.expect)
+			assert.Equal(t, tt.text, string(marshaled), "Expected marshaled text to match")
 		}
 	}
 }

--- a/zaptest/observer/observer.go
+++ b/zaptest/observer/observer.go
@@ -21,6 +21,7 @@
 package observer
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -84,6 +85,13 @@ func (o *ObservedLogs) AllUntimed() []LoggedEntry {
 func (o *ObservedLogs) FilterMessage(msg string) *ObservedLogs {
 	return o.filter(func(e LoggedEntry) bool {
 		return e.Message == msg
+	})
+}
+
+// FilterMessageSnippet filters entries to those that have a message containing the specified snippet.
+func (o *ObservedLogs) FilterMessageSnippet(snippet string) *ObservedLogs {
+	return o.filter(func(e LoggedEntry) bool {
+		return strings.Contains(e.Message, snippet)
 	})
 }
 

--- a/zaptest/observer/observer_test.go
+++ b/zaptest/observer/observer_test.go
@@ -137,6 +137,10 @@ func TestFilters(t *testing.T) {
 			Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "log c"},
 			Context: []zapcore.Field{zap.Int("a", 1), zap.Namespace("ns"), zap.Int("a", 2)},
 		},
+		{
+			Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "msg 1"},
+			Context: []zapcore.Field{zap.Int("a", 1), zap.Namespace("ns")},
+		},
 	}
 
 	logger, sink := New(zap.InfoLevel)
@@ -173,6 +177,16 @@ func TestFilters(t *testing.T) {
 			msg:      "filter doesn't match any messages",
 			filtered: sink.FilterMessage("no match"),
 			want:     []LoggedEntry{},
+		},
+		{
+			msg:      "filter by snippet",
+			filtered: sink.FilterMessageSnippet("log"),
+			want:     logs[0:4],
+		},
+		{
+			msg:      "filter by snippet and field",
+			filtered: sink.FilterMessageSnippet("a").FilterField(zap.Int("b", 2)),
+			want:     logs[1:2],
 		},
 	}
 


### PR DESCRIPTION
My team displays its yaml configs on HTML debug pages and thus requires that AtomicLevel support marshalling.

Additionally, we are currently transitioning from logrus style format logging to zap.SugaredLogger and use a testing strategy where we assert that a log message contains some list of snippets, rather than asserting on the entire formatted log message. This seems generally useful for users of the SugaredLogger.