### PR TITLE
zaptest: Expand TestingT interface

### DIFF
--- a/zaptest/testingt.go
+++ b/zaptest/testingt.go
@@ -29,6 +29,15 @@ type TestingT interface {
 	// Logs the given message and marks the test as failed.
 	Errorf(string, ...interface{})
 
+	// Marks the test as failed.
+	Fail()
+
+	// Returns true if the test has been marked as failed.
+	Failed() bool
+
+	// Returns the name of the test.
+	Name() string
+
 	// Marks the test as failed and stops execution of that test.
 	FailNow()
 }


### PR DESCRIPTION
This expands the TestingT interface to a much larger subset of
`testing.TB`.

The following were left out:

- `Error` and `Log` were left out in favor of `Errorf` and `Logf`
- `Fatal*` methods were left out in favor of `Errorf` followed by
  `FailNow`
- `Skip*` methods were left out because our test logger shouldn't be
  skipping tests
- `Helper` was left out because not all supported verisons of Go have
  that

I'm putting this in a separate PR so that we can discuss every included/omitted
method outside #518.

CC @akshayjshah @prashantv