### PR TITLE
Make user-supplied sinks operate on URIs

### DIFF
--- a/config.go
+++ b/config.go
@@ -74,10 +74,10 @@ type Config struct {
 	// EncoderConfig sets options for the chosen encoder. See
 	// zapcore.EncoderConfig for details.
 	EncoderConfig zapcore.EncoderConfig `json:"encoderConfig" yaml:"encoderConfig"`
-	// OutputPaths is a list of paths to write logging output to. See Open for
+	// OutputPaths is a list of URLs to write logging output to. See Open for
 	// details.
 	OutputPaths []string `json:"outputPaths" yaml:"outputPaths"`
-	// ErrorOutputPaths is a list of paths to write internal logger errors to.
+	// ErrorOutputPaths is a list of URLs to write internal logger errors to.
 	// The default is standard error.
 	//
 	// Note that this setting only affects internal errors; for sample code that

--- a/config.go
+++ b/config.go
@@ -74,8 +74,8 @@ type Config struct {
 	// EncoderConfig sets options for the chosen encoder. See
 	// zapcore.EncoderConfig for details.
 	EncoderConfig zapcore.EncoderConfig `json:"encoderConfig" yaml:"encoderConfig"`
-	// OutputPaths is a list of URLs to write logging output to. See Open for
-	// details.
+	// OutputPaths is a list of URLs or file paths to write logging output to.
+	// See Open for details.
 	OutputPaths []string `json:"outputPaths" yaml:"outputPaths"`
 	// ErrorOutputPaths is a list of URLs to write internal logger errors to.
 	// The default is standard error.

--- a/sink.go
+++ b/sink.go
@@ -42,6 +42,7 @@ func init() {
 func resetSinkRegistry() {
 	_sinkMutex.Lock()
 	defer _sinkMutex.Unlock()
+
 	_sinkFactories = map[string]func() (Sink, error){
 		"stdout": func() (Sink, error) { return nopCloserSink{os.Stdout}, nil },
 		"stderr": func() (Sink, error) { return nopCloserSink{os.Stderr}, nil },
@@ -67,6 +68,7 @@ type Sink interface {
 func RegisterSink(key string, sinkFactory func() (Sink, error)) error {
 	_sinkMutex.Lock()
 	defer _sinkMutex.Unlock()
+
 	if key == "" {
 		return errors.New("sink key cannot be blank")
 	}
@@ -82,6 +84,7 @@ func RegisterSink(key string, sinkFactory func() (Sink, error)) error {
 func newSink(key string) (Sink, error) {
 	_sinkMutex.RLock()
 	defer _sinkMutex.RUnlock()
+
 	sinkFactory, ok := _sinkFactories[key]
 	if !ok {
 		return nil, &errSinkNotFound{key}

--- a/sink.go
+++ b/sink.go
@@ -145,9 +145,6 @@ func normalizeScheme(s string) (string, error) {
 	if first := s[0]; 'a' > first || 'z' < first {
 		return "", errors.New("must start with a letter")
 	}
-	if len(s) < 2 {
-		return s, nil
-	}
 	for i := 1; i < len(s); i++ { // iterate over bytes, not runes
 		c := s[i]
 		switch {
@@ -158,7 +155,7 @@ func normalizeScheme(s string) (string, error) {
 		case c == '.' || c == '+' || c == '-':
 			continue
 		}
-		return "", fmt.Errorf("may not contain %q", string(c))
+		return "", fmt.Errorf("may not contain %q", c)
 	}
 	return s, nil
 }

--- a/sink.go
+++ b/sink.go
@@ -74,9 +74,9 @@ func (e *errSinkNotFound) Error() string {
 // particular scheme.
 //
 // All schemes must be ASCII, valid under section 3.1 of RFC 3986
-// (https://tools.ietf.org/html/rfc3986#section-3.1), and may not already have
-// a factory registered. Zap automatically registers a factory for the "file"
-// scheme.
+// (https://tools.ietf.org/html/rfc3986#section-3.1), and must not already
+// have a factory registered. Zap automatically registers a factory for the
+// "file" scheme.
 func RegisterSink(scheme string, factory func(*url.URL) (Sink, error)) error {
 	_sinkMutex.Lock()
 	defer _sinkMutex.Unlock()

--- a/sink.go
+++ b/sink.go
@@ -24,15 +24,19 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"strings"
 	"sync"
 
 	"go.uber.org/zap/zapcore"
 )
 
+const schemeFile = "file"
+
 var (
 	_sinkMutex     sync.RWMutex
-	_sinkFactories map[string]func() (Sink, error)
+	_sinkFactories map[string]func(*url.URL) (Sink, error) // keyed by scheme
 )
 
 func init() {
@@ -43,18 +47,9 @@ func resetSinkRegistry() {
 	_sinkMutex.Lock()
 	defer _sinkMutex.Unlock()
 
-	_sinkFactories = map[string]func() (Sink, error){
-		"stdout": func() (Sink, error) { return nopCloserSink{os.Stdout}, nil },
-		"stderr": func() (Sink, error) { return nopCloserSink{os.Stderr}, nil },
+	_sinkFactories = map[string]func(*url.URL) (Sink, error){
+		schemeFile: newFileSink,
 	}
-}
-
-type errSinkNotFound struct {
-	key string
-}
-
-func (e *errSinkNotFound) Error() string {
-	return fmt.Sprintf("no sink found for %q", e.key)
 }
 
 // Sink defines the interface to write to and close logger destinations.
@@ -63,35 +58,92 @@ type Sink interface {
 	io.Closer
 }
 
-// RegisterSink adds a Sink at the given key so it can be referenced
-// in config OutputPaths.
-func RegisterSink(key string, sinkFactory func() (Sink, error)) error {
-	_sinkMutex.Lock()
-	defer _sinkMutex.Unlock()
-
-	if key == "" {
-		return errors.New("sink key cannot be blank")
-	}
-	if _, ok := _sinkFactories[key]; ok {
-		return fmt.Errorf("sink already registered for key %q", key)
-	}
-	_sinkFactories[key] = sinkFactory
-	return nil
-}
-
-// newSink invokes the registered sink factory to create and return the
-// sink for the given key. Returns errSinkNotFound if the key cannot be found.
-func newSink(key string) (Sink, error) {
-	_sinkMutex.RLock()
-	defer _sinkMutex.RUnlock()
-
-	sinkFactory, ok := _sinkFactories[key]
-	if !ok {
-		return nil, &errSinkNotFound{key}
-	}
-	return sinkFactory()
-}
-
 type nopCloserSink struct{ zapcore.WriteSyncer }
 
 func (nopCloserSink) Close() error { return nil }
+
+type errSinkNotFound struct {
+	scheme string
+}
+
+func (e *errSinkNotFound) Error() string {
+	return fmt.Sprintf("no sink found for scheme %q", e.scheme)
+}
+
+// RegisterSink registers a user-supplied factory for all sinks with a
+// particular scheme.
+//
+// All schemes must be ASCII, valid under section 3.1 of RFC 3986
+// (https://tools.ietf.org/html/rfc3986#section-3.1), and may not already have
+// a factory registered. Zap automatically registers a factory for the "file"
+// scheme.
+func RegisterSink(scheme string, factory func(*url.URL) (Sink, error)) error {
+	_sinkMutex.Lock()
+	defer _sinkMutex.Unlock()
+
+	if scheme == "" {
+		return errors.New("can't register a sink factory for empty string")
+	}
+	normalized, err := normalizeScheme(scheme)
+	if err != nil {
+		return fmt.Errorf("%q is not a valid scheme: %v", scheme, err)
+	}
+	if _, ok := _sinkFactories[normalized]; ok {
+		return fmt.Errorf("sink factory already registered for scheme %q", normalized)
+	}
+	_sinkFactories[normalized] = factory
+	return nil
+}
+
+func newSink(rawURL string) (Sink, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("can't parse %q as a URL: %v", rawURL, err)
+	}
+	if u.Scheme == "" {
+		u.Scheme = schemeFile
+	}
+
+	_sinkMutex.RLock()
+	defer _sinkMutex.RUnlock()
+
+	factory, ok := _sinkFactories[u.Scheme]
+	if !ok {
+		return nil, &errSinkNotFound{u.Scheme}
+	}
+	return factory(u)
+}
+
+func newFileSink(u *url.URL) (Sink, error) {
+	switch u.Path {
+	case "stdout":
+		return nopCloserSink{os.Stdout}, nil
+	case "stderr":
+		return nopCloserSink{os.Stderr}, nil
+	}
+	return os.OpenFile(u.Path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
+}
+
+func normalizeScheme(s string) (string, error) {
+	// https://tools.ietf.org/html/rfc3986#section-3.1
+	s = strings.ToLower(s)
+	if first := s[0]; 'a' > first || 'z' < first {
+		return "", errors.New("must start with a letter")
+	}
+	if len(s) < 2 {
+		return s, nil
+	}
+	for i := 1; i < len(s); i++ { // iterate over bytes, not runes
+		c := s[i]
+		switch {
+		case 'a' <= c && c <= 'z':
+			continue
+		case '0' <= c && c <= '9':
+			continue
+		case c == '.' || c == '+' || c == '-':
+			continue
+		}
+		return "", fmt.Errorf("may not contain %q", string(c))
+	}
+	return s, nil
+}

--- a/sink_test.go
+++ b/sink_test.go
@@ -21,59 +21,79 @@
 package zap
 
 import (
-	"errors"
-	"os"
+	"bytes"
+	"io/ioutil"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestRegisterSink(t *testing.T) {
+	const (
+		memScheme = "m"
+		nopScheme = "no-op.1234"
+	)
+	var memCalls, nopCalls int
+
+	buf := bytes.NewBuffer(nil)
+	memFactory := func(u *url.URL) (Sink, error) {
+		assert.Equal(t, u.Scheme, memScheme, "Scheme didn't match registration.")
+		memCalls++
+		return nopCloserSink{zapcore.AddSync(buf)}, nil
+	}
+	nopFactory := func(u *url.URL) (Sink, error) {
+		assert.Equal(t, u.Scheme, nopScheme, "Scheme didn't match registration.")
+		nopCalls++
+		return nopCloserSink{zapcore.AddSync(ioutil.Discard)}, nil
+	}
+
 	defer resetSinkRegistry()
 
-	tests := []struct {
-		name      string
-		key       string
-		factory   func() (Sink, error)
-		wantError bool
-	}{
-		{"valid", "valid", func() (Sink, error) { return nopCloserSink{os.Stdout}, nil }, false},
-		{"empty", "", func() (Sink, error) { return nopCloserSink{os.Stdout}, nil }, true},
-		{"stdout", "stdout", func() (Sink, error) { return nopCloserSink{os.Stdout}, nil }, true},
-	}
+	require.NoError(t, RegisterSink(strings.ToUpper(memScheme), memFactory), "Failed to register scheme %q.", memScheme)
+	require.NoError(t, RegisterSink(nopScheme, nopFactory), "Failed to register scheme %q.", memScheme)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := RegisterSink(tt.key, tt.factory)
-			if tt.wantError {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.NotNil(t, _sinkFactories[tt.key], "expected the factory to be present")
-			}
-		})
-	}
+	sink, close, err := Open(
+		memScheme+"://somewhere",
+		nopScheme+"://somewhere-else",
+	)
+	assert.NoError(t, err, "Unexpected error opening URLs with registered schemes.")
+
+	defer close()
+
+	assert.Equal(t, 1, memCalls, "Unexpected number of calls to memory factory.")
+	assert.Equal(t, 1, nopCalls, "Unexpected number of calls to no-op factory.")
+
+	_, err = sink.Write([]byte("foo"))
+	assert.NoError(t, err, "Failed to write to combined WriteSyncer.")
+	assert.Equal(t, "foo", buf.String(), "Unexpected buffer contents.")
 }
 
-func TestNewSink(t *testing.T) {
-	defer resetSinkRegistry()
-
-	errTestSink := errors.New("test erroring")
-	err := RegisterSink("errors", func() (Sink, error) { return nil, errTestSink })
-	assert.Nil(t, err)
+func TestRegisterSinkErrors(t *testing.T) {
+	nopFactory := func(_ *url.URL) (Sink, error) {
+		return nopCloserSink{zapcore.AddSync(ioutil.Discard)}, nil
+	}
 	tests := []struct {
-		key string
-		err error
+		scheme string
+		err    string
 	}{
-		{"stdout", nil},
-		{"errors", errTestSink},
-		{"nonexistent", &errSinkNotFound{"nonexistent"}},
+		{"", "empty string"},
+		{"FILE", "already registered"},
+		{"42", "not a valid scheme"},
+		{"http*", "not a valid scheme"},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.key, func(t *testing.T) {
-			_, err := newSink(tt.key)
-			assert.Equal(t, tt.err, err)
+		t.Run("scheme-"+tt.scheme, func(t *testing.T) {
+			defer resetSinkRegistry()
+
+			err := RegisterSink(tt.scheme, nopFactory)
+			if assert.Error(t, err, "expected error") {
+				assert.Contains(t, err.Error(), tt.err, "unexpected error")
+			}
 		})
 	}
 }

--- a/sink_test.go
+++ b/sink_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestRegisterSink(t *testing.T) {
+	defer resetSinkRegistry()
+
 	tests := []struct {
 		name      string
 		key       string
@@ -55,6 +57,7 @@ func TestRegisterSink(t *testing.T) {
 
 func TestNewSink(t *testing.T) {
 	defer resetSinkRegistry()
+
 	errTestSink := errors.New("test erroring")
 	err := RegisterSink("errors", func() (Sink, error) { return nil, errTestSink })
 	assert.Nil(t, err)

--- a/sink_test.go
+++ b/sink_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.uber.org/zap/zapcore"
 )
 

--- a/writer.go
+++ b/writer.go
@@ -21,22 +21,27 @@
 package zap
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 
 	"go.uber.org/zap/zapcore"
 
 	"go.uber.org/multierr"
 )
 
-// Open is a high-level wrapper that takes a variadic number of paths, opens or
-// creates each of the specified files, and combines them into a locked
+// Open is a high-level wrapper that takes a variadic number of URLs, opens or
+// creates each of the specified resources, and combines them into a locked
 // WriteSyncer. It also returns any error encountered and a function to close
 // any opened files.
 //
-// Passing no paths returns a no-op WriteSyncer. The special paths "stdout" and
+// Passing no URLs returns a no-op WriteSyncer. URLs without a scheme (e.g.,
+// "/var/log/foo.log") are treated as though they had the "file" scheme. With
+// no scheme or the explicit "file" scheme, the special paths "stdout" and
 // "stderr" are interpreted as os.Stdout and os.Stderr, respectively.
+//
+// Users and third-party packages may register factories for other schemes
+// using RegisterSink.
 func Open(paths ...string) (zapcore.WriteSyncer, func(), error) {
 	writers, close, err := open(paths)
 	if err != nil {
@@ -48,7 +53,6 @@ func Open(paths ...string) (zapcore.WriteSyncer, func(), error) {
 }
 
 func open(paths []string) ([]zapcore.WriteSyncer, func(), error) {
-	var openErr error
 	writers := make([]zapcore.WriteSyncer, 0, len(paths))
 	closers := make([]io.Closer, 0, len(paths))
 	close := func() {
@@ -56,28 +60,17 @@ func open(paths []string) ([]zapcore.WriteSyncer, func(), error) {
 			c.Close()
 		}
 	}
+
+	var openErr error
 	for _, path := range paths {
 		sink, err := newSink(path)
-		if err == nil {
-			// Using a registered sink constructor.
-			writers = append(writers, sink)
-			closers = append(closers, sink)
+		if err != nil {
+			openErr = multierr.Append(openErr, fmt.Errorf("couldn't open sink %q: %v", path, err))
 			continue
 		}
-		if _, ok := err.(*errSinkNotFound); ok {
-			// No named sink constructor, use key as path to log file.
-			f, e := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
-			openErr = multierr.Append(openErr, e)
-			if e == nil {
-				writers = append(writers, f)
-				closers = append(closers, f)
-			}
-			continue
-		}
-		// Sink constructor failed.
-		openErr = multierr.Append(openErr, err)
+		writers = append(writers, sink)
+		closers = append(closers, sink)
 	}
-
 	if openErr != nil {
 		close()
 		return writers, nil, openErr

--- a/writer.go
+++ b/writer.go
@@ -35,13 +35,19 @@ import (
 // WriteSyncer. It also returns any error encountered and a function to close
 // any opened files.
 //
-// Passing no URLs returns a no-op WriteSyncer. URLs without a scheme (e.g.,
-// "/var/log/foo.log") are treated as though they had the "file" scheme. With
-// no scheme or the explicit "file" scheme, the special paths "stdout" and
-// "stderr" are interpreted as os.Stdout and os.Stderr, respectively.
+// Passing no URLs returns a no-op WriteSyncer. Zap handles URLs without a
+// scheme and URLs with the "file" scheme. Third-party code may register
+// factories for other schemes using RegisterSink.
 //
-// Users and third-party packages may register factories for other schemes
-// using RegisterSink.
+// URLs with the "file" scheme must use absolute paths on the local
+// filesystem. No user, password, port, fragments, or query parameters are
+// allowed, and the hostname must be empty or "localhost".
+//
+// Since it's common to write logs to the local filesystem, URLs without a
+// scheme (e.g., "/var/log/foo.log") are treated as local file paths. Without
+// a scheme, the special paths "stdout" and "stderr" are interpreted as
+// os.Stdout and os.Stderr. When specified without a scheme, relative file
+// paths also work.
 func Open(paths ...string) (zapcore.WriteSyncer, func(), error) {
 	writers, close, err := open(paths)
 	if err != nil {

--- a/writer_test.go
+++ b/writer_test.go
@@ -117,6 +117,7 @@ func (w *testWriter) Sync() error {
 
 func TestOpenWithCustomSink(t *testing.T) {
 	defer resetSinkRegistry()
+
 	tw := &testWriter{"test", t}
 	ctr := func() (Sink, error) { return nopCloserSink{tw}, nil }
 	assert.Nil(t, RegisterSink("TestOpenWithCustomSink", ctr))
@@ -128,6 +129,7 @@ func TestOpenWithCustomSink(t *testing.T) {
 
 func TestOpenWithErroringSinkFactory(t *testing.T) {
 	defer resetSinkRegistry()
+
 	expectedErr := errors.New("expected factory error")
 	ctr := func() (Sink, error) { return nil, expectedErr }
 	assert.Nil(t, RegisterSink("TestOpenWithErroringSinkFactory", ctr))


### PR DESCRIPTION
For future extensibility, make user-supplied factories for log sinks
operate on URIs. Each user-supplied factory owns a scheme, and
double-registering constructors for a scheme is an error. For
back-compat, zap automatically registers a factory for the `file` scheme
and treats URIs without a scheme as though they were for files.