### PR TITLE
Add package docs and import paths to zaptest

### DIFF
--- a/zaptest/doc.go
+++ b/zaptest/doc.go
@@ -18,5 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package zaptest provides helpers for testing log output.
+// Package zaptest provides low-level helpers for testing log output. These
+// utilities are helpful in zap's own unit tests, but any assertions using
+// them are strongly coupled to a single encoding.
+//
+// Users are likely better-served by the high-level utilities in
+// go.uber.org/zap/zaptest/observer.
 package zaptest // import "go.uber.org/zap/zaptest"

--- a/zaptest/doc.go
+++ b/zaptest/doc.go
@@ -22,6 +22,6 @@
 // utilities are helpful in zap's own unit tests, but any assertions using
 // them are strongly coupled to a single encoding.
 //
-// Users are likely better-served by the high-level utilities in
-// go.uber.org/zap/zaptest/observer.
+// Most users should use go.uber.org/zap/zaptest/observer instead of this
+// package.
 package zaptest // import "go.uber.org/zap/zaptest"

--- a/zaptest/doc.go
+++ b/zaptest/doc.go
@@ -18,34 +18,5 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package zaptest
-
-import (
-	"log"
-	"os"
-	"strconv"
-	"time"
-)
-
-var _timeoutScale = 1.0
-
-// Timeout scales the provided duration by $TEST_TIMEOUT_SCALE.
-func Timeout(base time.Duration) time.Duration {
-	return time.Duration(float64(base) * _timeoutScale)
-}
-
-// Sleep scales the sleep duration by $TEST_TIMEOUT_SCALE.
-func Sleep(base time.Duration) {
-	time.Sleep(Timeout(base))
-}
-
-func init() {
-	if v := os.Getenv("TEST_TIMEOUT_SCALE"); v != "" {
-		fv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			panic(err)
-		}
-		_timeoutScale = fv
-		log.Printf("Scaling timeouts by %vx.\n", _timeoutScale)
-	}
-}
+// Package zaptest provides helpers for testing log output.
+package zaptest // import "go.uber.org/zap/zaptest"

--- a/zaptest/observer/observer.go
+++ b/zaptest/observer/observer.go
@@ -18,7 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package observer
+// Package observer provides a zapcore.Core that keeps an in-memory,
+// encoding-agnostic repesentation of log entries. It's useful for
+// applications that want to unit test their log output without tying their
+// tests to a particular output encoding.
+package observer // import "go.uber.org/zap/zaptest/observer"
 
 import (
 	"strings"


### PR DESCRIPTION
The `zaptest` package needs some (short) package-level documentation and
a custom import path directive.

At some point, we should write a linter for the import paths - it's too
easy to forget.