### PR TITLE
Make level configurable for RedirectStdLog

### DIFF
--- a/global.go
+++ b/global.go
@@ -117,9 +117,48 @@ func RedirectStdLog(l *Logger) func() {
 	prefix := log.Prefix()
 	log.SetFlags(0)
 	log.SetPrefix("")
-	logFunc := l.WithOptions(
-		AddCallerSkip(_stdLogDefaultDepth + _loggerWriterDepth),
-	).Info
+	logger := l.WithOptions(AddCallerSkip(_stdLogDefaultDepth + _loggerWriterDepth))
+	logFunc := logger.Info
+	log.SetOutput(&loggerWriter{logFunc})
+	return func() {
+		log.SetFlags(flags)
+		log.SetPrefix(prefix)
+		log.SetOutput(os.Stderr)
+	}
+}
+
+// RedirectStdLogAt redirects output from the standard library's package-global
+// logger to the supplied logger at required level. Since zap already handles
+// caller annotations, timestamps, etc., it automatically disables the standard
+// library's annotations and prefixing.
+//
+// It returns a function to restore the original prefix and flags and reset the
+// standard library's output to os.Stdout.
+func RedirectStdLogAt(l *Logger, level zapcore.Level) (func(), error) {
+	flags := log.Flags()
+	prefix := log.Prefix()
+	log.SetFlags(0)
+	log.SetPrefix("")
+	logger := l.WithOptions(AddCallerSkip(_stdLogDefaultDepth + _loggerWriterDepth))
+	var logFunc func(string, ...zapcore.Field)
+	switch level {
+	case DebugLevel:
+		logFunc = logger.Debug
+	case InfoLevel:
+		logFunc = logger.Info
+	case WarnLevel:
+		logFunc = logger.Warn
+	case ErrorLevel:
+		logFunc = logger.Error
+	case DPanicLevel:
+		logFunc = logger.DPanic
+	case PanicLevel:
+		logFunc = logger.Panic
+	case FatalLevel:
+		logFunc = logger.Fatal
+	default:
+		return nil, fmt.Errorf("unrecognized level: %q", level)
+	}
 	log.SetOutput(&loggerWriter{logFunc})
 	return func() {
 		log.SetFlags(flags)

--- a/global_test.go
+++ b/global_test.go
@@ -175,6 +175,56 @@ func TestRedirectStdLogCaller(t *testing.T) {
 	})
 }
 
+func TestRedirectStdLogAt(t *testing.T) {
+	initialFlags := log.Flags()
+	initialPrefix := log.Prefix()
+
+	withLogger(t, DebugLevel, nil, func(l *Logger, logs *observer.ObservedLogs) {
+		defer RedirectStdLog(l)()
+		log.Print("redirected")
+
+		assert.Equal(t, []observer.LoggedEntry{{
+			Entry:   zapcore.Entry{Message: "redirected"},
+			Context: []zapcore.Field{},
+		}}, logs.AllUntimed(), "Unexpected global log output.")
+	})
+
+	assert.Equal(t, initialFlags, log.Flags(), "Expected to reset initial flags.")
+	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
+}
+
+func TestRedirectStdLogAtPanics(t *testing.T) {
+	// include DPanicLevel here and enable Development in options
+	levels := []zapcore.Level{DPanicLevel, PanicLevel}
+	for _, level := range levels {
+		withLogger(t, DebugLevel, []Option{AddCaller(), Development()}, func(l *Logger, logs *observer.ObservedLogs) {
+			std, err := NewStdLogAt(l, level)
+			require.NoError(t, err, "Unexpected error")
+			assert.Panics(t, func() { std.Print("redirected") }, "Expected log to panic.")
+			checkStdLogMessage(t, "redirected", logs)
+		})
+	}
+}
+
+func TestRedirectStdLogAtFatal(t *testing.T) {
+	withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
+		stub := exit.WithStub(func() {
+			std, err := NewStdLogAt(l, FatalLevel)
+			require.NoError(t, err, "Unexpected error.")
+			std.Print("redirected")
+			checkStdLogMessage(t, "redirected", logs)
+		})
+		assert.True(t, true, stub.Exited, "Expected Fatal logger call to terminate process.")
+		stub.Unstub()
+	})
+}
+
+func TestRedirectStdLogAtInvalid(t *testing.T) {
+	_, err := NewStdLogAt(NewNop(), zapcore.Level(99))
+	assert.Error(t, err, "Expected to get error.")
+	assert.Contains(t, err.Error(), "99", "Expected level code in error message")
+}
+
 func checkStdLogMessage(t *testing.T, msg string, logs *observer.ObservedLogs) {
 	require.Equal(t, 1, logs.Len(), "Expected exactly one entry to be logged")
 	entry := logs.AllUntimed()[0]


### PR DESCRIPTION
This change introduces a new function `RedirectStdLogAt`. It has the same
behaviour as `RedirectStdLog` but allows providing a log level to be used
by used `*log.Logger`.