### PR TITLE
Skip low level message to avoid `clock_gettime`

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -260,12 +260,20 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 
 	// Create basic checked entry thru the core; this will be non-nil if the
 	// log message will actually be written somewhere.
-	ent := zapcore.Entry{
-		LoggerName: log.name,
-		Time:       time.Now(),
-		Level:      lvl,
-		Message:    msg,
+	var ent zapcore.Entry
+	if log.core.Enabled(lvl) {
+		ent = zapcore.Entry{
+			LoggerName: log.name,
+			Time:       time.Now(),
+			Level:      lvl,
+			Message:    msg,
+		}
+	} else {
+		ent = zapcore.Entry{
+			Level: lvl,
+		}
 	}
+
 	ce := log.core.Check(ent, nil)
 	willWrite := ce != nil
 


### PR DESCRIPTION
Skip lower level logs to avoid too much`time.Now()`,  especially each `time.Now()` will invoke `clock_gettime`. This costs a lot of time even though there is no log match the level to print.

![log](https://user-images.githubusercontent.com/4532436/51731894-52b1d180-20b7-11e9-99af-b82fe0d15a0a.jpg)


This fix will significant reduce the number of syscall and improve performance.

On my test (set log level as `INFO`, then invoke `logger.Debug("xxx")` in benchmark ):

![srceen_shot 2019-01-25 at 14 28 31](https://user-images.githubusercontent.com/4532436/51731694-be476f00-20b6-11e9-8128-a972c1982af0.jpg)
