### PR TITLE
Add table of extensions to FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -135,6 +135,20 @@ core := zapcore.NewCore(
 logger := zap.New(core)
 ```
 
+## Extensions
+
+We'd love to support every logging need within zap itself, but we're only
+familiar with a handful of log ingestion systems, flag-parsing packages, and
+the like. Rather than merging code that we can't effectively debug and
+support, we'd rather grow an ecosystem of zap extensions.
+
+We're aware of the following extensions, but haven't used them ourselves:
+
+| Package | Integration |
+| --- | --- |
+| `github.com/tchap/zapext` | Sentry, syslog |
+| `github.com/fgrosse/zaptest` | Ginkgo |
+
 [go-proverbs]: https://go-proverbs.github.io/
 [import-path]: https://golang.org/cmd/go/#hdr-Remote_import_paths
 [lumberjack]: https://godoc.org/gopkg.in/natefinch/lumberjack.v2


### PR DESCRIPTION
As part of the discussion on https://github.com/uber-go/zap/issues/96,
it's clear that we need to make it easier for third-party packages to
extend zap's functionality. Some of that requires new APIs, but we'll
also need a way to refer people from the core zap package to the various
extensions.

This PR adds an FAQ entry that lists the extensions we're aware of. It's
currently a little hard to find (the GoDoc includes a link to the FAQ,
but it's not very prominent). We'll address that as part of a
documentation revamp later on.