### PR TITLE
Make zap.AtomicLevel implement fmt.Stringer

### DIFF
--- a/level.go
+++ b/level.go
@@ -98,6 +98,11 @@ func (lvl AtomicLevel) SetLevel(l zapcore.Level) {
 	lvl.l.Store(int32(l))
 }
 
+// String returns the string representation of the underlying Level.
+func (lvl AtomicLevel) String() string {
+	return lvl.Level().String()
+}
+
 // UnmarshalText unmarshals the text to an AtomicLevel. It uses the same text
 // representations as the static zapcore.Levels ("debug", "info", "warn",
 // "error", "dpanic", "panic", and "fatal").

--- a/level_test.go
+++ b/level_test.go
@@ -111,6 +111,7 @@ func TestAtomicLevelText(t *testing.T) {
 			marshaled, err := lvl.MarshalText()
 			assert.NoError(t, err, `Unexpected error marshalling level "%v" to text.`, tt.expect)
 			assert.Equal(t, tt.text, string(marshaled), "Expected marshaled text to match")
+			assert.Equal(t, tt.text, lvl.String(), "Expected Stringer call to match")
 		}
 	}
 }


### PR DESCRIPTION
To make it convenient to use `(zap.Config).Level` as a `zap.Field`.
Writing `zap.Stringer("level", config.Level)` is more natural than the stuttering `zap.Stringer("level", config.Level.Level())`.