### PR TITLE
Add Quoted Field Support

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -59,10 +59,32 @@ func Example_presets() {
 		zap.Int("attempt", 3),
 		zap.Duration("backoff", time.Second),
 	)
+
+	dat := struct {
+		Foo string            `json:"foo"`
+		Bar float64           `json:"bar"`
+		Baz map[string]string `json:"baz"`
+	}{
+		Foo: "now is the time for string-\"ception\"!",
+		Bar: 3.14,
+		Baz: map[string]string{
+			"such": "octopus 🐙", // TODO why doesn't this encode as \u0001f419
+		},
+	}
+
+	logger.Info("can your logger do this?",
+		zap.Quoted(zap.Object("inception", zapcore.ObjectMarshalerFunc(func(enc zapcore.ObjectEncoder) error {
+			enc.AddString("foo", dat.Foo)
+			enc.AddFloat64("bar", dat.Bar)
+			enc.AddReflected("baz", dat.Baz)
+			return nil
+		}))),
+	)
 	// Output:
 	// {"level":"info","msg":"Failed to fetch URL.","url":"http://example.com","attempt":3,"backoff":"1s"}
 	// {"level":"info","msg":"Failed to fetch URL: http://example.com"}
 	// {"level":"info","msg":"Failed to fetch URL.","url":"http://example.com","attempt":3,"backoff":"1s"}
+	// {"level":"info","msg":"can your logger do this?","inception":"{\"foo\":\"now is the time for string-\\\"ception\\\"!\",\"bar\":3.14,\"baz\":{\"such\":\"octopus 🐙\"}}"}
 }
 
 func Example_basicConfiguration() {

--- a/field.go
+++ b/field.go
@@ -201,6 +201,11 @@ func Duration(key string, val time.Duration) Field {
 	return Field{Key: key, Type: zapcore.DurationType, Integer: int64(val)}
 }
 
+func Quoted(val Field) Field {
+	val.Type |= zapcore.QuotedTypeBit
+	return val
+}
+
 // Object constructs a field with the given key and ObjectMarshaler. It
 // provides a flexible, but still type-safe and efficient, way to add map- or
 // struct-like user-defined types to the logging context. The struct's

--- a/field_test.go
+++ b/field_test.go
@@ -140,6 +140,7 @@ func TestFieldConstructors(t *testing.T) {
 		{"Any:Durations", Any("k", []time.Duration{time.Second}), Durations("k", []time.Duration{time.Second})},
 		{"Any:Fallback", Any("k", struct{}{}), Reflect("k", struct{}{})},
 		{"Namespace", Namespace("k"), Field{Key: "k", Type: zapcore.NamespaceType}},
+		// TODO quoted fields
 	}
 
 	for _, tt := range tests {

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -302,6 +302,20 @@ type ArrayEncoder interface {
 	AppendReflected(value interface{}) error
 }
 
+type QuotingObjectEncoder interface {
+	ObjectEncoder
+
+	// pity we don't have a "ValueEncoder" used by both object and array paths...
+	AddQuoted(key string, with func(ArrayEncoder) error) error
+}
+
+type QuotingArrayEncoder interface {
+	ArrayEncoder
+
+	// pity we don't have a "ValueEncoder" used by both object and array paths...
+	AppendQuoted(with func(ArrayEncoder) error) error
+}
+
 // PrimitiveArrayEncoder is the subset of the ArrayEncoder interface that deals
 // only in Go's built-in types. It's included only so that Duration- and
 // TimeEncoders cannot trigger infinite recursion.

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -105,13 +105,17 @@ type Field struct {
 // AddTo exports a field through the ObjectEncoder interface. It's primarily
 // useful to library authors, and shouldn't be necessary in most applications.
 func (f Field) AddTo(enc ObjectEncoder) {
-	var err error
+	if err := f.addTo(enc); err != nil {
+		enc.AddString(fmt.Sprintf("%sError", f.Key), err.Error())
+	}
+}
 
+func (f Field) addTo(enc ObjectEncoder) error {
 	switch f.Type {
 	case ArrayMarshalerType:
-		err = enc.AddArray(f.Key, f.Interface.(ArrayMarshaler))
+		return enc.AddArray(f.Key, f.Interface.(ArrayMarshaler))
 	case ObjectMarshalerType:
-		err = enc.AddObject(f.Key, f.Interface.(ObjectMarshaler))
+		return enc.AddObject(f.Key, f.Interface.(ObjectMarshaler))
 	case BinaryType:
 		enc.AddBinary(f.Key, f.Interface.([]byte))
 	case BoolType:
@@ -156,7 +160,7 @@ func (f Field) AddTo(enc ObjectEncoder) {
 	case UintptrType:
 		enc.AddUintptr(f.Key, uintptr(f.Integer))
 	case ReflectType:
-		err = enc.AddReflected(f.Key, f.Interface)
+		return enc.AddReflected(f.Key, f.Interface)
 	case NamespaceType:
 		enc.OpenNamespace(f.Key)
 	case StringerType:
@@ -168,10 +172,7 @@ func (f Field) AddTo(enc ObjectEncoder) {
 	default:
 		panic(fmt.Sprintf("unknown field type: %v", f))
 	}
-
-	if err != nil {
-		enc.AddString(fmt.Sprintf("%sError", f.Key), err.Error())
-	}
+	return nil
 }
 
 // Equals returns whether two fields are equal. For non-primitive types such as

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -175,6 +175,71 @@ func (f Field) addTo(enc ObjectEncoder) error {
 	return nil
 }
 
+func (f Field) appendTo(enc ArrayEncoder) error {
+	switch f.Type {
+	case ArrayMarshalerType:
+		return enc.AppendArray(f.Interface.(ArrayMarshaler))
+	case ObjectMarshalerType:
+		return enc.AppendObject(f.Interface.(ObjectMarshaler))
+	case BoolType:
+		enc.AppendBool(f.Integer == 1)
+	case ByteStringType:
+		enc.AppendByteString(f.Interface.([]byte))
+	case Complex128Type:
+		enc.AppendComplex128(f.Interface.(complex128))
+	case Complex64Type:
+		enc.AppendComplex64(f.Interface.(complex64))
+	case DurationType:
+		enc.AppendDuration(time.Duration(f.Integer))
+	case Float64Type:
+		enc.AppendFloat64(math.Float64frombits(uint64(f.Integer)))
+	case Float32Type:
+		enc.AppendFloat32(math.Float32frombits(uint32(f.Integer)))
+	case Int64Type:
+		enc.AppendInt64(f.Integer)
+	case Int32Type:
+		enc.AppendInt32(int32(f.Integer))
+	case Int16Type:
+		enc.AppendInt16(int16(f.Integer))
+	case Int8Type:
+		enc.AppendInt8(int8(f.Integer))
+	case StringType:
+		enc.AppendString(f.String)
+	case TimeType:
+		if f.Interface != nil {
+			enc.AppendTime(time.Unix(0, f.Integer).In(f.Interface.(*time.Location)))
+		} else {
+			// Fall back to UTC if location is nil.
+			enc.AppendTime(time.Unix(0, f.Integer))
+		}
+	case Uint64Type:
+		enc.AppendUint64(uint64(f.Integer))
+	case Uint32Type:
+		enc.AppendUint32(uint32(f.Integer))
+	case Uint16Type:
+		enc.AppendUint16(uint16(f.Integer))
+	case Uint8Type:
+		enc.AppendUint8(uint8(f.Integer))
+	case UintptrType:
+		enc.AppendUintptr(uintptr(f.Integer))
+	case ReflectType:
+		return enc.AppendReflected(f.Interface)
+	case StringerType:
+		enc.AppendString(f.Interface.(fmt.Stringer).String())
+	case SkipType:
+		break
+	case ErrorType:
+		panic("invalid error field in an array")
+	case BinaryType:
+		panic("invalid binary field in an array")
+	case NamespaceType:
+		panic("invalid namespace in an array")
+	default:
+		panic(fmt.Sprintf("unknown field type: %v", f))
+	}
+	return nil
+}
+
 // Equals returns whether two fields are equal. For non-primitive types such as
 // errors, marshalers, or reflect types, it uses reflect.DeepEqual.
 func (f Field) Equals(other Field) bool {

--- a/zapcore/field_test.go
+++ b/zapcore/field_test.go
@@ -117,6 +117,7 @@ func TestFields(t *testing.T) {
 		{t: NamespaceType, want: map[string]interface{}{}},
 		{t: StringerType, iface: users(2), want: "2 users"},
 		{t: SkipType, want: interface{}(nil)},
+		// TODO quoted fields
 	}
 
 	for _, tt := range tests {

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -178,23 +178,23 @@ func (enc *jsonEncoder) AppendBool(val bool) {
 
 func (enc *jsonEncoder) AppendByteString(val []byte) {
 	enc.addElementSeparator()
-	enc.buf.AppendByte('"')
+	enc.addQuote()
 	enc.safeAddByteString(val)
-	enc.buf.AppendByte('"')
+	enc.addQuote()
 }
 
 func (enc *jsonEncoder) AppendComplex128(val complex128) {
 	enc.addElementSeparator()
 	// Cast to a platform-independent, fixed-size type.
 	r, i := float64(real(val)), float64(imag(val))
-	enc.buf.AppendByte('"')
+	enc.addQuote()
 	// Because we're always in a quoted string, we can use strconv without
 	// special-casing NaN and +/-Inf.
 	enc.buf.AppendFloat(r, 64)
 	enc.buf.AppendByte('+')
 	enc.buf.AppendFloat(i, 64)
 	enc.buf.AppendByte('i')
-	enc.buf.AppendByte('"')
+	enc.addQuote()
 }
 
 func (enc *jsonEncoder) AppendDuration(val time.Duration) {
@@ -224,9 +224,9 @@ func (enc *jsonEncoder) AppendReflected(val interface{}) error {
 
 func (enc *jsonEncoder) AppendString(val string) {
 	enc.addElementSeparator()
-	enc.buf.AppendByte('"')
+	enc.addQuote()
 	enc.safeAddString(val)
-	enc.buf.AppendByte('"')
+	enc.addQuote()
 }
 
 func (enc *jsonEncoder) AppendTime(val time.Time) {
@@ -363,11 +363,15 @@ func (enc *jsonEncoder) closeOpenNamespaces() {
 	}
 }
 
+func (enc *jsonEncoder) addQuote() {
+	enc.buf.AppendByte('"')
+}
+
 func (enc *jsonEncoder) addKey(key string) {
 	enc.addElementSeparator()
-	enc.buf.AppendByte('"')
+	enc.addQuote()
 	enc.safeAddString(key)
-	enc.buf.AppendByte('"')
+	enc.addQuote()
 	enc.buf.AppendByte(':')
 	if enc.spaced {
 		enc.buf.AppendByte(' ')

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -36,6 +36,8 @@ import (
 	"go.uber.org/multierr"
 )
 
+// TODO quoting cases
+
 func TestJSONClone(t *testing.T) {
 	// The parent encoder is created with plenty of excess capacity.
 	parent := &jsonEncoder{buf: bufferpool.Get()}


### PR DESCRIPTION
This adds a path to fast sub-encoded data (i.e. logging a field whose value is quoted JSON) without forcing the log site to either:
- drive a stripped down copy of a zapcore json encoder targeted at a temporary byte buffer
- fallback to using `buf, _ := json.Marshal(thing); zap.ByteString("thing", buf)`

I added an example test first, for PoC demonstration, and minimal testing.

However this PR, at present, is just a start, things still TODO:
- [ ] implement memory encoder "quoting" (whatever that even means) so that tests can have parity
- [ ] consider whether we want to fail encoding when quoting is not supported, or instead fallback to a JSON string (see TOOD note inline below)
- [ ] write more (unit) tests, if we can agree to add this feature

Note how I've gone the optional interface upgrade route with `QuotedObjectEncoder` ; if this feature gets accepted, we should add a point the 2.x wish list to fold this in as an `ObjectEncoder` requirement.