### PR TITLE
Implementing grpclog.LoggerV2 compatible logger

### DIFF
--- a/zapgrpc/zapgrpc_test.go
+++ b/zapgrpc/zapgrpc_test.go
@@ -35,7 +35,13 @@ func TestLoggerInfoExpected(t *testing.T) {
 		"hello",
 		"world",
 		"foo",
+		"hello",
+		"world",
+		"foo",
 	}, func(logger *Logger) {
+		logger.Info("hello")
+		logger.Infof("world")
+		logger.Infoln("foo")
 		logger.Print("hello")
 		logger.Printf("world")
 		logger.Println("foo")
@@ -62,6 +68,30 @@ func TestLoggerDebugSuppressed(t *testing.T) {
 	})
 }
 
+func TestLoggerWarnExpected(t *testing.T) {
+	checkMessages(t, zapcore.DebugLevel, nil, zapcore.WarnLevel, []string{
+		"hello",
+		"world",
+		"foo",
+	}, func(logger *Logger) {
+		logger.Warning("hello")
+		logger.Warningf("world")
+		logger.Warningln("foo")
+	})
+}
+
+func TestLoggerErrorExpected(t *testing.T) {
+	checkMessages(t, zapcore.DebugLevel, nil, zapcore.ErrorLevel, []string{
+		"hello",
+		"world",
+		"foo",
+	}, func(logger *Logger) {
+		logger.Error("hello")
+		logger.Errorf("world")
+		logger.Errorln("foo")
+	})
+}
+
 func TestLoggerFatalExpected(t *testing.T) {
 	checkMessages(t, zapcore.DebugLevel, nil, zapcore.FatalLevel, []string{
 		"hello",
@@ -71,6 +101,30 @@ func TestLoggerFatalExpected(t *testing.T) {
 		logger.Fatal("hello")
 		logger.Fatalf("world")
 		logger.Fatalln("foo")
+	})
+}
+
+func TestLoggerTrueExpected(t *testing.T) {
+	checkLevel(t, zapcore.FatalLevel, true, func(logger *Logger) bool {
+		return logger.V(6)
+	})
+}
+
+func TestLoggerFalseExpected(t *testing.T) {
+	checkLevel(t, zapcore.FatalLevel, false, func(logger *Logger) bool {
+		return logger.V(0)
+	})
+}
+
+func checkLevel(
+	t testing.TB,
+	enab zapcore.LevelEnabler,
+	expectedBool bool,
+	f func(*Logger) bool,
+) {
+	withLogger(enab, nil, func(logger *Logger, observedLogs *observer.ObservedLogs) {
+		actualBool := f(logger)
+		require.Equal(t, expectedBool, actualBool)
 	})
 }
 


### PR DESCRIPTION
Currently, `go.uber.org/zap/zapgrpc.Logger` only provides an implementation for `grpclog.Logger`. With the release of `grpclog.LoggerV2`, an updated implementation is needed so that `go.uber.org/zap/zapgrpc.Logger` implements both `grpclog.Logger` and `grpclog.LoggerV2`.

Fixes #534