### PR TITLE
Use t.Run for some encoder tests

### DIFF
--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -223,7 +223,9 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assertOutput(t, tt.desc, tt.expected, tt.f)
+		t.Run(tt.desc, func(t *testing.T) {
+			assertOutput(t, tt.desc, tt.expected, tt.f)
+		})
 	}
 }
 
@@ -314,16 +316,18 @@ func TestJSONEncoderArrays(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		f := func(enc Encoder) error {
-			return enc.AddArray("array", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
-				tt.f(arr)
-				tt.f(arr)
-				return nil
-			}))
-		}
-		assertOutput(t, tt.desc, `"array":`+tt.expected, func(enc Encoder) {
-			err := f(enc)
-			assert.NoError(t, err, "Unexpected error adding array to JSON encoder.")
+		t.Run(tt.desc, func(t *testing.T) {
+			f := func(enc Encoder) error {
+				return enc.AddArray("array", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
+					tt.f(arr)
+					tt.f(arr)
+					return nil
+				}))
+			}
+			assertOutput(t, tt.desc, `"array":`+tt.expected, func(enc Encoder) {
+				err := f(enc)
+				assert.NoError(t, err, "Unexpected error adding array to JSON encoder.")
+			})
 		})
 	}
 }

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -224,7 +224,7 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			assertOutput(t, tt.desc, tt.expected, tt.f)
+			assertOutput(t, tt.expected, tt.f)
 		})
 	}
 }
@@ -324,7 +324,7 @@ func TestJSONEncoderArrays(t *testing.T) {
 					return nil
 				}))
 			}
-			assertOutput(t, tt.desc, `"array":`+tt.expected, func(enc Encoder) {
+			assertOutput(t, `"array":`+tt.expected, func(enc Encoder) {
 				err := f(enc)
 				assert.NoError(t, err, "Unexpected error adding array to JSON encoder.")
 			})
@@ -336,13 +336,13 @@ func assertJSON(t *testing.T, expected string, enc *jsonEncoder) {
 	assert.Equal(t, expected, enc.buf.String(), "Encoded JSON didn't match expectations.")
 }
 
-func assertOutput(t testing.TB, desc string, expected string, f func(Encoder)) {
+func assertOutput(t testing.TB, expected string, f func(Encoder)) {
 	enc := &jsonEncoder{buf: bufferpool.Get(), EncoderConfig: &EncoderConfig{
 		EncodeTime:     EpochTimeEncoder,
 		EncodeDuration: SecondsDurationEncoder,
 	}}
 	f(enc)
-	assert.Equal(t, expected, enc.buf.String(), "Unexpected encoder output after adding a %s.", desc)
+	assert.Equal(t, expected, enc.buf.String(), "Unexpected encoder output after adding.")
 
 	enc.truncate()
 	enc.AddString("foo", "bar")
@@ -353,7 +353,7 @@ func assertOutput(t testing.TB, desc string, expected string, f func(Encoder)) {
 		// field.
 		expectedPrefix += ","
 	}
-	assert.Equal(t, expectedPrefix+expected, enc.buf.String(), "Unexpected encoder output after adding a %s as a second field.", desc)
+	assert.Equal(t, expectedPrefix+expected, enc.buf.String(), "Unexpected encoder output after adding as a second field.")
 }
 
 // Nested Array- and ObjectMarshalers.

--- a/zapcore/memory_encoder_test.go
+++ b/zapcore/memory_encoder_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMapObjectEncoderAdd(t *testing.T) {
@@ -204,9 +205,11 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		enc := NewMapObjectEncoder()
-		tt.f(enc)
-		assert.Equal(t, tt.expected, enc.Fields["k"], "Unexpected encoder output.")
+		t.Run(tt.desc, func(t *testing.T) {
+			enc := NewMapObjectEncoder()
+			tt.f(enc)
+			assert.Equal(t, tt.expected, enc.Fields["k"], "Unexpected encoder output.")
+		})
 	}
 }
 func TestSliceArrayEncoderAppend(t *testing.T) {
@@ -255,19 +258,18 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		enc := NewMapObjectEncoder()
-		assert.NoError(t, enc.AddArray("k", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
-			tt.f(arr)
-			tt.f(arr)
-			return nil
-		})), "Expected AddArray to succeed.")
+		t.Run(tt.desc, func(t *testing.T) {
+			enc := NewMapObjectEncoder()
+			assert.NoError(t, enc.AddArray("k", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
+				tt.f(arr)
+				tt.f(arr)
+				return nil
+			})), "Expected AddArray to succeed.")
 
-		arr, ok := enc.Fields["k"].([]interface{})
-		if !ok {
-			t.Errorf("Test case %s didn't encode an array.", tt.desc)
-			continue
-		}
-		assert.Equal(t, []interface{}{tt.expected, tt.expected}, arr, "Unexpected encoder output.")
+			arr, ok := enc.Fields["k"].([]interface{})
+			require.True(t, ok, "Test case %s didn't encode an array.", tt.desc)
+			assert.Equal(t, []interface{}{tt.expected, tt.expected}, arr, "Unexpected encoder output.")
+		})
 	}
 }
 


### PR DESCRIPTION
Wrap each encoder test case with t.Run for improved test output and
ability to selectively run specific sub tests.