### PR TITLE
Updated github.com/rs/zerolog and added some new tests for it

### DIFF
--- a/benchmarks/scenario_bench_test.go
+++ b/benchmarks/scenario_bench_test.go
@@ -95,6 +95,17 @@ func BenchmarkDisabledWithoutFields(b *testing.B) {
 			}
 		})
 	})
+	b.Run("rs/zerolog.Check", func(b *testing.B) {
+		logger := newDisabledZerolog()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if e := logger.Info(); e != nil {
+					e.Msg(getMessage(0))
+				}
+			}
+		})
+	})
 }
 
 func BenchmarkDisabledAccumulatedContext(b *testing.B) {
@@ -164,6 +175,17 @@ func BenchmarkDisabledAccumulatedContext(b *testing.B) {
 			}
 		})
 	})
+	b.Run("rs/zerolog.Check", func(b *testing.B) {
+		logger := fakeZerologContext(newDisabledZerolog().With()).Logger()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if e := logger.Info(); e != nil {
+					e.Msg(getMessage(0))
+				}
+			}
+		})
+	})
 }
 
 func BenchmarkDisabledAddingFields(b *testing.B) {
@@ -221,6 +243,17 @@ func BenchmarkDisabledAddingFields(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				fakeZerologFields(logger.Info()).Msg(getMessage(0))
+			}
+		})
+	})
+	b.Run("rs/zerolog.Check", func(b *testing.B) {
+		logger := newDisabledZerolog()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				if e := logger.Info(); e != nil {
+					fakeZerologFields(e).Msg(getMessage(0))
+				}
 			}
 		})
 	})
@@ -365,8 +398,21 @@ func BenchmarkWithoutFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				if e := logger.Info(); e.Enabled() {
+				if e := logger.Info(); e != nil {
 					e.Msg(getMessage(0))
+				}
+			}
+		})
+	})
+	b.Run("rs/zerolog.CheckSampled", func(b *testing.B) {
+		logger := newSampledZerolog()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				i++
+				if e := logger.Info(); e != nil {
+					e.Msg(getMessage(i))
 				}
 			}
 		})
@@ -485,8 +531,21 @@ func BenchmarkAccumulatedContext(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				if e := logger.Info(); e.Enabled() {
+				if e := logger.Info(); e != nil {
 					e.Msg(getMessage(0))
+				}
+			}
+		})
+	})
+	b.Run("rs/zerolog.CheckSampled", func(b *testing.B) {
+		logger := fakeZerologContext(newSampledZerolog().With()).Logger()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				i++
+				if e := logger.Info(); e != nil {
+					e.Msg(getMessage(i))
 				}
 			}
 		})
@@ -605,8 +664,21 @@ func BenchmarkAddingFields(b *testing.B) {
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				if e := logger.Info(); e.Enabled() {
+				if e := logger.Info(); e != nil {
 					fakeZerologFields(e).Msg(getMessage(0))
+				}
+			}
+		})
+	})
+	b.Run("rs/zerolog.CheckSampled", func(b *testing.B) {
+		logger := newSampledZerolog()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				i++
+				if e := logger.Info(); e != nil {
+					fakeZerologFields(e).Msg(getMessage(i))
 				}
 			}
 		})

--- a/benchmarks/zerolog_test.go
+++ b/benchmarks/zerolog_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 
 	"github.com/rs/zerolog"
+	"time"
 )
 
 func newZerolog() zerolog.Logger {
@@ -32,6 +33,13 @@ func newZerolog() zerolog.Logger {
 
 func newDisabledZerolog() zerolog.Logger {
 	return newZerolog().Level(zerolog.Disabled)
+}
+
+func newSampledZerolog() zerolog.Logger {
+	return newZerolog().Sample(&zerolog.BurstSampler{
+		Burst:  10,
+		Period: 100 * time.Millisecond,
+	})
 }
 
 func fakeZerologFields(e *zerolog.Event) *zerolog.Event {


### PR DESCRIPTION
Got these results with this code:

```
BenchmarkDisabledWithoutFields/Zap-8            200000000                8.58 ns/op            0 B/op          0 allocs/op
BenchmarkDisabledWithoutFields/Zap.Check-8              200000000                8.11 ns/op            0 B/op          0 allocs/op
BenchmarkDisabledWithoutFields/Zap.Sugar-8              100000000               15.6 ns/op            16 B/op          1 allocs/op
BenchmarkDisabledWithoutFields/Zap.SugarFormatting-8            20000000                98.0 ns/op           184 B/op          7 allocs/op
BenchmarkDisabledWithoutFields/apex/log-8                       500000000                2.99 ns/op            0 B/op          0 allocs/op
BenchmarkDisabledWithoutFields/sirupsen/logrus-8                100000000               12.3 ns/op            16 B/op          1 allocs/op
BenchmarkDisabledWithoutFields/rs/zerolog-8                     500000000                3.28 ns/op            0 B/op          0 allocs/op
BenchmarkDisabledWithoutFields/rs/zerolog.Check-8               1000000000               2.06 ns/op            0 B/op          0 allocs/op
BenchmarkDisabledAccumulatedContext/Zap-8                       200000000                8.41 ns/op            0 B/op          0 allocs/op
BenchmarkDisabledAccumulatedContext/Zap.Check-8                 200000000                8.15 ns/op            0 B/op          0 allocs/op
BenchmarkDisabledAccumulatedContext/Zap.Sugar-8                 100000000               16.0 ns/op            16 B/op          1 allocs/op
BenchmarkDisabledAccumulatedContext/Zap.SugarFormatting-8       20000000                99.8 ns/op           184 B/op          7 allocs/op
BenchmarkDisabledAccumulatedContext/apex/log-8                  2000000000               1.79 ns/op            0 B/op          0 allocs/op
BenchmarkDisabledAccumulatedContext/sirupsen/logrus-8           100000000               13.0 ns/op            16 B/op          1 allocs/op
BenchmarkDisabledAccumulatedContext/rs/zerolog-8                500000000                3.26 ns/op            0 B/op          0 allocs/op
BenchmarkDisabledAccumulatedContext/rs/zerolog.Check-8          1000000000               2.07 ns/op            0 B/op          0 allocs/op
BenchmarkDisabledAddingFields/Zap-8                             10000000               218 ns/op             768 B/op          5 allocs/op
BenchmarkDisabledAddingFields/Zap.Check-8                       200000000                8.35 ns/op            0 B/op          0 allocs/op
BenchmarkDisabledAddingFields/Zap.Sugar-8                       20000000               105 ns/op             184 B/op          7 allocs/op
BenchmarkDisabledAddingFields/apex/log-8                         5000000               397 ns/op             934 B/op         11 allocs/op
BenchmarkDisabledAddingFields/sirupsen/logrus-8                  2000000               768 ns/op            1541 B/op         13 allocs/op
BenchmarkDisabledAddingFields/rs/zerolog-8                      20000000                79.0 ns/op           128 B/op          4 allocs/op
BenchmarkDisabledAddingFields/rs/zerolog.Check-8                1000000000               2.23 ns/op            0 B/op          0 allocs/op
BenchmarkWithoutFields/Zap-8                                    10000000               286 ns/op               0 B/op          0 allocs/op
BenchmarkWithoutFields/Zap.Check-8                              10000000               298 ns/op               0 B/op          0 allocs/op
BenchmarkWithoutFields/Zap.CheckSampled-8                       20000000                56.5 ns/op             0 B/op          0 allocs/op
BenchmarkWithoutFields/Zap.Sugar-8                               5000000               364 ns/op              80 B/op          2 allocs/op
BenchmarkWithoutFields/Zap.SugarFormatting-8                      200000              6534 ns/op            2068 B/op         59 allocs/op
BenchmarkWithoutFields/apex/log-8                                 300000              5760 ns/op             576 B/op         10 allocs/op
BenchmarkWithoutFields/go-kit/kit/log-8                          3000000               525 ns/op             640 B/op         11 allocs/op
BenchmarkWithoutFields/inconshreveable/log15-8                    200000             10246 ns/op            1792 B/op         24 allocs/op
BenchmarkWithoutFields/sirupsen/logrus-8                         1000000              1410 ns/op            1474 B/op         23 allocs/op
BenchmarkWithoutFields/go.pedge.io/lion-8                        2000000               868 ns/op            1217 B/op          9 allocs/op
BenchmarkWithoutFields/stdlib.Println-8                          2000000               608 ns/op              80 B/op          2 allocs/op
BenchmarkWithoutFields/stdlib.Printf-8                            300000              5086 ns/op            2058 B/op         59 allocs/op
BenchmarkWithoutFields/rs/zerolog-8                             10000000               183 ns/op               0 B/op          0 allocs/op
BenchmarkWithoutFields/rs/zerolog.Formatting-8                    200000              5783 ns/op            2059 B/op         59 allocs/op
BenchmarkWithoutFields/rs/zerolog.Check-8                       10000000               180 ns/op               0 B/op          0 allocs/op
BenchmarkWithoutFields/rs/zerolog.CheckSampled-8                50000000                33.8 ns/op             0 B/op          0 allocs/op
BenchmarkAccumulatedContext/Zap-8                                5000000               280 ns/op               0 B/op          0 allocs/op
BenchmarkAccumulatedContext/Zap.Check-8                          5000000               308 ns/op               0 B/op          0 allocs/op
BenchmarkAccumulatedContext/Zap.CheckSampled-8                  20000000                60.8 ns/op             0 B/op          0 allocs/op
BenchmarkAccumulatedContext/Zap.Sugar-8                          5000000               373 ns/op              80 B/op          2 allocs/op
BenchmarkAccumulatedContext/Zap.SugarFormatting-8                 200000              6569 ns/op            2078 B/op         59 allocs/op
BenchmarkAccumulatedContext/apex/log-8                             30000             47498 ns/op            6564 B/op        104 allocs/op
BenchmarkAccumulatedContext/go-kit/kit/log-8                      200000             10496 ns/op            6706 B/op        103 allocs/op
BenchmarkAccumulatedContext/inconshreveable/log15-8                50000             33850 ns/op            3986 B/op         75 allocs/op
BenchmarkAccumulatedContext/sirupsen/logrus-8                     100000             12904 ns/op           12500 B/op        116 allocs/op
BenchmarkAccumulatedContext/go.pedge.io/lion-8                    500000              3520 ns/op            5862 B/op         37 allocs/op
BenchmarkAccumulatedContext/rs/zerolog-8                        10000000               190 ns/op               0 B/op          0 allocs/op
BenchmarkAccumulatedContext/rs/zerolog.Check-8                  10000000               194 ns/op               0 B/op          0 allocs/op
BenchmarkAccumulatedContext/rs/zerolog.CheckSampled-8           50000000                33.6 ns/op             0 B/op          0 allocs/op
BenchmarkAccumulatedContext/rs/zerolog.Formatting-8               300000              5633 ns/op            2059 B/op         59 allocs/op
BenchmarkAddingFields/Zap-8                                      1000000              2291 ns/op             771 B/op          5 allocs/op
BenchmarkAddingFields/Zap.Check-8                                1000000              2332 ns/op             771 B/op          5 allocs/op
BenchmarkAddingFields/Zap.CheckSampled-8                         5000000               319 ns/op              96 B/op          0 allocs/op
BenchmarkAddingFields/Zap.Sugar-8                                 500000              2717 ns/op            1567 B/op         11 allocs/op
BenchmarkAddingFields/apex/log-8                                   30000             50556 ns/op            7503 B/op        115 allocs/op
BenchmarkAddingFields/go-kit/kit/log-8                            200000             10084 ns/op            6385 B/op        105 allocs/op
BenchmarkAddingFields/inconshreveable/log15-8                      30000             47531 ns/op            7664 B/op        127 allocs/op
BenchmarkAddingFields/sirupsen/logrus-8                           100000             13677 ns/op           14039 B/op        128 allocs/op
BenchmarkAddingFields/go.pedge.io/lion-8                          200000             10276 ns/op            9317 B/op        109 allocs/op
BenchmarkAddingFields/rs/zerolog-8                                200000             10136 ns/op            8515 B/op         84 allocs/op
BenchmarkAddingFields/rs/zerolog.Check-8                          200000             10241 ns/op            8515 B/op         84 allocs/op
BenchmarkAddingFields/rs/zerolog.CheckSampled-8                 50000000                27.7 ns/op             0 B/op          0 allocs/op
```

@rs you may want to update the zerolog's readme as well.