### PR TITLE
Add missing import comment

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -21,7 +21,7 @@
 // Package buffer provides a thin wrapper around a byte slice. Unlike the
 // standard library's bytes.Buffer, it supports a portion of the strconv
 // package's zero-allocation formatters.
-package buffer
+package buffer // import "go.uber.org/zap/buffer"
 
 import "strconv"
 


### PR DESCRIPTION
We let one exposed package sneak through without an import comment.
There's no practical way for anyone to be using with the wrong import
path, but let's clean up anyways.