### PR TITLE
Fix an inconsistency in MapObjectEncoder

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -76,7 +76,7 @@ func TestArrayWrappers(t *testing.T) {
 		{"empty uint8s", Uint8s("", []uint8{}), []interface{}{}},
 		{"empty uintptrs", Uintptrs("", []uintptr{}), []interface{}{}},
 		{"bools", Bools("", []bool{true, false}), []interface{}{true, false}},
-		{"byte strings", ByteStrings("", [][]byte{{1, 2}, {3, 4}}), []interface{}{[]byte{1, 2}, []byte{3, 4}}},
+		{"byte strings", ByteStrings("", [][]byte{{1, 2}, {3, 4}}), []interface{}{"\x01\x02", "\x03\x04"}},
 		{"complex128s", Complex128s("", []complex128{1 + 2i, 3 + 4i}), []interface{}{1 + 2i, 3 + 4i}},
 		{"complex64s", Complex64s("", []complex64{1 + 2i, 3 + 4i}), []interface{}{complex64(1 + 2i), complex64(3 + 4i)}},
 		{"durations", Durations("", []time.Duration{1, 2}), []interface{}{time.Nanosecond, 2 * time.Nanosecond}},

--- a/zapcore/memory_encoder.go
+++ b/zapcore/memory_encoder.go
@@ -158,7 +158,7 @@ func (s *sliceArrayEncoder) AppendReflected(v interface{}) error {
 }
 
 func (s *sliceArrayEncoder) AppendBool(v bool)              { s.elems = append(s.elems, v) }
-func (s *sliceArrayEncoder) AppendByteString(v []byte)      { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendByteString(v []byte)      { s.elems = append(s.elems, string(v)) }
 func (s *sliceArrayEncoder) AppendComplex128(v complex128)  { s.elems = append(s.elems, v) }
 func (s *sliceArrayEncoder) AppendComplex64(v complex64)    { s.elems = append(s.elems, v) }
 func (s *sliceArrayEncoder) AppendDuration(v time.Duration) { s.elems = append(s.elems, v) }

--- a/zapcore/memory_encoder_test.go
+++ b/zapcore/memory_encoder_test.go
@@ -88,6 +88,11 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 			expected: []byte("foo"),
 		},
 		{
+			desc:     "AddByteString",
+			f:        func(e ObjectEncoder) { e.AddByteString("k", []byte("foo")) },
+			expected: "foo",
+		},
+		{
 			desc:     "AddBool",
 			f:        func(e ObjectEncoder) { e.AddBool("k", true) },
 			expected: true,
@@ -228,6 +233,7 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 		// AppendObject and AppendArray are covered by the AddObject (nested) and
 		// AddArray (nested) cases above.
 		{"AppendBool", func(e ArrayEncoder) { e.AppendBool(true) }, true},
+		{"AppendByteString", func(e ArrayEncoder) { e.AppendByteString([]byte("foo")) }, "foo"},
 		{"AppendComplex128", func(e ArrayEncoder) { e.AppendComplex128(1 + 2i) }, 1 + 2i},
 		{"AppendComplex64", func(e ArrayEncoder) { e.AppendComplex64(1 + 2i) }, complex64(1 + 2i)},
 		{"AppendDuration", func(e ArrayEncoder) { e.AppendDuration(time.Second) }, time.Second},


### PR DESCRIPTION
For some reason, ObjectEncoder has `AddBinary` and `AddByteString` methods, but ArrayEncoder only has `AppendByteString`. This PR adds the missing (forgotten?) `AppendBinary` method.

Also, I've fixed up a small inconsistency in the MapObjectEncoder that's used in the tests.

Two independent commits - can be reviewed/merged separately (or split into two PRs if you prefer).