### PR TITLE
Add grpclog.LoggerV2 logger

### DIFF
--- a/zapgrpc/zapgrpc.go
+++ b/zapgrpc/zapgrpc.go
@@ -23,7 +23,6 @@ package zapgrpc // import "go.uber.org/zap/zapgrpc"
 
 import (
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // An Option overrides a Logger's default configuration.
@@ -43,6 +42,13 @@ func WithDebug() Option {
 	return optionFunc(func(logger *Logger) {
 		logger.print = (*zap.SugaredLogger).Debug
 		logger.printf = (*zap.SugaredLogger).Debugf
+	})
+}
+
+// WithVerbosity sets verbose level referred by V().
+func WithVerbosity(v int) Option {
+	return optionFunc(func(logger *Logger) {
+		logger.v = v
 	})
 }
 
@@ -71,6 +77,7 @@ func NewLogger(l *zap.Logger, options ...Option) *Logger {
 
 // Logger adapts zap's Logger to be compatible with grpclog.Logger and grpclog.LoggerV2.
 type Logger struct {
+	v        int
 	log      *zap.SugaredLogger
 	info     func(*zap.SugaredLogger, ...interface{})
 	infof    func(*zap.SugaredLogger, string, ...interface{})
@@ -161,5 +168,5 @@ func (l *Logger) Println(args ...interface{}) {
 
 // V implements grpclog.LoggerV2.
 func (l *Logger) V(lvl int) bool {
-	return l.log.Desugar().Core().Enabled(zapcore.Level(lvl))
+	return lvl <= l.v
 }

--- a/zapgrpc/zapgrpc_test.go
+++ b/zapgrpc/zapgrpc_test.go
@@ -35,7 +35,13 @@ func TestLoggerInfoExpected(t *testing.T) {
 		"hello",
 		"world",
 		"foo",
+		"hello",
+		"world",
+		"foo",
 	}, func(logger *Logger) {
+		logger.Info("hello")
+		logger.Infof("world")
+		logger.Infoln("foo")
 		logger.Print("hello")
 		logger.Printf("world")
 		logger.Println("foo")
@@ -62,6 +68,30 @@ func TestLoggerDebugSuppressed(t *testing.T) {
 	})
 }
 
+func TestLoggerWarnExpected(t *testing.T) {
+	checkMessages(t, zapcore.DebugLevel, nil, zapcore.WarnLevel, []string{
+		"hello",
+		"world",
+		"foo",
+	}, func(logger *Logger) {
+		logger.Warning("hello")
+		logger.Warningf("world")
+		logger.Warningln("foo")
+	})
+}
+
+func TestLoggerErrorExpected(t *testing.T) {
+	checkMessages(t, zapcore.DebugLevel, nil, zapcore.ErrorLevel, []string{
+		"hello",
+		"world",
+		"foo",
+	}, func(logger *Logger) {
+		logger.Error("hello")
+		logger.Errorf("world")
+		logger.Errorln("foo")
+	})
+}
+
 func TestLoggerFatalExpected(t *testing.T) {
 	checkMessages(t, zapcore.DebugLevel, nil, zapcore.FatalLevel, []string{
 		"hello",
@@ -71,6 +101,30 @@ func TestLoggerFatalExpected(t *testing.T) {
 		logger.Fatal("hello")
 		logger.Fatalf("world")
 		logger.Fatalln("foo")
+	})
+}
+
+func TestLoggerTrueExpected(t *testing.T) {
+	checkLevel(t, zapcore.FatalLevel, true, func(logger *Logger) bool {
+		return logger.V(6)
+	})
+}
+
+func TestLoggerFalseExpected(t *testing.T) {
+	checkLevel(t, zapcore.FatalLevel, false, func(logger *Logger) bool {
+		return logger.V(0)
+	})
+}
+
+func checkLevel(
+	t testing.TB,
+	enab zapcore.LevelEnabler,
+	expectedBool bool,
+	f func(*Logger) bool,
+) {
+	withLogger(enab, nil, func(logger *Logger, observedLogs *observer.ObservedLogs) {
+		actualBool := f(logger)
+		require.Equal(t, expectedBool, actualBool)
 	})
 }
 

--- a/zapgrpc/zapgrpc_test.go
+++ b/zapgrpc/zapgrpc_test.go
@@ -105,13 +105,13 @@ func TestLoggerFatalExpected(t *testing.T) {
 }
 
 func TestLoggerTrueExpected(t *testing.T) {
-	checkLevel(t, zapcore.FatalLevel, true, func(logger *Logger) bool {
+	checkLevel(t, zapcore.FatalLevel, false, func(logger *Logger) bool {
 		return logger.V(6)
 	})
 }
 
 func TestLoggerFalseExpected(t *testing.T) {
-	checkLevel(t, zapcore.FatalLevel, false, func(logger *Logger) bool {
+	checkLevel(t, zapcore.FatalLevel, true, func(logger *Logger) bool {
 		return logger.V(0)
 	})
 }


### PR DESCRIPTION
Fixed V() implementation based on https://github.com/uber-go/zap/pull/538.

[Official grpclog.LoggerV2 implementation](https://github.com/grpc/grpc-go/blob/master/grpclog/loggerv2.go#L107 ) sets verbose level at initialization. So I adopt functional option to set verbose level.