### PR TITLE
Update Travis config to build/test with Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: false
 go:
-  - 1.9.x
   - 1.10.x
+  - 1.11.x
 go_import_path: go.uber.org/zap
 env:
   global:


### PR DESCRIPTION
Now that Go 1.11 has been released, the most-recent two Go versions are 1.10 and 1.11.

The CI build should be testing compatibility with Go 1.11!