### PR TITLE
Fix FAQ for log rotation

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -119,12 +119,14 @@ However, it's easy to integrate a log rotation package like
 [`gopkg.in/natefinch/lumberjack.v2`][lumberjack] as a `zapcore.WriteSyncer`.
 
 ```go
-w := zapcore.Lock(zapcore.AddSync(&lumberjack.Logger{
+// lumberjack.Logger is already safe for concurrent use, so we don't need to
+// lock it.
+w := zapcore.AddSync(&lumberjack.Logger{
   Filename:   "/var/log/myapp/foo.log",
   MaxSize:    500, // megabytes
   MaxBackups: 3,
   MaxAge:     28, // days
-}))
+})
 core := zapcore.NewCore(
   zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
   w,


### PR DESCRIPTION
Lumberjack's `Logger` is already safe for concurrent use
(https://github.com/natefinch/lumberjack/blob/v2.1/lumberjack.go#L136),
so there's no need to wrap it in `zapcore.Lock`.