### PR TITLE
zapcore.Level: Move MarshalText to value receiver

### DIFF
--- a/zapcore/level.go
+++ b/zapcore/level.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 )
 
-var errMarshalNilLevel = errors.New("can't marshal a nil *Level to text")
+var errUnmarshalNilLevel = errors.New("can't unmarshal a nil *Level")
 
 // A Level is a logging priority. Higher levels are more important.
 type Level int8
@@ -102,10 +102,7 @@ func (l Level) CapitalString() string {
 
 // MarshalText marshals the Level to text. Note that the text representation
 // drops the -Level suffix (see example).
-func (l *Level) MarshalText() ([]byte, error) {
-	if l == nil {
-		return nil, errMarshalNilLevel
-	}
+func (l Level) MarshalText() ([]byte, error) {
 	return []byte(l.String()), nil
 }
 
@@ -116,6 +113,9 @@ func (l *Level) MarshalText() ([]byte, error) {
 // In particular, this makes it easy to configure logging levels using YAML,
 // TOML, or JSON files.
 func (l *Level) UnmarshalText(text []byte) error {
+	if l == nil {
+		return errUnmarshalNilLevel
+	}
 	switch string(text) {
 	case "debug":
 		*l = DebugLevel

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -84,13 +84,12 @@ func TestLevelNils(t *testing.T) {
 		assert.Equal(t, "Level(nil)", l.String(), "Unexpected result stringifying nil *Level.")
 	}, "Level(nil).String() should panic")
 
-	_, err := l.MarshalText()
-	assert.Equal(t, errMarshalNilLevel, err, "Expected errMarshalNilLevel.")
-
 	assert.Panics(t, func() {
-		var l *Level
-		l.UnmarshalText([]byte("debug"))
-	}, "Expected to panic when unmarshaling into a null pointer.")
+		l.MarshalText()
+	}, "Expected to panic when marshalling a nil level.")
+
+	err := l.UnmarshalText([]byte("debug"))
+	assert.Equal(t, errUnmarshalNilLevel, err, "Expected to error unmarshalling into a nil Level.")
 }
 
 func TestLevelUnmarshalUnknownText(t *testing.T) {


### PR DESCRIPTION
Currently, MarshalText and UnmarshalText are both using pointer
receivers but only UnmarshalText needs a pointer receiver since it
mutates the underlying value.

MarshalText should be on the same receiver type as String. On the other
hand, UnmarshalText requires a pointer receiver, and it can handle the
case where we try to unmarshal to a nil pointer.

cc @ZymoticB