### PR TITLE
Add zaptest logger option to wrap zap.Option's

### DIFF
--- a/zaptest/logger.go
+++ b/zaptest/logger.go
@@ -33,7 +33,8 @@ type LoggerOption interface {
 }
 
 type loggerOptions struct {
-	Level zapcore.LevelEnabler
+	Level     zapcore.LevelEnabler
+	AddCaller bool
 }
 
 type loggerOptionFunc func(*loggerOptions)
@@ -50,6 +51,13 @@ func Level(enab zapcore.LevelEnabler) LoggerOption {
 	})
 }
 
+// AddCaller ensures caller is logged by a test Logger built by NewLogger.
+func AddCaller() LoggerOption {
+	return loggerOptionFunc(func(opts *loggerOptions) {
+		opts.AddCaller = true
+	})
+}
+
 // NewLogger builds a new Logger that logs all messages to the given
 // testing.TB.
 //
@@ -59,9 +67,14 @@ func Level(enab zapcore.LevelEnabler) LoggerOption {
 // if a test fails or if you ran go test -v.
 //
 // The returned logger defaults to logging debug level messages and above.
-// This may be changd by passing a zaptest.Level during construction.
+// This may be changed by passing a zaptest.Level during construction.
 //
 //   logger := zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))
+//
+// The returned logger doesn't log caller.
+// This may be changed by passing a zaptest.AddCaller during construction.
+//
+//   logger := zaptest.NewLogger(t, zaptest.AddCaller())
 func NewLogger(t TestingT, opts ...LoggerOption) *zap.Logger {
 	cfg := loggerOptions{
 		Level: zapcore.DebugLevel,
@@ -71,16 +84,22 @@ func NewLogger(t TestingT, opts ...LoggerOption) *zap.Logger {
 	}
 
 	writer := newTestingWriter(t)
+	zapOptions := []zap.Option{
+		// Send zap errors to the same writer and mark the test as failed if
+		// that happens.
+		zap.ErrorOutput(writer.WithMarkFailed(true)),
+	}
+	if cfg.AddCaller {
+		zapOptions = append(zapOptions, zap.AddCaller())
+	}
+
 	return zap.New(
 		zapcore.NewCore(
 			zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
 			writer,
 			cfg.Level,
 		),
-
-		// Send zap errors to the same writer and mark the test as failed if
-		// that happens.
-		zap.ErrorOutput(writer.WithMarkFailed(true)),
+		zapOptions...,
 	)
 }
 

--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -80,11 +80,11 @@ func TestTestLoggerSupportsLevels(t *testing.T) {
 	)
 }
 
-func TestTestLoggerSupportsAddCaller(t *testing.T) {
+func TestTestLoggerSupportsWrappedZapOptions(t *testing.T) {
 	ts := newTestLogSpy(t)
 	defer ts.AssertPassed()
 
-	log := NewLogger(ts, AddCaller())
+	log := NewLogger(ts, WrapOptions(zap.AddCaller(), zap.Fields(zap.String("k1", "v1"))))
 
 	log.Info("received work order")
 	log.Debug("starting work")
@@ -96,11 +96,11 @@ func TestTestLoggerSupportsAddCaller(t *testing.T) {
 	}, "log.Panic should panic")
 
 	ts.AssertMessages(
-		"INFO	zaptest/logger_test.go:89	received work order",
-		"DEBUG	zaptest/logger_test.go:90	starting work",
-		"WARN	zaptest/logger_test.go:91	work may fail",
-		`ERROR	zaptest/logger_test.go:92	work failed	{"error": "great sadness"}`,
-		"PANIC	zaptest/logger_test.go:95	failed to do work",
+		`INFO	zaptest/logger_test.go:89	received work order	{"k1": "v1"}`,
+		`DEBUG	zaptest/logger_test.go:90	starting work	{"k1": "v1"}`,
+		`WARN	zaptest/logger_test.go:91	work may fail	{"k1": "v1"}`,
+		`ERROR	zaptest/logger_test.go:92	work failed	{"k1": "v1", "error": "great sadness"}`,
+		`PANIC	zaptest/logger_test.go:95	failed to do work	{"k1": "v1"}`,
 	)
 }
 

--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -80,6 +80,30 @@ func TestTestLoggerSupportsLevels(t *testing.T) {
 	)
 }
 
+func TestTestLoggerSupportsAddCaller(t *testing.T) {
+	ts := newTestLogSpy(t)
+	defer ts.AssertPassed()
+
+	log := NewLogger(ts, AddCaller())
+
+	log.Info("received work order")
+	log.Debug("starting work")
+	log.Warn("work may fail")
+	log.Error("work failed", zap.Error(errors.New("great sadness")))
+
+	assert.Panics(t, func() {
+		log.Panic("failed to do work")
+	}, "log.Panic should panic")
+
+	ts.AssertMessages(
+		"INFO	zaptest/logger_test.go:89	received work order",
+		"DEBUG	zaptest/logger_test.go:90	starting work",
+		"WARN	zaptest/logger_test.go:91	work may fail",
+		`ERROR	zaptest/logger_test.go:92	work failed	{"error": "great sadness"}`,
+		"PANIC	zaptest/logger_test.go:95	failed to do work",
+	)
+}
+
 func TestTestingWriter(t *testing.T) {
 	ts := newTestLogSpy(t)
 	w := newTestingWriter(ts)


### PR DESCRIPTION
## Synopsis

This PR adds feature suggested in https://github.com/uber-go/zap/issues/609