### PR TITLE
Lint on Go 1.9, drop 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: go
 sudo: false
 go:
-  - 1.7
   - 1.8
   - 1.9
 go_import_path: go.uber.org/zap
 env:
   global:
-    - GO15VENDOREXPERIMENT=1
     - TEST_TIMEOUT_SCALE=10
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PKG_FILES ?= *.go zapcore benchmarks buffer zapgrpc zaptest zaptest/observer int
 # stable release.
 GO_VERSION := $(shell go version | cut -d " " -f 3)
 GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
-LINTABLE_MINOR_VERSIONS := 8
+LINTABLE_MINOR_VERSIONS := 9
 ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 SHOULD_LINT := true
 endif


### PR DESCRIPTION
We're already building on Go 1.9; now that it's been out for a bit,
start running the linters there too. Since we're only committed to
supporting the last two releases, drop 1.7 to speed up Travis runs.

Fixes #509.