### PR TITLE
Add method for constructing a logger with custom syncer

### DIFF
--- a/config.go
+++ b/config.go
@@ -170,6 +170,23 @@ func (cfg Config) Build(opts ...Option) (*Logger, error) {
 	return log, nil
 }
 
+// BuildWithCustomSyncers constructs a logger from the config, and Options using a custom WriteSyncer
+func (cfg Config) BuildWithCustomSyncers(out zapcore.WriteSyncer, errOut zapcore.WriteSyncer, opts ...Option) (*Logger, error) {
+	enc, err := cfg.buildEncoder()
+	if err != nil {
+		return nil, err
+	}
+
+	log := New(
+		zapcore.NewCore(enc, out, cfg.Level),
+		cfg.buildOptions(errOut)...,
+	)
+	if len(opts) > 0 {
+		log = log.WithOptions(opts...)
+	}
+	return log, nil
+}
+
 func (cfg Config) buildOptions(errSink zapcore.WriteSyncer) []Option {
 	opts := []Option{ErrorOutput(errSink)}
 


### PR DESCRIPTION
This provides a super easy way to create a logger with a config and custom WriteSyncer's. This way developers using zap can create a WriteSyncer out of whatever implementation of io.Writer they have for their project and create a logger from there.

For example, in a lot of projects developers will create mock writers where values are stored in internal byte slices instead of going to stdout/stderr. This way developers can easily set up unit tests that test to make sure the proper values are being logged. 

Signed-off-by: grantseltzer <grant@capsule8.com>