### PR TITLE
fixed Printf to Infof; got error when doing Printf

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -48,7 +48,7 @@
 //    "attempt", 3,
 //    "backoff", time.Second,
 //  )
-//  sugar.Printf("failed to fetch URL: %s", "http://example.com")
+//  sugar.Infof("failed to fetch URL: %s", "http://example.com")
 //
 // By default, loggers are unbuffered. However, since zap's low-level APIs
 // allow buffering, calling Sync before letting your process exit is a good


### PR DESCRIPTION
Just made a quick change on the go doc to be consistent with the Github doc. 