### PR TITLE
Don't panic when a given field value is nil

### DIFF
--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -160,7 +160,7 @@ func (f Field) AddTo(enc ObjectEncoder) {
 	case NamespaceType:
 		enc.OpenNamespace(f.Key)
 	case StringerType:
-		enc.AddString(f.Key, f.Interface.(fmt.Stringer).String())
+		err = encodeStringer(f.Key, f.Interface, enc)
 	case ErrorType:
 		encodeError(f.Key, f.Interface.(error), enc)
 	case SkipType:
@@ -198,4 +198,15 @@ func addFields(enc ObjectEncoder, fields []Field) {
 	for i := range fields {
 		fields[i].AddTo(enc)
 	}
+}
+
+func encodeStringer(key string, stringer interface{}, enc ObjectEncoder) (err error) {
+	defer func() {
+		if v := recover(); v != nil {
+			err = fmt.Errorf("PANIC=%v", v)
+		}
+	}()
+
+	enc.AddString(key, stringer.(fmt.Stringer).String())
+	return
 }


### PR DESCRIPTION
Ideally a logging framework doesn't cause a panic for code like this:

```go
foo, err := getFoo()

if err != nil {
   log.Error("Couldn't acquire foo", zap.Error(err))
}

// foo could be nil here
log = log.With(zap.Stringer("foo", foo))

bar, err := getBar()

if err != nil {
  // panics
  log.Error("Couldn't acquire bar", zap.Error(err))
}
```

This is probably also fixing #495 and #528 