### PR TITLE
skip timestamp if EncodeTime is nil (#645)

### DIFF
--- a/zapcore/encoder_test.go
+++ b/zapcore/encoder_test.go
@@ -437,6 +437,24 @@ func TestEncoderConfiguration(t *testing.T) {
 			expectedConsole: "0\tinfo\tfoo.go:42\thello\nfake-stack\n",
 		},
 		{
+			desc: "handle nil EncodeTime - skip timestamp if EncodeTime is nil ",
+			cfg: EncoderConfig{
+				LevelKey:       "L",
+				TimeKey:        "T",
+				MessageKey:     "M",
+				NameKey:        "N",
+				CallerKey:      "C",
+				StacktraceKey:  "S",
+				LineEnding:     base.LineEnding,
+				EncodeTime:     nil,
+				EncodeDuration: base.EncodeDuration,
+				EncodeLevel:    base.EncodeLevel,
+				EncodeCaller:   base.EncodeCaller,
+			},
+			expectedJSON:    `{"L":"info","N":"main","C":"foo.go:42","M":"hello","S":"fake-stack"}` + "\n",
+			expectedConsole: "info\tmain\tfoo.go:42\thello\nfake-stack\n",
+		},
+		{
 			desc: "use custom line separator",
 			cfg: EncoderConfig{
 				LevelKey:       "L",

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -319,7 +319,7 @@ func (enc *jsonEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 			final.AppendString(ent.Level.String())
 		}
 	}
-	if final.TimeKey != "" {
+	if final.TimeKey != "" && final.EncodeTime != nil {
 		final.AddTime(final.TimeKey, ent.Time)
 	}
 	if ent.LoggerName != "" && final.NameKey != "" {


### PR DESCRIPTION
This PR fix the issue #645 
Program will panic when user set the `TimeKey` and did not set `EncodeTime` explicitly.
I've noticed that in `consoleEncoder` it will skip timestamp if EncodeTime is nil, so I add this into `jsonEncoder` to ensure behavioral consistency.