### PR TITLE
Only set entry time when it will be logged

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -262,7 +262,6 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 	// log message will actually be written somewhere.
 	ent := zapcore.Entry{
 		LoggerName: log.name,
-		Time:       time.Now(),
 		Level:      lvl,
 		Message:    msg,
 	}
@@ -287,6 +286,8 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 	if !willWrite {
 		return ce
 	}
+
+	ent.Time = time.Now()
 
 	// Thread the error output through to the CheckedEntry.
 	ce.ErrorOutput = log.errorOutput


### PR DESCRIPTION
This pull request optimizes the Check scenario. It only sets the entry time after the decision has been made to log the entry or not. This improves performance in a disabled scenario by 63.55%.

```
benchmark                                           old ns/op     new ns/op     delta
BenchmarkDisabledAccumulatedContext/Zap.Check-4     20.3          7.40          -63.55%
```