### PR TITLE
Add AddClassFunction option

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -45,8 +45,9 @@ type Logger struct {
 	name        string
 	errorOutput zapcore.WriteSyncer
 
-	addCaller bool
-	addStack  zapcore.LevelEnabler
+	addCaller        bool
+	addClassFunction bool
+	addStack         zapcore.LevelEnabler
 
 	callerSkip int
 }
@@ -290,7 +291,7 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 
 	// Thread the error output through to the CheckedEntry.
 	ce.ErrorOutput = log.errorOutput
-	if log.addCaller {
+	if log.addCaller || log.addClassFunction {
 		ce.Entry.Caller = zapcore.NewEntryCaller(runtime.Caller(log.callerSkip + callerSkipOffset))
 		if !ce.Entry.Caller.Defined {
 			fmt.Fprintf(log.errorOutput, "%v Logger.check error: failed to get caller\n", time.Now().UTC())

--- a/options.go
+++ b/options.go
@@ -90,6 +90,14 @@ func AddCaller() Option {
 	})
 }
 
+// AddClassFunction configures the Logger to annotate each message with
+// the caller class and function name.
+func AddClassFunction() Option {
+	return optionFunc(func(log *Logger) {
+		log.addClassFunction = true
+	})
+}
+
 // AddCallerSkip increases the number of callers skipped by caller annotation
 // (as enabled by the AddCaller option). When building wrappers around the
 // Logger and SugaredLogger, supplying this Option prevents zap from always

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -184,12 +184,22 @@ func ShortCallerEncoder(caller EntryCaller, enc PrimitiveArrayEncoder) {
 	enc.AppendString(caller.TrimmedPath())
 }
 
+// ShortCallerWithClassFunctionEncoder serializes a caller in
+// package/file:line class.function format
+// trimming all but the final directory from the full path.
+func ShortCallerWithClassFunctionEncoder(caller EntryCaller, enc PrimitiveArrayEncoder) {
+	// TODO: consider using a byte-oriented API to save an allocation.
+	enc.AppendString(caller.TrimmedPath(true))
+}
+
 // UnmarshalText unmarshals text to a CallerEncoder. "full" is unmarshaled to
 // FullCallerEncoder and anything else is unmarshaled to ShortCallerEncoder.
 func (e *CallerEncoder) UnmarshalText(text []byte) error {
 	switch string(text) {
 	case "full":
 		*e = FullCallerEncoder
+	case "withclassfunction":
+		*e = ShortCallerWithClassFunctionEncoder
 	default:
 		*e = ShortCallerEncoder
 	}


### PR DESCRIPTION
Configures the Logger to annotate each message with the caller class and
function name.

for example :

http/server.go:127 (*Server).ListenAndServe

Signed-off-by: Nicolas PLANEL <nplanel@redhat.com>