### PR TITLE
Small documentation formatting fixes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -51,7 +51,7 @@
 //  sugar.Printf("failed to fetch URL: %s", "http://example.com")
 //
 // By default, loggers are unbuffered. However, since zap's low-level APIs
-// allow buffering, calling `Sync` before letting your process exit is a good
+// allow buffering, calling Sync before letting your process exit is a good
 // habit.
 //
 // In the rare contexts where every microsecond and every allocation matter,

--- a/example_test.go
+++ b/example_test.go
@@ -75,17 +75,18 @@ func Example_basicConfiguration() {
 	// See the documentation for Config and zapcore.EncoderConfig for all the
 	// available options.
 	rawJSON := []byte(`{
-		"level": "debug",
-		"encoding": "json",
-		"outputPaths": ["stdout", "/tmp/logs"],
-		"errorOutputPaths": ["stderr"],
-		"initialFields": {"foo": "bar"},
-		"encoderConfig": {
-			"messageKey": "message",
-			"levelKey": "level",
-			"levelEncoder": "lowercase"
-		}
+	  "level": "debug",
+	  "encoding": "json",
+	  "outputPaths": ["stdout", "/tmp/logs"],
+	  "errorOutputPaths": ["stderr"],
+	  "initialFields": {"foo": "bar"},
+	  "encoderConfig": {
+	    "messageKey": "message",
+	    "levelKey": "level",
+	    "levelEncoder": "lowercase"
+	  }
 	}`)
+
 	var cfg zap.Config
 	if err := json.Unmarshal(rawJSON, &cfg); err != nil {
 		panic(err)
@@ -124,11 +125,13 @@ func Example_advancedConfiguration() {
 	// implement io.Writer, we can use zapcore.AddSync to add a no-op Sync
 	// method. If they're not safe for concurrent use, we can add a protecting
 	// mutex with zapcore.Lock.)
-	topicDebugging, topicErrors := zapcore.AddSync(ioutil.Discard), zapcore.AddSync(ioutil.Discard)
+	topicDebugging := zapcore.AddSync(ioutil.Discard)
+	topicErrors := zapcore.AddSync(ioutil.Discard)
 
 	// High-priority output should also go to standard error, and low-priority
 	// output should also go to standard out.
-	consoleDebugging, consoleErrors := zapcore.Lock(os.Stdout), zapcore.Lock(os.Stderr)
+	consoleDebugging := zapcore.Lock(os.Stdout)
+	consoleErrors := zapcore.Lock(os.Stderr)
 
 	// Optimize the Kafka output for machine consumption and the console output
 	// for human operators.


### PR DESCRIPTION
GoDoc.org renders docs a little differently from my local `godoc`. This
PR fixes some whitespace and breaks up some long lines so that they look
better.

It also removes backticks from a last-minute documentation addition I
made (Markdown habits die hard).