### PR TITLE
Add MarshalText to AtomicLevel

### DIFF
--- a/level.go
+++ b/level.go
@@ -114,3 +114,10 @@ func (lvl *AtomicLevel) UnmarshalText(text []byte) error {
 	lvl.SetLevel(l)
 	return nil
 }
+
+// MarshalText marshals the AtomicLevel to a byte slice. It uses the same
+// text representation as the static zapcore.Levels ("debug", "info", "warn",
+// "error", "dpanic", "panic", and "fatal").
+func (lvl AtomicLevel) MarshalText() (text []byte, err error) {
+	return lvl.Level().MarshalText()
+}

--- a/level_test.go
+++ b/level_test.go
@@ -75,7 +75,7 @@ func TestAtomicLevelMutation(t *testing.T) {
 	wg.Wait()
 }
 
-func TestAtomicLevelUnmarshalText(t *testing.T) {
+func TestAtomicLevelText(t *testing.T) {
 	tests := []struct {
 		text   string
 		expect zapcore.Level
@@ -103,6 +103,14 @@ func TestAtomicLevelUnmarshalText(t *testing.T) {
 			}
 			assert.Equal(t, tt.expect, lvl.Level(), "Unexpected level after unmarshaling.")
 			lvl.SetLevel(InfoLevel)
+		}
+
+		// Test marshalling
+		if tt.text != "" && !tt.err {
+			lvl.SetLevel(tt.expect)
+			marshaled, err := lvl.MarshalText()
+			assert.NoError(t, err, `Unexpected error marshalling level "%v" to text.`, tt.expect)
+			assert.Equal(t, tt.text, string(marshaled), "Expected marshaled text to match")
 		}
 	}
 }


### PR DESCRIPTION
My team displays it's config on a "debug page" which means that we marshal our entire config so that it can be displayed in a browser. This means that we need AtomicLevel to support marshaling since we use it in our config. 