### PR TITLE
Add FilterMessageSnippet to zaptest/observer

### DIFF
--- a/zaptest/observer/observer.go
+++ b/zaptest/observer/observer.go
@@ -21,6 +21,7 @@
 package observer
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -84,6 +85,13 @@ func (o *ObservedLogs) AllUntimed() []LoggedEntry {
 func (o *ObservedLogs) FilterMessage(msg string) *ObservedLogs {
 	return o.filter(func(e LoggedEntry) bool {
 		return e.Message == msg
+	})
+}
+
+// FilterMessageSnippet filters entries to those that have a message containing the specified snippet.
+func (o *ObservedLogs) FilterMessageSnippet(snippet string) *ObservedLogs {
+	return o.filter(func(e LoggedEntry) bool {
+		return strings.Contains(e.Message, snippet)
 	})
 }
 

--- a/zaptest/observer/observer_test.go
+++ b/zaptest/observer/observer_test.go
@@ -137,6 +137,10 @@ func TestFilters(t *testing.T) {
 			Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "log c"},
 			Context: []zapcore.Field{zap.Int("a", 1), zap.Namespace("ns"), zap.Int("a", 2)},
 		},
+		{
+			Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "msg 1"},
+			Context: []zapcore.Field{zap.Int("a", 1), zap.Namespace("ns")},
+		},
 	}
 
 	logger, sink := New(zap.InfoLevel)
@@ -173,6 +177,16 @@ func TestFilters(t *testing.T) {
 			msg:      "filter doesn't match any messages",
 			filtered: sink.FilterMessage("no match"),
 			want:     []LoggedEntry{},
+		},
+		{
+			msg:      "filter by snippet",
+			filtered: sink.FilterMessageSnippet("log"),
+			want:     logs[0:4],
+		},
+		{
+			msg:      "filter by snippet and field",
+			filtered: sink.FilterMessageSnippet("a").FilterField(zap.Int("b", 2)),
+			want:     logs[1:2],
 		},
 	}
 


### PR DESCRIPTION
My team is currently transitioning from logrus style format logging to zap.SugaredLogger and use a testing strategy where we assert that a log message contains some list of snippets, rather than asserting on the entire formatted log message. This seems generally useful for users of the SugaredLogger.