### PR TITLE
Less verbose output for multierr

### DIFF
--- a/zapcore/error.go
+++ b/zapcore/error.go
@@ -46,12 +46,11 @@ func encodeError(key string, err error, enc ObjectEncoder) error {
 	basic := err.Error()
 	enc.AddString(key, basic)
 
-	if group, ok := err.(errorGroup); ok {
-		return enc.AddArray(key+"Causes", errArray(group.Errors()))
-	}
-
-	if fancy, ok := err.(fmt.Formatter); ok {
-		verbose := fmt.Sprintf("%+v", fancy)
+	switch e := err.(type) {
+	case errorGroup:
+		return enc.AddArray(key+"Causes", errArray(e.Errors()))
+	case fmt.Formatter:
+		verbose := fmt.Sprintf("%+v", e)
 		if verbose != basic {
 			// This is a rich error type, like those produced by
 			// github.com/pkg/errors.


### PR DESCRIPTION
Following the discussions on uber-go/zap#460, uber-go/multierr#6, and
(most recently) uber-go/multierr#23, reduce log verbosity for
`multierr`. This is fully backward-compatible with the last released
version of zap.

The small changes introduced here do two things:

1. First, we either report `errorCauses` or `errorVerbose`, but not
   both.
2. Second, we prefer `errorCauses` to `errorVerbose`.

I think that this addresses our top-level wants without breaking any
interfaces or removing behavior we've already shipped.

In a future minor, we can add an `ErrorEncoder` interface that the
JSON encoder and console encoder implement, and make the error field
attempt an upcast into that type. That would let the user supply their
own error encoder (much like they supply their own time and duration
encoders now). Even if we do that, though, I suspect that we'll want to
preserve the behavior here as the default.