### PR TITLE
Set a static test coverage target

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,7 +7,7 @@ coverage:
     project:                   # measuring the overall project coverage
       default:                 # context, you can create multiple ones with custom titles
         enabled: yes           # must be yes|true to enable this status
-        target: auto           # specify the target coverage for each commit status
+        target: 95%            # specify the target coverage for each commit status
                                #   option: "auto" (must increase from parent commit or pull request base)
                                #   option: "X%" a static target percentage to hit
         if_not_found: success  # if parent is not found report status as success, error, or failure


### PR DESCRIPTION
Set a static test coverage target of 95%. Using the "auto" option is
introducing a lot of flakiness, since even a 0.1% drop fails the build.