### PR TITLE
Add Go import comments.

### DIFF
--- a/benchmarks/doc.go
+++ b/benchmarks/doc.go
@@ -20,4 +20,4 @@
 
 // Package benchmarks contains only benchmarks comparing zap to other
 // structured logging libraries.
-package benchmarks
+package benchmarks // import "go.uber.org/zap/benchmarks"

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -21,7 +21,7 @@
 // Package buffer provides a thin wrapper around a byte slice. Unlike the
 // standard library's bytes.Buffer, it supports a portion of the strconv
 // package's zero-allocation formatters.
-package buffer
+package buffer // import "go.uber.org/zap/buffer"
 
 import "strconv"
 

--- a/internal/bufferpool/bufferpool.go
+++ b/internal/bufferpool/bufferpool.go
@@ -20,7 +20,7 @@
 
 // Package bufferpool houses zap's shared internal buffer pool. Third-party
 // packages can recreate the same functionality with buffers.NewPool.
-package bufferpool
+package bufferpool // import "go.uber.org/zap/internal/bufferpool"
 
 import "go.uber.org/zap/buffer"
 

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 // Package color adds coloring functionality for TTY output.
-package color
+package color // import "go.uber.org/zap/internal/color"
 
 import "fmt"
 

--- a/internal/exit/exit.go
+++ b/internal/exit/exit.go
@@ -20,7 +20,7 @@
 
 // Package exit provides stubs so that unit tests can exercise code that calls
 // os.Exit(1).
-package exit
+package exit // import "go.uber.org/zap/internal/exit"
 
 import "os"
 


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in each package
to ensure that the package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
