### PR TITLE
Allow thereafter in sampler to be zero

### DIFF
--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -127,7 +127,7 @@ func (s *sampler) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
 
 	counter := s.counts.get(ent.Level, ent.Message)
 	n := counter.IncCheckReset(ent.Time, s.tick)
-	if n > s.first && (n-s.first)%s.thereafter != 0 {
+	if n > s.first && (s.thereafter == 0 || (n-s.first)%s.thereafter != 0) {
 		return ce
 	}
 	return s.Core.Check(ent, ce)

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -86,6 +86,28 @@ func TestSampler(t *testing.T) {
 	}
 }
 
+func TestSamplerZeroThereafter(t *testing.T) {
+	for _, lvl := range []Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel, PanicLevel, FatalLevel} {
+		sampler, logs := fakeSampler(DebugLevel, time.Minute, 2, 0)
+
+		// Ensure that counts aren't shared between levels.
+		probeLevel := DebugLevel
+		if lvl == DebugLevel {
+			probeLevel = InfoLevel
+		}
+		for i := 0; i < 10; i++ {
+			writeSequence(sampler, 1, probeLevel)
+		}
+		// Clear any output.
+		logs.TakeAll()
+
+		for i := 1; i < 10; i++ {
+			writeSequence(sampler, i, lvl)
+		}
+		assertSequence(t, logs.TakeAll(), lvl, 1, 2)
+	}
+}
+
 func TestSamplerDisabledLevels(t *testing.T) {
 	sampler, logs := fakeSampler(InfoLevel, time.Minute, 1, 100)
 


### PR DESCRIPTION
When creating a new Sampler, there is nothing stopping us from passing
in 0 as a value for thereafter. One might expect this to be legal -- as
the documentation doesn't say thereafter should be greater than zero and
no error is returned when passing in this configuration -- and to mean
"drop all messages after the first n". What actually happens is a

    panic: runtime error: integer divide by zero

when we try to log a message.

This patch avoids the division by zero and enforces the behavior
described above.

This fixes issue 632.