### PR TITLE
Accept capital strings in Level.UnmarshalText

### DIFF
--- a/zapcore/level.go
+++ b/zapcore/level.go
@@ -117,19 +117,19 @@ func (l *Level) UnmarshalText(text []byte) error {
 		return errUnmarshalNilLevel
 	}
 	switch string(text) {
-	case "debug":
+	case "debug", "DEBUG":
 		*l = DebugLevel
-	case "info", "": // make the zero value useful
+	case "info", "INFO", "": // make the zero value useful
 		*l = InfoLevel
-	case "warn":
+	case "warn", "WARN":
 		*l = WarnLevel
-	case "error":
+	case "error", "ERROR":
 		*l = ErrorLevel
-	case "dpanic":
+	case "dpanic", "DPANIC":
 		*l = DPanicLevel
-	case "panic":
+	case "panic", "PANIC":
 		*l = PanicLevel
-	case "fatal":
+	case "fatal", "FATAL":
 		*l = FatalLevel
 	default:
 		return fmt.Errorf("unrecognized level: %v", string(text))

--- a/zapcore/level.go
+++ b/zapcore/level.go
@@ -21,6 +21,7 @@
 package zapcore
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 )
@@ -116,7 +117,7 @@ func (l *Level) UnmarshalText(text []byte) error {
 	if l == nil {
 		return errUnmarshalNilLevel
 	}
-	if !l.unmarshalText(text) {
+	if !l.unmarshalText(text) && !l.unmarshalText(bytes.ToLower(text)) {
 		return fmt.Errorf("unrecognized level: %v", string(text))
 	}
 	return nil

--- a/zapcore/level.go
+++ b/zapcore/level.go
@@ -118,7 +118,7 @@ func (l *Level) UnmarshalText(text []byte) error {
 		return errUnmarshalNilLevel
 	}
 	if !l.unmarshalText(text) && !l.unmarshalText(bytes.ToLower(text)) {
-		return fmt.Errorf("unrecognized level: %v", string(text))
+		return fmt.Errorf("unrecognized level: %q", text)
 	}
 	return nil
 }

--- a/zapcore/level.go
+++ b/zapcore/level.go
@@ -116,6 +116,13 @@ func (l *Level) UnmarshalText(text []byte) error {
 	if l == nil {
 		return errUnmarshalNilLevel
 	}
+	if !l.unmarshalText(text) {
+		return fmt.Errorf("unrecognized level: %v", string(text))
+	}
+	return nil
+}
+
+func (l *Level) unmarshalText(text []byte) bool {
 	switch string(text) {
 	case "debug", "DEBUG":
 		*l = DebugLevel
@@ -132,9 +139,9 @@ func (l *Level) UnmarshalText(text []byte) error {
 	case "fatal", "FATAL":
 		*l = FatalLevel
 	default:
-		return fmt.Errorf("unrecognized level: %v", string(text))
+		return false
 	}
-	return nil
+	return true
 }
 
 // Set sets the level for the flag.Value interface.

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -71,8 +71,8 @@ func TestLevelText(t *testing.T) {
 
 		var unmarshaled Level
 		err := unmarshaled.UnmarshalText([]byte(tt.text))
-		assert.NoError(t, err, `Unexpected error unmarshaling text "%v" to level.`, tt.text)
-		assert.Equal(t, tt.level, unmarshaled, `Text "%v" unmarshaled to an unexpected level.`, tt.text)
+		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
+		assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
 	}
 }
 

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -76,6 +76,27 @@ func TestLevelText(t *testing.T) {
 	}
 }
 
+func TestCapitalLevelsParse(t *testing.T) {
+	tests := []struct {
+		text  string
+		level Level
+	}{
+		{"DEBUG", DebugLevel},
+		{"INFO", InfoLevel},
+		{"WARN", WarnLevel},
+		{"ERROR", ErrorLevel},
+		{"DPANIC", DPanicLevel},
+		{"PANIC", PanicLevel},
+		{"FATAL", FatalLevel},
+	}
+	for _, tt := range tests {
+		var unmarshaled Level
+		err := unmarshaled.UnmarshalText([]byte(tt.text))
+		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
+		assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
+	}
+}
+
 func TestLevelNils(t *testing.T) {
 	var l *Level
 

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -170,7 +170,7 @@ func TestLevelAsFlagValue(t *testing.T) {
 	assert.Error(t, fs.Parse([]string{"-level", "nope"}))
 	assert.Equal(
 		t,
-		`invalid value "nope" for flag -level: unrecognized level: nope`,
+		`invalid value "nope" for flag -level: unrecognized level: "nope"`,
 		strings.Split(buf.String(), "\n")[0], // second line is help message
 		"Unexpected error output from invalid flag input.",
 	)

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -97,6 +97,37 @@ func TestCapitalLevelsParse(t *testing.T) {
 	}
 }
 
+func TestWeirdLevelsParse(t *testing.T) {
+	tests := []struct {
+		text  string
+		level Level
+	}{
+		// I guess...
+		{"Debug", DebugLevel},
+		{"Info", InfoLevel},
+		{"Warn", WarnLevel},
+		{"Error", ErrorLevel},
+		{"Dpanic", DPanicLevel},
+		{"Panic", PanicLevel},
+		{"Fatal", FatalLevel},
+
+		// What even is...
+		{"DeBuG", DebugLevel},
+		{"InFo", InfoLevel},
+		{"WaRn", WarnLevel},
+		{"ErRor", ErrorLevel},
+		{"DpAnIc", DPanicLevel},
+		{"PaNiC", PanicLevel},
+		{"FaTaL", FatalLevel},
+	}
+	for _, tt := range tests {
+		var unmarshaled Level
+		err := unmarshaled.UnmarshalText([]byte(tt.text))
+		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
+		assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
+	}
+}
+
 func TestLevelNils(t *testing.T) {
 	var l *Level
 


### PR DESCRIPTION
Makes it easier to parse zap's own log output (especially since capital level strings is our internal standard).