### PR TITLE
Update tests to use zap.Field alias

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -52,7 +52,7 @@ func BenchmarkBoolsReflect(b *testing.B) {
 func TestArrayWrappers(t *testing.T) {
 	tests := []struct {
 		desc     string
-		field    zapcore.Field
+		field    Field
 		expected []interface{}
 	}{
 		{"empty bools", Bools("", []bool{}), []interface{}(nil)},

--- a/benchmarks/zap_test.go
+++ b/benchmarks/zap_test.go
@@ -124,8 +124,8 @@ func newSampledLogger(lvl zapcore.Level) *zap.Logger {
 	))
 }
 
-func fakeFields() []zapcore.Field {
-	return []zapcore.Field{
+func fakeFields() []zap.Field {
+	return []zap.Field{
 		zap.Int("int", _tenInts[0]),
 		zap.Ints("ints", _tenInts),
 		zap.String("string", _tenStrings[0]),

--- a/error_test.go
+++ b/error_test.go
@@ -36,13 +36,13 @@ func TestErrorConstructors(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		field  zapcore.Field
-		expect zapcore.Field
+		field  Field
+		expect Field
 	}{
 		{"Error", Skip(), Error(nil)},
-		{"Error", zapcore.Field{Key: "error", Type: zapcore.ErrorType, Interface: fail}, Error(fail)},
+		{"Error", Field{Key: "error", Type: zapcore.ErrorType, Interface: fail}, Error(fail)},
 		{"NamedError", Skip(), NamedError("foo", nil)},
-		{"NamedError", zapcore.Field{Key: "foo", Type: zapcore.ErrorType, Interface: fail}, NamedError("foo", fail)},
+		{"NamedError", Field{Key: "foo", Type: zapcore.ErrorType, Interface: fail}, NamedError("foo", fail)},
 		{"Any:Error", Any("k", errors.New("v")), NamedError("k", errors.New("v"))},
 		{"Any:Errors", Any("k", []error{errors.New("v")}), Errors("k", []error{errors.New("v")})},
 	}
@@ -58,7 +58,7 @@ func TestErrorConstructors(t *testing.T) {
 func TestErrorArrayConstructor(t *testing.T) {
 	tests := []struct {
 		desc     string
-		field    zapcore.Field
+		field    Field
 		expected []interface{}
 	}{
 		{"empty errors", Errors("", []error{}), []interface{}(nil)},

--- a/field_test.go
+++ b/field_test.go
@@ -37,7 +37,7 @@ func (n username) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	return nil
 }
 
-func assertCanBeReused(t testing.TB, field zapcore.Field) {
+func assertCanBeReused(t testing.TB, field Field) {
 	var wg sync.WaitGroup
 
 	for i := 0; i < 100; i++ {
@@ -65,34 +65,34 @@ func TestFieldConstructors(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		field  zapcore.Field
-		expect zapcore.Field
+		field  Field
+		expect Field
 	}{
-		{"Skip", zapcore.Field{Type: zapcore.SkipType}, Skip()},
-		{"Binary", zapcore.Field{Key: "k", Type: zapcore.BinaryType, Interface: []byte("ab12")}, Binary("k", []byte("ab12"))},
-		{"Bool", zapcore.Field{Key: "k", Type: zapcore.BoolType, Integer: 1}, Bool("k", true)},
-		{"Bool", zapcore.Field{Key: "k", Type: zapcore.BoolType, Integer: 1}, Bool("k", true)},
-		{"ByteString", zapcore.Field{Key: "k", Type: zapcore.ByteStringType, Interface: []byte("ab12")}, ByteString("k", []byte("ab12"))},
-		{"Complex128", zapcore.Field{Key: "k", Type: zapcore.Complex128Type, Interface: 1 + 2i}, Complex128("k", 1+2i)},
-		{"Complex64", zapcore.Field{Key: "k", Type: zapcore.Complex64Type, Interface: complex64(1 + 2i)}, Complex64("k", 1+2i)},
-		{"Duration", zapcore.Field{Key: "k", Type: zapcore.DurationType, Integer: 1}, Duration("k", 1)},
-		{"Int", zapcore.Field{Key: "k", Type: zapcore.Int64Type, Integer: 1}, Int("k", 1)},
-		{"Int64", zapcore.Field{Key: "k", Type: zapcore.Int64Type, Integer: 1}, Int64("k", 1)},
-		{"Int32", zapcore.Field{Key: "k", Type: zapcore.Int32Type, Integer: 1}, Int32("k", 1)},
-		{"Int16", zapcore.Field{Key: "k", Type: zapcore.Int16Type, Integer: 1}, Int16("k", 1)},
-		{"Int8", zapcore.Field{Key: "k", Type: zapcore.Int8Type, Integer: 1}, Int8("k", 1)},
-		{"String", zapcore.Field{Key: "k", Type: zapcore.StringType, String: "foo"}, String("k", "foo")},
-		{"Time", zapcore.Field{Key: "k", Type: zapcore.TimeType, Integer: 0, Interface: time.UTC}, Time("k", time.Unix(0, 0).In(time.UTC))},
-		{"Time", zapcore.Field{Key: "k", Type: zapcore.TimeType, Integer: 1000, Interface: time.UTC}, Time("k", time.Unix(0, 1000).In(time.UTC))},
-		{"Uint", zapcore.Field{Key: "k", Type: zapcore.Uint64Type, Integer: 1}, Uint("k", 1)},
-		{"Uint64", zapcore.Field{Key: "k", Type: zapcore.Uint64Type, Integer: 1}, Uint64("k", 1)},
-		{"Uint32", zapcore.Field{Key: "k", Type: zapcore.Uint32Type, Integer: 1}, Uint32("k", 1)},
-		{"Uint16", zapcore.Field{Key: "k", Type: zapcore.Uint16Type, Integer: 1}, Uint16("k", 1)},
-		{"Uint8", zapcore.Field{Key: "k", Type: zapcore.Uint8Type, Integer: 1}, Uint8("k", 1)},
-		{"Uintptr", zapcore.Field{Key: "k", Type: zapcore.UintptrType, Integer: 10}, Uintptr("k", 0xa)},
-		{"Reflect", zapcore.Field{Key: "k", Type: zapcore.ReflectType, Interface: ints}, Reflect("k", ints)},
-		{"Stringer", zapcore.Field{Key: "k", Type: zapcore.StringerType, Interface: addr}, Stringer("k", addr)},
-		{"Object", zapcore.Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: name}, Object("k", name)},
+		{"Skip", Field{Type: zapcore.SkipType}, Skip()},
+		{"Binary", Field{Key: "k", Type: zapcore.BinaryType, Interface: []byte("ab12")}, Binary("k", []byte("ab12"))},
+		{"Bool", Field{Key: "k", Type: zapcore.BoolType, Integer: 1}, Bool("k", true)},
+		{"Bool", Field{Key: "k", Type: zapcore.BoolType, Integer: 1}, Bool("k", true)},
+		{"ByteString", Field{Key: "k", Type: zapcore.ByteStringType, Interface: []byte("ab12")}, ByteString("k", []byte("ab12"))},
+		{"Complex128", Field{Key: "k", Type: zapcore.Complex128Type, Interface: 1 + 2i}, Complex128("k", 1+2i)},
+		{"Complex64", Field{Key: "k", Type: zapcore.Complex64Type, Interface: complex64(1 + 2i)}, Complex64("k", 1+2i)},
+		{"Duration", Field{Key: "k", Type: zapcore.DurationType, Integer: 1}, Duration("k", 1)},
+		{"Int", Field{Key: "k", Type: zapcore.Int64Type, Integer: 1}, Int("k", 1)},
+		{"Int64", Field{Key: "k", Type: zapcore.Int64Type, Integer: 1}, Int64("k", 1)},
+		{"Int32", Field{Key: "k", Type: zapcore.Int32Type, Integer: 1}, Int32("k", 1)},
+		{"Int16", Field{Key: "k", Type: zapcore.Int16Type, Integer: 1}, Int16("k", 1)},
+		{"Int8", Field{Key: "k", Type: zapcore.Int8Type, Integer: 1}, Int8("k", 1)},
+		{"String", Field{Key: "k", Type: zapcore.StringType, String: "foo"}, String("k", "foo")},
+		{"Time", Field{Key: "k", Type: zapcore.TimeType, Integer: 0, Interface: time.UTC}, Time("k", time.Unix(0, 0).In(time.UTC))},
+		{"Time", Field{Key: "k", Type: zapcore.TimeType, Integer: 1000, Interface: time.UTC}, Time("k", time.Unix(0, 1000).In(time.UTC))},
+		{"Uint", Field{Key: "k", Type: zapcore.Uint64Type, Integer: 1}, Uint("k", 1)},
+		{"Uint64", Field{Key: "k", Type: zapcore.Uint64Type, Integer: 1}, Uint64("k", 1)},
+		{"Uint32", Field{Key: "k", Type: zapcore.Uint32Type, Integer: 1}, Uint32("k", 1)},
+		{"Uint16", Field{Key: "k", Type: zapcore.Uint16Type, Integer: 1}, Uint16("k", 1)},
+		{"Uint8", Field{Key: "k", Type: zapcore.Uint8Type, Integer: 1}, Uint8("k", 1)},
+		{"Uintptr", Field{Key: "k", Type: zapcore.UintptrType, Integer: 10}, Uintptr("k", 0xa)},
+		{"Reflect", Field{Key: "k", Type: zapcore.ReflectType, Interface: ints}, Reflect("k", ints)},
+		{"Stringer", Field{Key: "k", Type: zapcore.StringerType, Interface: addr}, Stringer("k", addr)},
+		{"Object", Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: name}, Object("k", name)},
 		{"Any:ObjectMarshaler", Any("k", name), Object("k", name)},
 		{"Any:ArrayMarshaler", Any("k", bools([]bool{true})), Array("k", bools([]bool{true}))},
 		{"Any:Stringer", Any("k", addr), Stringer("k", addr)},
@@ -139,7 +139,7 @@ func TestFieldConstructors(t *testing.T) {
 		{"Any:Duration", Any("k", time.Second), Duration("k", time.Second)},
 		{"Any:Durations", Any("k", []time.Duration{time.Second}), Durations("k", []time.Duration{time.Second})},
 		{"Any:Fallback", Any("k", struct{}{}), Reflect("k", struct{}{})},
-		{"Namespace", Namespace("k"), zapcore.Field{Key: "k", Type: zapcore.NamespaceType}},
+		{"Namespace", Namespace("k"), Field{Key: "k", Type: zapcore.NamespaceType}},
 	}
 
 	for _, tt := range tests {

--- a/global_test.go
+++ b/global_test.go
@@ -52,7 +52,7 @@ func TestReplaceGlobals(t *testing.T) {
 		S().Info("captured")
 		expected := observer.LoggedEntry{
 			Entry:   zapcore.Entry{Message: "captured"},
-			Context: []zapcore.Field{},
+			Context: []Field{},
 		}
 		assert.Equal(
 			t,
@@ -157,7 +157,7 @@ func TestRedirectStdLog(t *testing.T) {
 
 		assert.Equal(t, []observer.LoggedEntry{{
 			Entry:   zapcore.Entry{Message: "redirected"},
-			Context: []zapcore.Field{},
+			Context: []Field{},
 		}}, logs.AllUntimed(), "Unexpected global log output.")
 	})
 
@@ -190,7 +190,7 @@ func TestRedirectStdLogAt(t *testing.T) {
 
 			assert.Equal(t, []observer.LoggedEntry{{
 				Entry:   zapcore.Entry{Level: level, Message: "redirected"},
-				Context: []zapcore.Field{},
+				Context: []Field{},
 			}}, logs.AllUntimed(), "Unexpected global log output.")
 		})
 	}
@@ -269,7 +269,7 @@ func TestRedirectStdLogAtInvalid(t *testing.T) {
 func checkStdLogMessage(t *testing.T, msg string, logs *observer.ObservedLogs) {
 	require.Equal(t, 1, logs.Len(), "Expected exactly one entry to be logged")
 	entry := logs.AllUntimed()[0]
-	assert.Equal(t, []zapcore.Field{}, entry.Context, "Unexpected entry context.")
+	assert.Equal(t, []Field{}, entry.Context, "Unexpected entry context.")
 	assert.Equal(t, "redirected", entry.Entry.Message, "Unexpected entry message.")
 	assert.Regexp(
 		t,

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -207,8 +207,8 @@ func Benchmark100Fields(b *testing.B) {
 	// Don't include allocating these helper slices in the benchmark. Since
 	// access to them isn't synchronized, we can't run the benchmark in
 	// parallel.
-	first := make([]zapcore.Field, batchSize)
-	second := make([]zapcore.Field, batchSize)
+	first := make([]Field, batchSize)
+	second := make([]Field, batchSize)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/logger_test.go
+++ b/logger_test.go
@@ -89,7 +89,7 @@ func TestLoggerInitialFields(t *testing.T) {
 		logger.Info("")
 		assert.Equal(
 			t,
-			observer.LoggedEntry{Context: []zapcore.Field{Int("foo", 42), String("bar", "baz")}},
+			observer.LoggedEntry{Context: []Field{Int("foo", 42), String("bar", "baz")}},
 			logs.AllUntimed()[0],
 			"Unexpected output with initial fields set.",
 		)
@@ -106,9 +106,9 @@ func TestLoggerWith(t *testing.T) {
 		logger.Info("")
 
 		assert.Equal(t, []observer.LoggedEntry{
-			{Context: []zapcore.Field{Int("foo", 42), String("one", "two")}},
-			{Context: []zapcore.Field{Int("foo", 42), String("three", "four")}},
-			{Context: []zapcore.Field{Int("foo", 42)}},
+			{Context: []Field{Int("foo", 42), String("one", "two")}},
+			{Context: []Field{Int("foo", 42), String("three", "four")}},
+			{Context: []Field{Int("foo", 42)}},
 		}, logs.AllUntimed(), "Unexpected cross-talk between child loggers.")
 	})
 }
@@ -171,7 +171,7 @@ func TestLoggerLogFatal(t *testing.T) {
 func TestLoggerLeveledMethods(t *testing.T) {
 	withLogger(t, DebugLevel, nil, func(logger *Logger, logs *observer.ObservedLogs) {
 		tests := []struct {
-			method        func(string, ...zapcore.Field)
+			method        func(string, ...Field)
 			expectedLevel zapcore.Level
 		}{
 			{logger.Debug, DebugLevel},
@@ -232,7 +232,7 @@ func TestLoggerDPanic(t *testing.T) {
 		assert.NotPanics(t, func() { logger.DPanic("") })
 		assert.Equal(
 			t,
-			[]observer.LoggedEntry{{Entry: zapcore.Entry{Level: DPanicLevel}, Context: []zapcore.Field{}}},
+			[]observer.LoggedEntry{{Entry: zapcore.Entry{Level: DPanicLevel}, Context: []Field{}}},
 			logs.AllUntimed(),
 			"Unexpected log output from DPanic in production mode.",
 		)
@@ -241,7 +241,7 @@ func TestLoggerDPanic(t *testing.T) {
 		assert.Panics(t, func() { logger.DPanic("") })
 		assert.Equal(
 			t,
-			[]observer.LoggedEntry{{Entry: zapcore.Entry{Level: DPanicLevel}, Context: []zapcore.Field{}}},
+			[]observer.LoggedEntry{{Entry: zapcore.Entry{Level: DPanicLevel}, Context: []Field{}}},
 			logs.AllUntimed(),
 			"Unexpected log output from DPanic in development mode.",
 		)
@@ -422,7 +422,7 @@ func TestLoggerConcurrent(t *testing.T) {
 				t,
 				observer.LoggedEntry{
 					Entry:   zapcore.Entry{Level: InfoLevel},
-					Context: []zapcore.Field{String("foo", "bar")},
+					Context: []Field{String("foo", "bar")},
 				},
 				obs,
 				"Unexpected log output.",

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -37,86 +37,86 @@ func TestSugarWith(t *testing.T) {
 	ignored := func(msg interface{}) observer.LoggedEntry {
 		return observer.LoggedEntry{
 			Entry:   zapcore.Entry{Level: DPanicLevel, Message: _oddNumberErrMsg},
-			Context: []zapcore.Field{Any("ignored", msg)},
+			Context: []Field{Any("ignored", msg)},
 		}
 	}
 	nonString := func(pairs ...invalidPair) observer.LoggedEntry {
 		return observer.LoggedEntry{
 			Entry:   zapcore.Entry{Level: DPanicLevel, Message: _nonStringKeyErrMsg},
-			Context: []zapcore.Field{Array("invalid", invalidPairs(pairs))},
+			Context: []Field{Array("invalid", invalidPairs(pairs))},
 		}
 	}
 
 	tests := []struct {
 		desc     string
 		args     []interface{}
-		expected []zapcore.Field
+		expected []Field
 		errLogs  []observer.LoggedEntry
 	}{
 		{
 			desc:     "nil args",
 			args:     nil,
-			expected: []zapcore.Field{},
+			expected: []Field{},
 			errLogs:  nil,
 		},
 		{
 			desc:     "empty slice of args",
 			args:     []interface{}{},
-			expected: []zapcore.Field{},
+			expected: []Field{},
 			errLogs:  nil,
 		},
 		{
 			desc:     "just a dangling key",
 			args:     []interface{}{"should ignore"},
-			expected: []zapcore.Field{},
+			expected: []Field{},
 			errLogs:  []observer.LoggedEntry{ignored("should ignore")},
 		},
 		{
 			desc:     "well-formed key-value pairs",
 			args:     []interface{}{"foo", 42, "true", "bar"},
-			expected: []zapcore.Field{Int("foo", 42), String("true", "bar")},
+			expected: []Field{Int("foo", 42), String("true", "bar")},
 			errLogs:  nil,
 		},
 		{
 			desc:     "just a structured field",
 			args:     []interface{}{Int("foo", 42)},
-			expected: []zapcore.Field{Int("foo", 42)},
+			expected: []Field{Int("foo", 42)},
 			errLogs:  nil,
 		},
 		{
 			desc:     "structured field and a dangling key",
 			args:     []interface{}{Int("foo", 42), "dangling"},
-			expected: []zapcore.Field{Int("foo", 42)},
+			expected: []Field{Int("foo", 42)},
 			errLogs:  []observer.LoggedEntry{ignored("dangling")},
 		},
 		{
 			desc:     "structured field and a dangling non-string key",
 			args:     []interface{}{Int("foo", 42), 13},
-			expected: []zapcore.Field{Int("foo", 42)},
+			expected: []Field{Int("foo", 42)},
 			errLogs:  []observer.LoggedEntry{ignored(13)},
 		},
 		{
 			desc:     "key-value pair and a dangling key",
 			args:     []interface{}{"foo", 42, "dangling"},
-			expected: []zapcore.Field{Int("foo", 42)},
+			expected: []Field{Int("foo", 42)},
 			errLogs:  []observer.LoggedEntry{ignored("dangling")},
 		},
 		{
 			desc:     "pairs, a structured field, and a dangling key",
 			args:     []interface{}{"first", "field", Int("foo", 42), "baz", "quux", "dangling"},
-			expected: []zapcore.Field{String("first", "field"), Int("foo", 42), String("baz", "quux")},
+			expected: []Field{String("first", "field"), Int("foo", 42), String("baz", "quux")},
 			errLogs:  []observer.LoggedEntry{ignored("dangling")},
 		},
 		{
 			desc:     "one non-string key",
 			args:     []interface{}{"foo", 42, true, "bar"},
-			expected: []zapcore.Field{Int("foo", 42)},
+			expected: []Field{Int("foo", 42)},
 			errLogs:  []observer.LoggedEntry{nonString(invalidPair{2, true, "bar"})},
 		},
 		{
 			desc:     "pairs, structured fields, non-string keys, and a dangling key",
 			args:     []interface{}{"foo", 42, true, "bar", Int("structure", 11), 42, "reversed", "baz", "quux", "dangling"},
-			expected: []zapcore.Field{Int("foo", 42), Int("structure", 11), String("baz", "quux")},
+			expected: []Field{Int("foo", 42), Int("structure", 11), String("baz", "quux")},
 			errLogs: []observer.LoggedEntry{
 				ignored("dangling"),
 				nonString(invalidPair{2, true, "bar"}, invalidPair{5, 42, "reversed"}),
@@ -146,7 +146,7 @@ func TestSugarFieldsInvalidPairs(t *testing.T) {
 
 		// Double-check that the actual message was logged.
 		require.Equal(t, 2, len(output), "Unexpected number of entries logged.")
-		require.Equal(t, observer.LoggedEntry{Context: []zapcore.Field{}}, output[1], "Unexpected non-error log entry.")
+		require.Equal(t, observer.LoggedEntry{Context: []Field{}}, output[1], "Unexpected non-error log entry.")
 
 		// Assert that the error message's structured fields serialize properly.
 		require.Equal(t, 1, len(output[0].Context), "Expected one field in error entry context.")
@@ -175,7 +175,7 @@ func TestSugarStructuredLogging(t *testing.T) {
 	// Common to all test cases.
 	context := []interface{}{"foo", "bar"}
 	extra := []interface{}{"baz", false}
-	expectedFields := []zapcore.Field{String("foo", "bar"), Bool("baz", false)}
+	expectedFields := []Field{String("foo", "bar"), Bool("baz", false)}
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
@@ -207,7 +207,7 @@ func TestSugarConcatenatingLogging(t *testing.T) {
 
 	// Common to all test cases.
 	context := []interface{}{"foo", "bar"}
-	expectedFields := []zapcore.Field{String("foo", "bar")}
+	expectedFields := []Field{String("foo", "bar")}
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
@@ -243,7 +243,7 @@ func TestSugarTemplatedLogging(t *testing.T) {
 
 	// Common to all test cases.
 	context := []interface{}{"foo", "bar"}
-	expectedFields := []zapcore.Field{String("foo", "bar")}
+	expectedFields := []Field{String("foo", "bar")}
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
@@ -287,7 +287,7 @@ func TestSugarPanicLogging(t *testing.T) {
 			assert.Panics(t, func() { tt.f(sugar) }, "Expected panic-level logger calls to panic.")
 			if tt.expectedMsg != "" {
 				assert.Equal(t, []observer.LoggedEntry{{
-					Context: []zapcore.Field{},
+					Context: []Field{},
 					Entry:   zapcore.Entry{Message: tt.expectedMsg, Level: PanicLevel},
 				}}, logs.AllUntimed(), "Unexpected log output.")
 			} else {
@@ -320,7 +320,7 @@ func TestSugarFatalLogging(t *testing.T) {
 			assert.True(t, stub.Exited, "Expected all calls to fatal logger methods to exit process.")
 			if tt.expectedMsg != "" {
 				assert.Equal(t, []observer.LoggedEntry{{
-					Context: []zapcore.Field{},
+					Context: []Field{},
 					Entry:   zapcore.Entry{Message: tt.expectedMsg, Level: FatalLevel},
 				}}, logs.AllUntimed(), "Unexpected log output.")
 			} else {


### PR DESCRIPTION
Update zap's tests to use the new `zap.Field` alias. Keeping this change
in a separate commit lets us verify that changing to an alias is
backward-compatible for callers.