### PR TITLE
Break dependency between zap and zaptest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export GO15VENDOREXPERIMENT=1
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 PKGS ?= $(shell glide novendor)
 # Many Go tools take file globs or directories as arguments instead of packages.
-PKG_FILES ?= *.go zapcore benchmarks buffer zapgrpc zaptest zaptest/observer internal/bufferpool internal/exit internal/color
+PKG_FILES ?= *.go zapcore benchmarks buffer zapgrpc zaptest zaptest/observer internal/bufferpool internal/exit internal/color internal/ztest
 
 # The linting tools evolve with each Go version, so run them only on the latest
 # stable release.

--- a/benchmarks/zap_test.go
+++ b/benchmarks/zap_test.go
@@ -27,8 +27,8 @@ import (
 
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+	"go.uber.org/zap/internal/ztest"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 )
 
 var (
@@ -110,7 +110,7 @@ func newZapLogger(lvl zapcore.Level) *zap.Logger {
 	enc := zapcore.NewJSONEncoder(ec)
 	return zap.New(zapcore.NewCore(
 		enc,
-		&zaptest.Discarder{},
+		&ztest.Discarder{},
 		lvl,
 	))
 }

--- a/global_test.go
+++ b/global_test.go
@@ -27,9 +27,9 @@ import (
 	"time"
 
 	"go.uber.org/zap/internal/exit"
+	"go.uber.org/zap/internal/ztest"
 
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
@@ -89,7 +89,7 @@ func TestGlobalsConcurrentUse(t *testing.T) {
 		}()
 	}
 
-	zaptest.Sleep(100 * time.Millisecond)
+	ztest.Sleep(100 * time.Millisecond)
 	stop.Toggle()
 	wg.Wait()
 }

--- a/internal/ztest/doc.go
+++ b/internal/ztest/doc.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package ztest provides low-level helpers for testing log output. These
+// utilities are helpful in zap's own unit tests, but any assertions using
+// them are strongly coupled to a single encoding.
+package ztest // import "go.uber.org/zap/internal/ztest"

--- a/internal/ztest/timeout.go
+++ b/internal/ztest/timeout.go
@@ -39,13 +39,21 @@ func Sleep(base time.Duration) {
 	time.Sleep(Timeout(base))
 }
 
+// Initialize checks the environment and alters the timeout scale accordingly.
+// It returns a function to undo the scaling.
+func Initialize(factor string) func() {
+	original := _timeoutScale
+	fv, err := strconv.ParseFloat(factor, 64)
+	if err != nil {
+		panic(err)
+	}
+	_timeoutScale = fv
+	return func() { _timeoutScale = original }
+}
+
 func init() {
 	if v := os.Getenv("TEST_TIMEOUT_SCALE"); v != "" {
-		fv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			panic(err)
-		}
-		_timeoutScale = fv
+		Initialize(v)
 		log.Printf("Scaling timeouts by %vx.\n", _timeoutScale)
 	}
 }

--- a/internal/ztest/timeout.go
+++ b/internal/ztest/timeout.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ztest
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"time"
+)
+
+var _timeoutScale = 1.0
+
+// Timeout scales the provided duration by $TEST_TIMEOUT_SCALE.
+func Timeout(base time.Duration) time.Duration {
+	return time.Duration(float64(base) * _timeoutScale)
+}
+
+// Sleep scales the sleep duration by $TEST_TIMEOUT_SCALE.
+func Sleep(base time.Duration) {
+	time.Sleep(Timeout(base))
+}
+
+func init() {
+	if v := os.Getenv("TEST_TIMEOUT_SCALE"); v != "" {
+		fv, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			panic(err)
+		}
+		_timeoutScale = fv
+		log.Printf("Scaling timeouts by %vx.\n", _timeoutScale)
+	}
+}

--- a/internal/ztest/writer.go
+++ b/internal/ztest/writer.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ztest
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"strings"
+)
+
+// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
+type Syncer struct {
+	err    error
+	called bool
+}
+
+// SetError sets the error that the Sync method will return.
+func (s *Syncer) SetError(err error) {
+	s.err = err
+}
+
+// Sync records that it was called, then returns the user-supplied error (if
+// any).
+func (s *Syncer) Sync() error {
+	s.called = true
+	return s.err
+}
+
+// Called reports whether the Sync method was called.
+func (s *Syncer) Called() bool {
+	return s.called
+}
+
+// A Discarder sends all writes to ioutil.Discard.
+type Discarder struct{ Syncer }
+
+// Write implements io.Writer.
+func (d *Discarder) Write(b []byte) (int, error) {
+	return ioutil.Discard.Write(b)
+}
+
+// FailWriter is a WriteSyncer that always returns an error on writes.
+type FailWriter struct{ Syncer }
+
+// Write implements io.Writer.
+func (w FailWriter) Write(b []byte) (int, error) {
+	return len(b), errors.New("failed")
+}
+
+// ShortWriter is a WriteSyncer whose write method never fails, but
+// nevertheless fails to the last byte of the input.
+type ShortWriter struct{ Syncer }
+
+// Write implements io.Writer.
+func (w ShortWriter) Write(b []byte) (int, error) {
+	return len(b) - 1, nil
+}
+
+// Buffer is an implementation of zapcore.WriteSyncer that sends all writes to
+// a bytes.Buffer. It has convenience methods to split the accumulated buffer
+// on newlines.
+type Buffer struct {
+	bytes.Buffer
+	Syncer
+}
+
+// Lines returns the current buffer contents, split on newlines.
+func (b *Buffer) Lines() []string {
+	output := strings.Split(b.String(), "\n")
+	return output[:len(output)-1]
+}
+
+// Stripped returns the current buffer contents with the last trailing newline
+// stripped.
+func (b *Buffer) Stripped() string {
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap/internal/ztest"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 )
 
 type user struct {
@@ -52,7 +52,7 @@ func withBenchedLogger(b *testing.B, f func(*Logger)) {
 	logger := New(
 		zapcore.NewCore(
 			zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
-			&zaptest.Discarder{},
+			&ztest.Discarder{},
 			DebugLevel,
 		))
 	b.ResetTimer()
@@ -166,7 +166,7 @@ func BenchmarkAddCallerHook(b *testing.B) {
 	logger := New(
 		zapcore.NewCore(
 			zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
-			&zaptest.Discarder{},
+			&ztest.Discarder{},
 			InfoLevel,
 		),
 		AddCaller(),
@@ -200,7 +200,7 @@ func Benchmark100Fields(b *testing.B) {
 	const batchSize = 50
 	logger := New(zapcore.NewCore(
 		zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
-		&zaptest.Discarder{},
+		&ztest.Discarder{},
 		DebugLevel,
 	))
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 
 	"go.uber.org/zap/internal/exit"
+	"go.uber.org/zap/internal/ztest"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
@@ -298,11 +298,11 @@ func TestLoggerNames(t *testing.T) {
 }
 
 func TestLoggerWriteFailure(t *testing.T) {
-	errSink := &zaptest.Buffer{}
+	errSink := &ztest.Buffer{}
 	logger := New(
 		zapcore.NewCore(
 			zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
-			zapcore.Lock(zapcore.AddSync(zaptest.FailWriter{})),
+			zapcore.Lock(zapcore.AddSync(ztest.FailWriter{})),
 			DebugLevel,
 		),
 		ErrorOutput(errSink),
@@ -322,7 +322,7 @@ func TestLoggerSync(t *testing.T) {
 }
 
 func TestLoggerSyncFail(t *testing.T) {
-	noSync := &zaptest.Buffer{}
+	noSync := &ztest.Buffer{}
 	err := errors.New("fail")
 	noSync.SetError(err)
 	logger := New(zapcore.NewCore(
@@ -362,7 +362,7 @@ func TestLoggerAddCaller(t *testing.T) {
 }
 
 func TestLoggerAddCallerFail(t *testing.T) {
-	errBuf := &zaptest.Buffer{}
+	errBuf := &ztest.Buffer{}
 	withLogger(t, DebugLevel, opts(AddCaller(), ErrorOutput(errBuf)), func(log *Logger, logs *observer.ObservedLogs) {
 		log.callerSkip = 1e3
 		log.Info("Failure.")

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 
 	"go.uber.org/zap/internal/exit"
+	"go.uber.org/zap/internal/ztest"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
@@ -356,7 +356,7 @@ func TestSugarAddCaller(t *testing.T) {
 }
 
 func TestSugarAddCallerFail(t *testing.T) {
-	errBuf := &zaptest.Buffer{}
+	errBuf := &ztest.Buffer{}
 	withSugar(t, DebugLevel, opts(AddCaller(), AddCallerSkip(1e3), ErrorOutput(errBuf)), func(log *SugaredLogger, logs *observer.ObservedLogs) {
 		log.Info("Failure.")
 		assert.Regexp(

--- a/zapcore/core_test.go
+++ b/zapcore/core_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap/internal/ztest"
 	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,7 +106,7 @@ func TestIOCore(t *testing.T) {
 }
 
 func TestIOCoreSyncFail(t *testing.T) {
-	sink := &zaptest.Discarder{}
+	sink := &ztest.Discarder{}
 	err := errors.New("failed")
 	sink.SetError(err)
 
@@ -139,7 +139,7 @@ func TestIOCoreSyncsOutput(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		sink := &zaptest.Discarder{}
+		sink := &ztest.Discarder{}
 		core := NewCore(
 			NewJSONEncoder(testEncoderConfig()),
 			sink,
@@ -154,7 +154,7 @@ func TestIOCoreSyncsOutput(t *testing.T) {
 func TestIOCoreWriteFailure(t *testing.T) {
 	core := NewCore(
 		NewJSONEncoder(testEncoderConfig()),
-		Lock(&zaptest.FailWriter{}),
+		Lock(&ztest.FailWriter{}),
 		DebugLevel,
 	)
 	err := core.Write(Entry{}, nil)

--- a/zapcore/sampler_bench_test.go
+++ b/zapcore/sampler_bench_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap/internal/ztest"
 	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 )
 
 var counterTestCases = [][]string{
@@ -206,7 +206,7 @@ func BenchmarkSampler_Check(b *testing.B) {
 			fac := NewSampler(
 				NewCore(
 					NewJSONEncoder(testEncoderConfig()),
-					&zaptest.Discarder{},
+					&ztest.Discarder{},
 					DebugLevel,
 				),
 				time.Millisecond, 1, 1000)

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -27,8 +27,8 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
+	"go.uber.org/zap/internal/ztest"
 	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
@@ -105,7 +105,7 @@ func TestSamplerTicking(t *testing.T) {
 		for i := 1; i <= 5; i++ {
 			writeSequence(sampler, i, InfoLevel)
 		}
-		zaptest.Sleep(15 * time.Millisecond)
+		ztest.Sleep(15 * time.Millisecond)
 	}
 	assertSequence(
 		t,
@@ -121,7 +121,7 @@ func TestSamplerTicking(t *testing.T) {
 		for i := 1; i < 18; i++ {
 			writeSequence(sampler, i, InfoLevel)
 		}
-		zaptest.Sleep(10 * time.Millisecond)
+		ztest.Sleep(10 * time.Millisecond)
 	}
 
 	assertSequence(
@@ -160,7 +160,7 @@ func TestSamplerConcurrent(t *testing.T) {
 		expectedCount = numMessages * logsPerTick * numTicks
 	)
 
-	tick := zaptest.Timeout(10 * time.Millisecond)
+	tick := ztest.Timeout(10 * time.Millisecond)
 	cc := &countingCore{}
 	sampler := NewSampler(cc, tick, logsPerTick, 100000)
 

--- a/zapcore/tee_logger_bench_test.go
+++ b/zapcore/tee_logger_bench_test.go
@@ -23,14 +23,14 @@ package zapcore_test
 import (
 	"testing"
 
+	"go.uber.org/zap/internal/ztest"
 	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 )
 
 func withBenchedTee(b *testing.B, f func(Core)) {
 	fac := NewTee(
-		NewCore(NewJSONEncoder(testEncoderConfig()), &zaptest.Discarder{}, DebugLevel),
-		NewCore(NewJSONEncoder(testEncoderConfig()), &zaptest.Discarder{}, InfoLevel),
+		NewCore(NewJSONEncoder(testEncoderConfig()), &ztest.Discarder{}, DebugLevel),
+		NewCore(NewJSONEncoder(testEncoderConfig()), &ztest.Discarder{}, InfoLevel),
 	)
 	b.ResetTimer()
 	f(fac)

--- a/zapcore/tee_test.go
+++ b/zapcore/tee_test.go
@@ -24,8 +24,8 @@ import (
 	"errors"
 	"testing"
 
+	"go.uber.org/zap/internal/ztest"
 	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
@@ -139,7 +139,7 @@ func TestTeeSync(t *testing.T) {
 	tee := NewTee(infoLogger, warnLogger)
 	assert.NoError(t, tee.Sync(), "Unexpected error from Syncing a tee.")
 
-	sink := &zaptest.Discarder{}
+	sink := &ztest.Discarder{}
 	err := errors.New("failed")
 	sink.SetError(err)
 

--- a/zapcore/write_syncer_bench_test.go
+++ b/zapcore/write_syncer_bench_test.go
@@ -23,14 +23,14 @@ package zapcore
 import (
 	"testing"
 
-	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/internal/ztest"
 )
 
 func BenchmarkMultiWriteSyncer(b *testing.B) {
 	b.Run("2", func(b *testing.B) {
 		w := NewMultiWriteSyncer(
-			&zaptest.Discarder{},
-			&zaptest.Discarder{},
+			&ztest.Discarder{},
+			&ztest.Discarder{},
 		)
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
@@ -41,10 +41,10 @@ func BenchmarkMultiWriteSyncer(b *testing.B) {
 	})
 	b.Run("4", func(b *testing.B) {
 		w := NewMultiWriteSyncer(
-			&zaptest.Discarder{},
-			&zaptest.Discarder{},
-			&zaptest.Discarder{},
-			&zaptest.Discarder{},
+			&ztest.Discarder{},
+			&ztest.Discarder{},
+			&ztest.Discarder{},
+			&ztest.Discarder{},
 		)
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {

--- a/zaptest/timeout.go
+++ b/zaptest/timeout.go
@@ -21,31 +21,25 @@
 package zaptest
 
 import (
-	"log"
-	"os"
-	"strconv"
 	"time"
+
+	"go.uber.org/zap/internal/ztest"
 )
 
-var _timeoutScale = 1.0
-
 // Timeout scales the provided duration by $TEST_TIMEOUT_SCALE.
+//
+// Deprecated: This function is intended for internal testing and shouldn't be
+// used outside zap itself. It was introduced before Go supported internal
+// packages.
 func Timeout(base time.Duration) time.Duration {
-	return time.Duration(float64(base) * _timeoutScale)
+	return ztest.Timeout(base)
 }
 
 // Sleep scales the sleep duration by $TEST_TIMEOUT_SCALE.
+//
+// Deprecated: This function is intended for internal testing and shouldn't be
+// used outside zap itself. It was introduced before Go supported internal
+// packages.
 func Sleep(base time.Duration) {
-	time.Sleep(Timeout(base))
-}
-
-func init() {
-	if v := os.Getenv("TEST_TIMEOUT_SCALE"); v != "" {
-		fv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			panic(err)
-		}
-		_timeoutScale = fv
-		log.Printf("Scaling timeouts by %vx.\n", _timeoutScale)
-	}
+	ztest.Sleep(base)
 }

--- a/zaptest/timeout_test.go
+++ b/zaptest/timeout_test.go
@@ -18,5 +18,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package zaptest provides a variety of helpers for testing log output.
-package zaptest // import "go.uber.org/zap/zaptest"
+package zaptest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/internal/ztest"
+)
+
+func TestTimeout(t *testing.T) {
+	defer ztest.Initialize("2")()
+	assert.Equal(t, time.Duration(100), Timeout(50), "Expected to scale up timeout.")
+}
+
+func TestSleep(t *testing.T) {
+	defer ztest.Initialize("2")()
+	const sleepFor = 50 * time.Millisecond
+	now := time.Now()
+	Sleep(sleepFor)
+	elapsed := time.Since(now)
+	assert.True(t, 2*sleepFor <= elapsed, "Expected to scale up timeout.")
+}

--- a/zaptest/writer.go
+++ b/zaptest/writer.go
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// +build !go1.9
+
 package zaptest
 
 import (

--- a/zaptest/writer_go_19.go
+++ b/zaptest/writer_go_19.go
@@ -18,5 +18,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package zaptest provides a variety of helpers for testing log output.
-package zaptest // import "go.uber.org/zap/zaptest"
+// Type aliases are available only in Go 1.9 and later.
+// +build go1.9
+
+package zaptest
+
+import "go.uber.org/zap/internal/ztest"
+
+type (
+	// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
+	Syncer = ztest.Syncer
+
+	// A Discarder sends all writes to ioutil.Discard.
+	Discarder = ztest.Discarder
+
+	// FailWriter is a WriteSyncer that always returns an error on writes.
+	FailWriter = ztest.FailWriter
+
+	// ShortWriter is a WriteSyncer whose write method never fails, but
+	// nevertheless fails to the last byte of the input.
+	ShortWriter = ztest.ShortWriter
+
+	// Buffer is an implementation of zapcore.WriteSyncer that sends all writes to
+	// a bytes.Buffer. It has convenience methods to split the accumulated buffer
+	// on newlines.
+	Buffer = ztest.Buffer
+)

--- a/zaptest/writer_test.go
+++ b/zaptest/writer_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func readCode(t testing.TB, fname string) []string {
+	f, err := os.Open(fname)
+	require.NoError(t, err, "Failed to read %s.", fname)
+	defer func() {
+		require.NoError(t, f.Close(), "Error closing file %s.", fname)
+	}()
+
+	var lines []string
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		l := s.Text()
+		if len(l) == 0 {
+			continue
+		}
+		if strings.HasPrefix(l, "//") {
+			continue
+		}
+		if strings.HasPrefix(l, "package ") {
+			continue
+		}
+		lines = append(lines, l)
+	}
+	return lines
+}
+
+func TestCopiedCodeInSync(t *testing.T) {
+	// Until we drop Go 1.8 support, we need to keep a near-exact copy of the
+	// ztest package's WriteSyncer test spies in zaptest. This test ensures that
+	// the two files stay in sync.
+	assert.Equal(t,
+		readCode(t, "../internal/ztest/writer.go"),
+		readCode(t, "writer.go"),
+		"Writer spy implementations in zaptest and internal/ztest should be identical.",
+	)
+}
+
+func TestSyncer(t *testing.T) {
+	err := errors.New("sentinel")
+	s := &Syncer{}
+	s.SetError(err)
+	assert.Equal(t, err, s.Sync(), "Expected Sync to fail with provided error.")
+	assert.True(t, s.Called(), "Expected to record that Sync was called.")
+}
+
+func TestDiscarder(t *testing.T) {
+	d := &Discarder{}
+	payload := []byte("foo")
+	n, err := d.Write(payload)
+	assert.NoError(t, err, "Unexpected error writing to Discarder.")
+	assert.Equal(t, len(payload), n, "Wrong number of bytes written.")
+}
+
+func TestFailWriter(t *testing.T) {
+	w := &FailWriter{}
+	payload := []byte("foo")
+	n, err := w.Write(payload)
+	assert.Error(t, err, "Expected an error writing to FailWriter.")
+	assert.Equal(t, len(payload), n, "Wrong number of bytes written.")
+}
+
+func TestShortWriter(t *testing.T) {
+	w := &ShortWriter{}
+	payload := []byte("foo")
+	n, err := w.Write(payload)
+	assert.NoError(t, err, "Unexpected error writing to ShortWriter.")
+	assert.Equal(t, len(payload)-1, n, "Wrong number of bytes written.")
+}
+
+func TestBuffer(t *testing.T) {
+	buf := &Buffer{}
+	buf.WriteString("foo\n")
+	buf.WriteString("bar\n")
+	assert.Equal(t, []string{"foo", "bar"}, buf.Lines(), "Unexpected output from Lines.")
+	assert.Equal(t, "foo\nbar", buf.Stripped(), "Unexpected output from Stripped.")
+}


### PR DESCRIPTION
In order to introduce new testing helpers into the `zaptest` package, where users will expect to find them, we need to break the dependency between `zap` and `zaptest`. (Unfortunately, we introduced `zaptest` before Go supported internal packages and squatted on the best user-facing name.)

This PR can be reviewed commit-by-commit if necessary. It makes a wordy, but logically simple series of changes: we copy the `zaptest` package to `internal/ztest`, change the rest of `zap` to use the new internal helpers, and finally convert `zaptest` to a shim around the internal helpers. In Go 1.9, we use type aliases to also clean up the documentation (aliases don't have their methods documented); for older Go versions, we leave a copy of the original code and a test to make sure that the two versions don't drift out of sync.

This should make #518 much nicer. Since it begins using type aliases, it depends on #524.