### PR TITLE
Add forgotten AppendBinary to ArrayEncoder

### DIFF
--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -308,7 +308,8 @@ type ArrayEncoder interface {
 type PrimitiveArrayEncoder interface {
 	// Built-in types.
 	AppendBool(bool)
-	AppendByteString([]byte) // for UTF-8 encoded bytes
+	AppendBinary(value []byte) // for arbitrary bytes
+	AppendByteString([]byte)   // for UTF-8 encoded bytes
 	AppendComplex128(complex128)
 	AppendComplex64(complex64)
 	AppendFloat64(float64)

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -196,6 +196,10 @@ func (enc *jsonEncoder) AppendBool(val bool) {
 	enc.buf.AppendBool(val)
 }
 
+func (enc *jsonEncoder) AppendBinary(val []byte) {
+	enc.AppendString(base64.StdEncoding.EncodeToString(val))
+}
+
 func (enc *jsonEncoder) AppendByteString(val []byte) {
 	enc.addElementSeparator()
 	enc.buf.AppendByte('"')

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -236,6 +236,8 @@ func TestJSONEncoderArrays(t *testing.T) {
 		f        func(ArrayEncoder)
 	}{
 		{"bool", `[true,true]`, func(e ArrayEncoder) { e.AppendBool(true) }},
+		{"binary", `["aw==","aw=="]`, func(e ArrayEncoder) { e.AppendBinary([]byte("k")) }},
+		{"binary", `["a1w=","a1w="]`, func(e ArrayEncoder) { e.AppendBinary([]byte(`k\`)) }},
 		{"byteString", `["k","k"]`, func(e ArrayEncoder) { e.AppendByteString([]byte("k")) }},
 		{"byteString", `["k\\","k\\"]`, func(e ArrayEncoder) { e.AppendByteString([]byte(`k\`)) }},
 		{"complex128", `["1+2i","1+2i"]`, func(e ArrayEncoder) { e.AppendComplex128(1 + 2i) }},

--- a/zapcore/memory_encoder.go
+++ b/zapcore/memory_encoder.go
@@ -158,6 +158,7 @@ func (s *sliceArrayEncoder) AppendReflected(v interface{}) error {
 }
 
 func (s *sliceArrayEncoder) AppendBool(v bool)              { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendBinary(v []byte)          { s.elems = append(s.elems, v) }
 func (s *sliceArrayEncoder) AppendByteString(v []byte)      { s.elems = append(s.elems, v) }
 func (s *sliceArrayEncoder) AppendComplex128(v complex128)  { s.elems = append(s.elems, v) }
 func (s *sliceArrayEncoder) AppendComplex64(v complex64)    { s.elems = append(s.elems, v) }

--- a/zapcore/memory_encoder_test.go
+++ b/zapcore/memory_encoder_test.go
@@ -228,6 +228,7 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 		// AppendObject and AppendArray are covered by the AddObject (nested) and
 		// AddArray (nested) cases above.
 		{"AppendBool", func(e ArrayEncoder) { e.AppendBool(true) }, true},
+		{"AppendBinary", func(e ArrayEncoder) { e.AppendBinary([]byte("foo")) }, []byte("foo")},
 		{"AppendComplex128", func(e ArrayEncoder) { e.AppendComplex128(1 + 2i) }, 1 + 2i},
 		{"AppendComplex64", func(e ArrayEncoder) { e.AppendComplex64(1 + 2i) }, complex64(1 + 2i)},
 		{"AppendDuration", func(e ArrayEncoder) { e.AppendDuration(time.Second) }, time.Second},


### PR DESCRIPTION
For some reason, ObjectEncoder has AddBinary and AddByteString methods, but ArrayEncoder only has AppendByteString. This PR adds the missing (forgotten?) AppendBinary method.

I realise this will have to wait until zap v2, since it's a breaking API change.