### PR TITLE
Make level configurable for NewStdLog. (#439)

### DIFF
--- a/global_test.go
+++ b/global_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap/internal/exit"
+
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
@@ -96,18 +98,53 @@ func TestNewStdLog(t *testing.T) {
 	withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
 		std := NewStdLog(l)
 		std.Print("redirected")
-
-		require.Equal(t, 1, logs.Len(), "Expected exactly one entry to be logged.")
-		entry := logs.AllUntimed()[0]
-		assert.Equal(t, []zapcore.Field{}, entry.Context, "Unexpected entry context.")
-		assert.Equal(t, "redirected", entry.Entry.Message, "Unexpected entry message.")
-		assert.Regexp(
-			t,
-			`go.uber.org/zap/global_test.go:\d+$`,
-			entry.Entry.Caller.String(),
-			"Unexpected caller annotation.",
-		)
+		checkStdLogMessage(t, "redirected", logs)
 	})
+}
+
+func TestNewStdLogAt_Regular(t *testing.T) {
+	// include DPanicLevel here, but do not include Development in options
+	levels := []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
+	for _, level := range levels {
+		withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
+			std, err := NewStdLogAt(l, level)
+			require.Nil(t, err, "Unexpected error.")
+			std.Print("redirected")
+			checkStdLogMessage(t, "redirected", logs)
+		})
+	}
+}
+
+func TestNewStdLogAt_Fatal(t *testing.T) {
+	withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
+		stub := exit.WithStub(func() {
+			std, err := NewStdLogAt(l, FatalLevel)
+			require.Nil(t, err, "Unexpected error.")
+			std.Print("redirected")
+			checkStdLogMessage(t, "redirected", logs)
+		})
+		assert.True(t, true, stub.Exited, "Expected Fatal logger call to terminate process.")
+		stub.Unstub()
+	})
+}
+
+func TestNewStdLogAt_Panics(t *testing.T) {
+	// include DPanicLevel here and enable Development in options
+	levels := []zapcore.Level{DPanicLevel, PanicLevel}
+	for _, level := range levels {
+		withLogger(t, DebugLevel, []Option{AddCaller(), Development()}, func(l *Logger, logs *observer.ObservedLogs) {
+			std, err := NewStdLogAt(l, level)
+			require.Nil(t, err, "Unexpected error")
+			assert.Panics(t, func() { std.Print("redirected") }, "Expected log to panic.")
+			checkStdLogMessage(t, "redirected", logs)
+		})
+	}
+}
+
+func TestNewStdLog_InvalidLevel(t *testing.T) {
+	_, err := NewStdLogAt(NewNop(), zapcore.Level(99))
+	assert.NotNil(t, err, "Expected to get error.")
+	assert.Contains(t, err.Error(), "99", "Expected level code in error message")
 }
 
 func TestRedirectStdLog(t *testing.T) {
@@ -136,4 +173,17 @@ func TestRedirectStdLogCaller(t *testing.T) {
 		require.Len(t, entries, 1, "Unexpected number of logs.")
 		assert.Contains(t, entries[0].Entry.Caller.File, "global_test.go", "Unexpected caller annotation.")
 	})
+}
+
+func checkStdLogMessage(t *testing.T, msg string, logs *observer.ObservedLogs) {
+	require.Equal(t, 1, logs.Len(), "Expected exactly one entry to be logged")
+	entry := logs.AllUntimed()[0]
+	assert.Equal(t, []zapcore.Field{}, entry.Context, "Unexpected entry context.")
+	assert.Equal(t, "redirected", entry.Entry.Message, "Unexpected entry message.")
+	assert.Regexp(
+		t,
+		`go.uber.org/zap/global_test.go:\d+$`,
+		entry.Entry.Caller.String(),
+		"Unexpected caller annotation.",
+	)
 }


### PR DESCRIPTION
With this change new function is added called `NewStdLogAt`. It has same
behaviour as NewStdLog, but it allows providing log level to use by
returned `*log.Logger`.

Couple of things to note:
- it would be much more straight forward to implement this if there is function `*zap.Logger.Log(Level, string, …zapcore.Fields)` in addition to `Debug`, `Info`, etc. I understand if you do not want to introduce it, but if you are opened to it, I can add it and adapt implementation.
- `loggerWriter` is changed to accept function to use, so that decision which function should be used is elsewhere. Existing code is compatible, since default was `Info` and that is passed. This can be other way around - `loggerWriter` can have both logger and level and decide which function to call during `Write` execution, but I do not really like idea of executing switch case every time `Write` is called.
- Tests are refactored a bit, so that common parts among new tests and existing one `TestNewStdLog` can be reused. It might be possible to generalize this to table-driven test, but DPanic, Panic and Fatal levels have special handling, so it might be a bit long. I prefer it the way I wrote it, but I am opened to changing it to table driven test if that is preferred. 
