### PR TITLE
Add benchmarks for zerolog

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,41 +66,41 @@ Log a message and 10 fields:
 
 | Package | Time | Objects Allocated |
 | :--- | :---: | :---: |
-| :zap: zap | 3174 ns/op | 5 allocs/op |
-| :zap: zap (sugared) | 3929 ns/op | 21 allocs/op |
-| go-kit | 16475 ns/op | 126 allocs/op |
-| zerolog | 17013 ns/op | 90 allocs/op |
-| lion | 17119 ns/op | 111 allocs/op |
-| logrus | 23344 ns/op | 142 allocs/op |
-| log15 | 34996 ns/op | 149 allocs/op |
-| apex/log | 39062 ns/op | 126 allocs/op |
+| :zap: zap | 3131 ns/op | 5 allocs/op |
+| :zap: zap (sugared) | 4173 ns/op | 21 allocs/op |
+| zerolog | 16154 ns/op | 90 allocs/op |
+| lion | 16341 ns/op | 111 allocs/op |
+| go-kit | 17049 ns/op | 126 allocs/op |
+| logrus | 23662 ns/op | 142 allocs/op |
+| log15 | 36351 ns/op | 149 allocs/op |
+| apex/log | 42530 ns/op | 126 allocs/op |
 
 Log a message with a logger that already has 10 fields of context:
 
 | Package | Time | Objects Allocated |
 | :--- | :---: | :---: |
-| :zap: zap | 381 ns/op | 0 allocs/op |
-| :zap: zap (sugared) | 546 ns/op | 2 allocs/op |
-| zerolog | 316 ns/op | 0 allocs/op |
-| lion | 6215 ns/op | 39 allocs/op |
-| go-kit | 19241 ns/op | 115 allocs/op |
-| logrus | 21331 ns/op | 130 allocs/op |
-| log15 | 26071 ns/op | 79 allocs/op |
-| apex/log | 37891 ns/op | 115 allocs/op |
+| :zap: zap | 380 ns/op | 0 allocs/op |
+| :zap: zap (sugared) | 564 ns/op | 2 allocs/op |
+| zerolog | 321 ns/op | 0 allocs/op |
+| lion | 7092 ns/op | 39 allocs/op |
+| go-kit | 20226 ns/op | 115 allocs/op |
+| logrus | 22312 ns/op | 130 allocs/op |
+| log15 | 28788 ns/op | 79 allocs/op |
+| apex/log | 42063 ns/op | 115 allocs/op |
 
 Log a static string, without any context or `printf`-style templating:
 
 | Package | Time | Objects Allocated |
 | :--- | :---: | :---: |
-| :zap: zap | 338 ns/op | 0 allocs/op |
-| :zap: zap (sugared) | 549 ns/op | 2 allocs/op |
-| zerolog | 303 ns/op | 0 allocs/op |
-| standard library | 586 ns/op | 2 allocs/op |
-| go-kit | 958 ns/op | 13 allocs/op |
-| lion | 1452 ns/op | 10 allocs/op |
-| logrus | 2367 ns/op | 27 allocs/op |
-| apex/log | 3383 ns/op | 11 allocs/op |
-| log15 | 6481 ns/op | 26 allocs/op |
+| :zap: zap | 361 ns/op | 0 allocs/op |
+| :zap: zap (sugared) | 534 ns/op | 2 allocs/op |
+| zerolog | 323 ns/op | 0 allocs/op |
+| standard library | 575 ns/op | 2 allocs/op |
+| go-kit | 922 ns/op | 13 allocs/op |
+| lion | 1413 ns/op | 10 allocs/op |
+| logrus | 2291 ns/op | 27 allocs/op |
+| apex/log | 3690 ns/op | 11 allocs/op |
+| log15 | 5954 ns/op | 26 allocs/op |
 
 ## Development Status: Stable
 

--- a/README.md
+++ b/README.md
@@ -66,38 +66,41 @@ Log a message and 10 fields:
 
 | Package | Time | Objects Allocated |
 | :--- | :---: | :---: |
-| :zap: zap | 3243 ns/op | 5 allocs/op |
-| :zap: zap (sugared) | 4232 ns/op | 21 allocs/op |
-| go-kit | 16652 ns/op | 126 allocs/op |
-| lion | 16753 ns/op | 111 allocs/op |
-| logrus | 22492 ns/op | 142 allocs/op |
-| log15 | 36261 ns/op | 149 allocs/op |
-| apex/log | 40263 ns/op | 126 allocs/op |
+| :zap: zap | 3174 ns/op | 5 allocs/op |
+| :zap: zap (sugared) | 3929 ns/op | 21 allocs/op |
+| go-kit | 16475 ns/op | 126 allocs/op |
+| zerolog | 17013 ns/op | 90 allocs/op |
+| lion | 17119 ns/op | 111 allocs/op |
+| logrus | 23344 ns/op | 142 allocs/op |
+| log15 | 34996 ns/op | 149 allocs/op |
+| apex/log | 39062 ns/op | 126 allocs/op |
 
 Log a message with a logger that already has 10 fields of context:
 
 | Package | Time | Objects Allocated |
 | :--- | :---: | :---: |
-| :zap: zap | 405 ns/op | 0 allocs/op |
-| :zap: zap (sugared) | 547 ns/op | 2 allocs/op |
-| lion | 6462 ns/op | 39 allocs/op |
-| go-kit | 19563 ns/op | 115 allocs/op |
-| logrus | 23127 ns/op | 130 allocs/op |
-| log15 | 27495 ns/op | 79 allocs/op |
-| apex/log | 38938 ns/op | 115 allocs/op |
+| :zap: zap | 381 ns/op | 0 allocs/op |
+| :zap: zap (sugared) | 546 ns/op | 2 allocs/op |
+| zerolog | 316 ns/op | 0 allocs/op |
+| lion | 6215 ns/op | 39 allocs/op |
+| go-kit | 19241 ns/op | 115 allocs/op |
+| logrus | 21331 ns/op | 130 allocs/op |
+| log15 | 26071 ns/op | 79 allocs/op |
+| apex/log | 37891 ns/op | 115 allocs/op |
 
 Log a static string, without any context or `printf`-style templating:
 
 | Package | Time | Objects Allocated |
 | :--- | :---: | :---: |
-| :zap: zap | 429 ns/op | 0 allocs/op |
+| :zap: zap | 338 ns/op | 0 allocs/op |
 | :zap: zap (sugared) | 549 ns/op | 2 allocs/op |
-| standard library | 585 ns/op | 2 allocs/op |
-| go-kit | 909 ns/op | 13 allocs/op |
-| lion | 1420 ns/op | 10 allocs/op |
-| logrus | 2404 ns/op | 27 allocs/op |
-| apex/log | 3457 ns/op | 11 allocs/op |
-| log15 | 6313 ns/op | 26 allocs/op |
+| zerolog | 303 ns/op | 0 allocs/op |
+| standard library | 586 ns/op | 2 allocs/op |
+| go-kit | 958 ns/op | 13 allocs/op |
+| lion | 1452 ns/op | 10 allocs/op |
+| logrus | 2367 ns/op | 27 allocs/op |
+| apex/log | 3383 ns/op | 11 allocs/op |
+| log15 | 6481 ns/op | 26 allocs/op |
 
 ## Development Status: Stable
 

--- a/benchmarks/scenario_bench_test.go
+++ b/benchmarks/scenario_bench_test.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"log"
 	"testing"
-	"time"
 
 	"go.uber.org/zap"
 )
@@ -65,18 +64,7 @@ func BenchmarkDisabledWithoutFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.Infof("%v %v %v %s %v %v %v %v %v %s\n",
-					1,
-					int64(1),
-					3.0,
-					"four!",
-					true,
-					time.Unix(0, 0),
-					errExample,
-					time.Second,
-					_oneUser,
-					"done!",
-				)
+				logger.Infof("%v %v %v %s %v %v %v %v %v %s\n", fakeFmtArgs()...)
 			}
 		})
 	})
@@ -145,18 +133,7 @@ func BenchmarkDisabledAccumulatedContext(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.Infof("%v %v %v %s %v %v %v %v %v %s\n",
-					1,
-					int64(1),
-					3.0,
-					"four!",
-					true,
-					time.Unix(0, 0),
-					errExample,
-					time.Second,
-					_oneUser,
-					"done!",
-				)
+				logger.Infof("%v %v %v %s %v %v %v %v %v %s\n", fakeFmtArgs()...)
 			}
 		})
 	})
@@ -298,18 +275,7 @@ func BenchmarkWithoutFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.Infof("%v %v %v %s %v %v %v %v %v %s\n",
-					1,
-					int64(1),
-					3.0,
-					"four!",
-					true,
-					time.Unix(0, 0),
-					errExample,
-					time.Second,
-					_oneUser,
-					"done!",
-				)
+				logger.Infof("%v %v %v %s %v %v %v %v %v %s\n", fakeFmtArgs()...)
 			}
 		})
 	})
@@ -372,18 +338,7 @@ func BenchmarkWithoutFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.Printf("%v %v %v %s %v %v %v %v %v %s\n",
-					1,
-					int64(1),
-					3.0,
-					"four!",
-					true,
-					time.Unix(0, 0),
-					errExample,
-					time.Second,
-					_oneUser,
-					"done!",
-				)
+				logger.Printf("%v %v %v %s %v %v %v %v %v %s\n", fakeFmtArgs()...)
 			}
 		})
 	})
@@ -401,18 +356,7 @@ func BenchmarkWithoutFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.Info().Msgf("%v %v %v %s %v %v %v %v %v %s\n",
-					1,
-					int64(1),
-					3.0,
-					"four!",
-					true,
-					time.Unix(0, 0),
-					errExample,
-					time.Second,
-					_oneUser,
-					"done!",
-				)
+				logger.Info().Msgf("%v %v %v %s %v %v %v %v %v %s\n", fakeFmtArgs()...)
 			}
 		})
 	})
@@ -478,18 +422,7 @@ func BenchmarkAccumulatedContext(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.Infof("%v %v %v %s %v %v %v %v %v %s\n",
-					1,
-					int64(1),
-					3.0,
-					"four!",
-					true,
-					time.Unix(0, 0),
-					errExample,
-					time.Second,
-					_oneUser,
-					"done!",
-				)
+				logger.Infof("%v %v %v %s %v %v %v %v %v %s\n", fakeFmtArgs()...)
 			}
 		})
 	})
@@ -563,18 +496,7 @@ func BenchmarkAccumulatedContext(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				logger.Info().Msgf("%v %v %v %s %v %v %v %v %v %s\n",
-					1,
-					int64(1),
-					3.0,
-					"four!",
-					true,
-					time.Unix(0, 0),
-					errExample,
-					time.Second,
-					_oneUser,
-					"done!",
-				)
+				logger.Info().Msgf("%v %v %v %s %v %v %v %v %v %s\n", fakeFmtArgs()...)
 			}
 		})
 	})

--- a/benchmarks/scenario_bench_test.go
+++ b/benchmarks/scenario_bench_test.go
@@ -98,6 +98,15 @@ func BenchmarkDisabledWithoutFields(b *testing.B) {
 			}
 		})
 	})
+	b.Run("rs/zerolog", func(b *testing.B) {
+		logger := newDisabledZerolog()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				logger.Info().Msg(getMessage(0))
+			}
+		})
+	})
 }
 
 func BenchmarkDisabledAccumulatedContext(b *testing.B) {
@@ -169,6 +178,15 @@ func BenchmarkDisabledAccumulatedContext(b *testing.B) {
 			}
 		})
 	})
+	b.Run("rs/zerolog", func(b *testing.B) {
+		logger := fakeZerologContext(newDisabledZerolog().With()).Logger()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				logger.Info().Msg(getMessage(0))
+			}
+		})
+	})
 }
 
 func BenchmarkDisabledAddingFields(b *testing.B) {
@@ -217,6 +235,15 @@ func BenchmarkDisabledAddingFields(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				logger.WithFields(fakeLogrusFields()).Info(getMessage(0))
+			}
+		})
+	})
+	b.Run("rs/zerolog", func(b *testing.B) {
+		logger := newDisabledZerolog()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				fakeZerologFields(logger.Info()).Msg(getMessage(0))
 			}
 		})
 	})
@@ -360,6 +387,46 @@ func BenchmarkWithoutFields(b *testing.B) {
 			}
 		})
 	})
+	b.Run("rs/zerolog", func(b *testing.B) {
+		logger := newZerolog()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				logger.Info().Msg(getMessage(0))
+			}
+		})
+	})
+	b.Run("rs/zerolog.Formatting", func(b *testing.B) {
+		logger := newZerolog()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				logger.Info().Msgf("%v %v %v %s %v %v %v %v %v %s\n",
+					1,
+					int64(1),
+					3.0,
+					"four!",
+					true,
+					time.Unix(0, 0),
+					errExample,
+					time.Second,
+					_oneUser,
+					"done!",
+				)
+			}
+		})
+	})
+	b.Run("rs/zerolog.Check", func(b *testing.B) {
+		logger := newZerolog()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if e := logger.Info(); e.Enabled() {
+					e.Msg(getMessage(0))
+				}
+			}
+		})
+	})
 }
 
 func BenchmarkAccumulatedContext(b *testing.B) {
@@ -471,6 +538,46 @@ func BenchmarkAccumulatedContext(b *testing.B) {
 			}
 		})
 	})
+	b.Run("rs/zerolog", func(b *testing.B) {
+		logger := fakeZerologContext(newZerolog().With()).Logger()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				logger.Info().Msg(getMessage(0))
+			}
+		})
+	})
+	b.Run("rs/zerolog.Check", func(b *testing.B) {
+		logger := fakeZerologContext(newZerolog().With()).Logger()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if e := logger.Info(); e.Enabled() {
+					e.Msg(getMessage(0))
+				}
+			}
+		})
+	})
+	b.Run("rs/zerolog.Formatting", func(b *testing.B) {
+		logger := fakeZerologContext(newZerolog().With()).Logger()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				logger.Info().Msgf("%v %v %v %s %v %v %v %v %v %s\n",
+					1,
+					int64(1),
+					3.0,
+					"four!",
+					true,
+					time.Unix(0, 0),
+					errExample,
+					time.Second,
+					_oneUser,
+					"done!",
+				)
+			}
+		})
+	})
 }
 
 func BenchmarkAddingFields(b *testing.B) {
@@ -559,6 +666,26 @@ func BenchmarkAddingFields(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				logger.WithFields(fakeLogrusFields()).Infof(getMessage(0))
+			}
+		})
+	})
+	b.Run("rs/zerolog", func(b *testing.B) {
+		logger := newZerolog()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				fakeZerologFields(logger.Info()).Msg(getMessage(0))
+			}
+		})
+	})
+	b.Run("rs/zerolog.Check", func(b *testing.B) {
+		logger := newZerolog()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if e := logger.Info(); e.Enabled() {
+					fakeZerologFields(e).Msg(getMessage(0))
+				}
 			}
 		})
 	})

--- a/benchmarks/zap_test.go
+++ b/benchmarks/zap_test.go
@@ -153,3 +153,20 @@ func fakeSugarFields() []interface{} {
 		"error", errExample,
 	}
 }
+
+func fakeFmtArgs() []interface{} {
+	// Need to keep this a function instead of a package-global var so that we
+	// pay the cast-to-interface{} penalty on each call.
+	return []interface{}{
+		_tenInts[0],
+		_tenInts,
+		_tenStrings[0],
+		_tenStrings,
+		_tenTimes[0],
+		_tenTimes,
+		_oneUser,
+		_oneUser,
+		_tenUsers,
+		errExample,
+	}
+}

--- a/benchmarks/zerolog_test.go
+++ b/benchmarks/zerolog_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package benchmarks
+
+import (
+	"io/ioutil"
+
+	"github.com/rs/zerolog"
+)
+
+func newZerolog() zerolog.Logger {
+	return zerolog.New(ioutil.Discard).With().Timestamp().Logger()
+}
+
+func newDisabledZerolog() zerolog.Logger {
+	return newZerolog().Level(zerolog.Disabled)
+}
+
+func fakeZerologFields(e *zerolog.Event) *zerolog.Event {
+	return e.
+		Int("int", _tenInts[0]).
+		Interface("ints", _tenInts).
+		Str("string", _tenStrings[0]).
+		Interface("strings", _tenStrings).
+		Time("time", _tenTimes[0]).
+		Interface("times", _tenTimes).
+		Interface("user1", _oneUser).
+		Interface("user2", _oneUser).
+		Interface("users", _tenUsers).
+		Err(errExample)
+}
+
+func fakeZerologContext(c zerolog.Context) zerolog.Context {
+	return c.
+		Int("int", _tenInts[0]).
+		Interface("ints", _tenInts).
+		Str("string", _tenStrings[0]).
+		Interface("strings", _tenStrings).
+		Time("time", _tenTimes[0]).
+		Interface("times", _tenTimes).
+		Interface("user1", _oneUser).
+		Interface("user2", _oneUser).
+		Interface("users", _tenUsers).
+		Err(errExample)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2b8be1588d6028696f61ce80eb1b50dbad19144b4d4ead760977ad54064f4f26
-updated: 2017-06-30T10:57:16.454459206-07:00
+hash: f073ba522c06c88ea3075bde32a8aaf0969a840a66cab6318a0897d141ffee92
+updated: 2017-07-22T18:06:49.598185334-07:00
 imports:
 - name: go.uber.org/atomic
   version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
@@ -7,7 +7,7 @@ imports:
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 testImports:
 - name: github.com/apex/log
-  version: 8f3a15d95392c8fc202d1e1059f46df21dff2992
+  version: d9b960447bfa720077b2da653cc79e533455b499
   subpackages:
   - handlers/json
 - name: github.com/axw/gocov
@@ -15,19 +15,19 @@ testImports:
   subpackages:
   - gocov
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/fatih/color
   version: 62e9147c64a1ed519147b62a56a14e83e2be02c1
 - name: github.com/go-kit/kit
-  version: 9917269ff0e9fc93df46474b411ea1716195a61b
+  version: e10f5bf035be9af21fd5b2fb4469d5716c6ab07d
   subpackages:
   - log
 - name: github.com/go-logfmt/logfmt
   version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
 - name: github.com/go-stack/stack
-  version: 7a2f19628aabfe68f0766b59e74d6315f8347d22
+  version: 54be5f394ed2c3e19dac9134a40a95ba5a017f7b
 - name: github.com/golang/lint
   version: c5fb716d6688a859aae56d26d3e6070808df29f7
   subpackages:
@@ -35,23 +35,25 @@ testImports:
 - name: github.com/kr/logfmt
   version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
 - name: github.com/mattn/go-colorable
-  version: 5411d3eea5978e6cdc258b30de592b60df6aba96
+  version: 3fa8c76f9daed4067e4a806fb7e4dc86455c6d6a
 - name: github.com/mattn/go-isatty
-  version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 - name: github.com/mattn/goveralls
-  version: a2cbbd7cdce4f5e051016fedf639c64bb05ef031
+  version: 6efce81852ad1b7567c17ad71b03aeccc9dd9ae0
 - name: github.com/pborman/uuid
-  version: 1b00554d822231195d1babd97ff4a781231955c9
+  version: e790cca94e6cc75c7064b1332e63811d4aae1a53
 - name: github.com/pkg/errors
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/rs/zerolog
+  version: eed4c2b94d945e0b2456ad6aa518a443986b5f22
 - name: github.com/satori/go.uuid
   version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/sirupsen/logrus
-  version: 68cec9f21fbf3ea8d8f98c044bc6ce05f17b267a
+  version: 7dd06bf38e1e13df288d471a57d5adbac106be9e
 - name: github.com/stretchr/testify
   version: f6abca593680b2315d2075e0f5e2a9751e3f431a
   subpackages:
@@ -60,11 +62,11 @@ testImports:
 - name: go.pedge.io/lion
   version: 87958e8713f1fa138d993087133b97e976642159
 - name: golang.org/x/sys
-  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+  version: c4489faa6e5ab84c0ef40d6ee878f7a030281f0f
   subpackages:
   - unix
 - name: golang.org/x/tools
-  version: 1529f889eb4b594d1f047f2fb8d5b3cc85c8f006
+  version: 496819729719f9d07692195e0a94d6edd2251389
   subpackages:
   - cover
 - name: gopkg.in/inconshreveable/log15.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,6 +23,7 @@ testImport:
 - package: github.com/pborman/uuid
 - package: github.com/pkg/errors
 - package: go.pedge.io/lion
+- package: github.com/rs/zerolog
 - package: golang.org/x/tools
   subpackages:
   - cover

--- a/internal/readme/readme.go
+++ b/internal/readme/readme.go
@@ -44,6 +44,7 @@ var (
 		"inconshreveable/log15": "log15",
 		"apex/log":              "apex/log",
 		"go.pedge.io/lion":      "lion",
+		"rs/zerolog":            "zerolog",
 	}
 )
 


### PR DESCRIPTION
Add some benchmarks for `github.com/rs/zerolog`.

These aren't exactly the same as the benchmarks in the author's PR:

1. The author's benchmarks don't timestamp zerolog's output, which is
   why they're so startingly fast.
2. Zerolog's sampler is too simple for reasonable production use - it
   just blindly drops a percentage of logs, rather than reservoir
   sampling. Given that, I left out sampling benchmarks.

After those two adjustments, zerolog ends up being a bit faster than zap (~50
ns) when all context has already been added, but much slower (~14000 ns) when
adding fields.

This seems like a reasonable price to pay for zap's configurability,
thread-safety, and encoding-agnosticism.