### PR TITLE
Add LazyMessage function as message argument in debug methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _testmain.go
 *.pprof
 *.out
 *.log
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ _testmain.go
 *.out
 *.log
 .vscode/
+*.swp

--- a/benchmarks/zap_test.go
+++ b/benchmarks/zap_test.go
@@ -34,10 +34,11 @@ import (
 var (
 	errExample = errors.New("fail")
 
-	_messages   = fakeMessages(1000)
-	_tenInts    = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
-	_tenStrings = []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
-	_tenTimes   = []time.Time{
+	_messages     = fakeMessages(1000)
+	_messageBytes = fakeMessageBytes(1000)
+	_tenInts      = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
+	_tenStrings   = []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
+	_tenTimes     = []time.Time{
 		time.Unix(0, 0),
 		time.Unix(1, 0),
 		time.Unix(2, 0),
@@ -78,6 +79,23 @@ func fakeMessages(n int) []string {
 
 func getMessage(iter int) string {
 	return _messages[iter%1000]
+}
+
+func fakeMessageBytes(n int) [][]byte {
+	messageBytes := make([][]byte, n)
+	for i := range messageBytes {
+		messageBytes[i] = []byte(fmt.Sprintf(`
+Test logging, but use a somewhat realistic message length and convert to byte array. (#%v).
+Commonly in most requests a long entity body may be created and submitted to the target server. (#%v).
+And again I am making this message a bit longer than usual to be logged. (#%v).
+Thus, a more realistic situation may be simulated, yes ...... longer and longer, lenthier and lenthier, and done for now. (#%v).
+			`, i, i+1, i+2, i+3))
+	}
+	return messageBytes
+}
+
+func getMessageBytes(iter int) []byte {
+	return _messageBytes[iter%1000]
 }
 
 type users []*user

--- a/config_test.go
+++ b/config_test.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"testing"
 
+	"go.uber.org/zap/zapcore"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,7 +48,7 @@ func TestConfig(t *testing.T) {
 		{
 			desc:    "development",
 			cfg:     NewDevelopmentConfig(),
-			expectN: 3 + 200, // 3 initial logs, all 200 subsequent logs
+			expectN: 4 + 200, // 3 initial logs, all 200 subsequent logs
 			expectRe: "DEBUG\tzap/config_test.go:" + `\d+` + "\tdebug\t" + `{"k": "v", "z": "zz"}` + "\n" +
 				"INFO\tzap/config_test.go:" + `\d+` + "\tinfo\t" + `{"k": "v", "z": "zz"}` + "\n" +
 				"WARN\tzap/config_test.go:" + `\d+` + "\twarn\t" + `{"k": "v", "z": "zz"}` + "\n" +
@@ -68,6 +70,7 @@ func TestConfig(t *testing.T) {
 			logger, err := tt.cfg.Build(Hooks(hook))
 			require.NoError(t, err, "Unexpected error constructing logger.")
 
+			logger.Debugl(zapcore.LazyMessage(func() string { return "debugl" }))
 			logger.Debug("debug")
 			logger.Info("info")
 			logger.Warn("warn")

--- a/logger_test.go
+++ b/logger_test.go
@@ -385,6 +385,7 @@ func TestLoggerReplaceCore(t *testing.T) {
 		return zapcore.NewNopCore()
 	})
 	withLogger(t, DebugLevel, opts(replace), func(logger *Logger, logs *observer.ObservedLogs) {
+		logger.Debugl(zapcore.LazyMessage(func() string { return "" }))
 		logger.Debug("")
 		logger.Info("")
 		logger.Warn("")
@@ -395,10 +396,11 @@ func TestLoggerReplaceCore(t *testing.T) {
 func TestLoggerHooks(t *testing.T) {
 	hook, seen := makeCountingHook()
 	withLogger(t, DebugLevel, opts(Hooks(hook)), func(logger *Logger, logs *observer.ObservedLogs) {
+		logger.Debugl(zapcore.LazyMessage(func() string { return "" }))
 		logger.Debug("")
 		logger.Info("")
 	})
-	assert.Equal(t, int64(2), seen.Load(), "Hook saw an unexpected number of logs.")
+	assert.Equal(t, int64(3), seen.Load(), "Hook saw an unexpected number of logs.")
 }
 
 func TestLoggerConcurrent(t *testing.T) {

--- a/zapcore/core.go
+++ b/zapcore/core.go
@@ -83,6 +83,9 @@ func (c *ioCore) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
 }
 
 func (c *ioCore) Write(ent Entry, fields []Field) error {
+	if len(ent.Message) == 0 && ent.LazyMessage != nil {
+		ent.Message = ent.LazyMessage()
+	}
 	buf, err := c.enc.EncodeEntry(ent, fields)
 	if err != nil {
 		return err

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -134,19 +134,29 @@ func (ec EntryCaller) TrimmedPath() string {
 	return caller
 }
 
+// LazyMessage defines a function that returns a string.
+// The function is passed to the logger in the Debugl method
+// and should be evaluated when the message is actually going to
+// be written to the core. The common practice is that this function
+// should only be called once.
+type LazyMessage func() string
+
 // An Entry represents a complete log message. The entry's structured context
 // is already serialized, but the log level, time, message, and call site
 // information are available for inspection and modification.
+// The LazyMessage field is added to handle LazyMessage passed to
+// Debugl method.
 //
 // Entries are pooled, so any functions that accept them MUST be careful not to
 // retain references to them.
 type Entry struct {
-	Level      Level
-	Time       time.Time
-	LoggerName string
-	Message    string
-	Caller     EntryCaller
-	Stack      string
+	Level       Level
+	Time        time.Time
+	LoggerName  string
+	Message     string
+	LazyMessage LazyMessage
+	Caller      EntryCaller
+	Stack       string
 }
 
 // CheckWriteAction indicates what action to take after a log entry is

--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -41,6 +41,7 @@ func TestTestLogger(t *testing.T) {
 	log := NewLogger(ts)
 
 	log.Info("received work order")
+	log.Debugl(zapcore.LazyMessage(func() string { return "starting work " + "for debugl" }))
 	log.Debug("starting work")
 	log.Warn("work may fail")
 	log.Error("work failed", zap.Error(errors.New("great sadness")))
@@ -51,6 +52,7 @@ func TestTestLogger(t *testing.T) {
 
 	ts.AssertMessages(
 		"INFO	received work order",
+		"DEBUG	starting work for debugl",
 		"DEBUG	starting work",
 		"WARN	work may fail",
 		`ERROR	work failed	{"error": "great sadness"}`,
@@ -65,6 +67,7 @@ func TestTestLoggerSupportsLevels(t *testing.T) {
 	log := NewLogger(ts, Level(zap.WarnLevel))
 
 	log.Info("received work order")
+	log.Debugl(zapcore.LazyMessage(func() string { return "starting" + " work for debugl" }))
 	log.Debug("starting work")
 	log.Warn("work may fail")
 	log.Error("work failed", zap.Error(errors.New("great sadness")))
@@ -87,6 +90,7 @@ func TestTestLoggerSupportsWrappedZapOptions(t *testing.T) {
 	log := NewLogger(ts, WrapOptions(zap.AddCaller(), zap.Fields(zap.String("k1", "v1"))))
 
 	log.Info("received work order")
+	log.Debugl(zapcore.LazyMessage(func() string { return "starting work " + "for debugl" }))
 	log.Debug("starting work")
 	log.Warn("work may fail")
 	log.Error("work failed", zap.Error(errors.New("great sadness")))
@@ -96,11 +100,12 @@ func TestTestLoggerSupportsWrappedZapOptions(t *testing.T) {
 	}, "log.Panic should panic")
 
 	ts.AssertMessages(
-		`INFO	zaptest/logger_test.go:89	received work order	{"k1": "v1"}`,
-		`DEBUG	zaptest/logger_test.go:90	starting work	{"k1": "v1"}`,
-		`WARN	zaptest/logger_test.go:91	work may fail	{"k1": "v1"}`,
-		`ERROR	zaptest/logger_test.go:92	work failed	{"k1": "v1", "error": "great sadness"}`,
-		`PANIC	zaptest/logger_test.go:95	failed to do work	{"k1": "v1"}`,
+		`INFO	zaptest/logger_test.go:92	received work order	{"k1": "v1"}`,
+		`DEBUG	zaptest/logger_test.go:93	starting work for debugl	{"k1": "v1"}`,
+		`DEBUG	zaptest/logger_test.go:94	starting work	{"k1": "v1"}`,
+		`WARN	zaptest/logger_test.go:95	work may fail	{"k1": "v1"}`,
+		`ERROR	zaptest/logger_test.go:96	work failed	{"k1": "v1", "error": "great sadness"}`,
+		`PANIC	zaptest/logger_test.go:99	failed to do work	{"k1": "v1"}`,
 	)
 }
 

--- a/zaptest/observer/observer_test.go
+++ b/zaptest/observer/observer_test.go
@@ -46,6 +46,7 @@ func TestObserver(t *testing.T) {
 	obs := zap.New(observer).With(zap.Int("i", 1))
 	obs.Info("foo")
 	obs.Debug("bar")
+	obs.Debugl(zapcore.LazyMessage(func() string { return "bar" + "l" }))
 	want := []LoggedEntry{{
 		Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "foo"},
 		Context: []zapcore.Field{zap.Int("i", 1)},


### PR DESCRIPTION
# Add LazyMessage Function as Message Argument in Debug Methods

Logging debug messages is a common way to print out diagnostic information in log files during development and testing phases. However, too many debug-level logs may impact system performance in production especially when debug messages have to be generated before being passed to log functions. Examples of such use cases are but not limited to:

* Printing out string representation of a byte array in a request body to find out what is actually in the request
* Printing out a struct in a custom (mostly a calculated form) string form instead of Go's default implementation.

This change introduces `LazyMessage` function as an argument to be passed to Debug functions. `LazyMessage` is a simple no-arg function that returns a string, exactly the same signature as `stringer` does. When a debug function is called, the logging level is checked before `LazyMessage` function is evaluated, which eliminates unnecessary debug message generation if debug is disabled in the current log level (often in production).

Both `zap.Logger` and `zap.SugaredLogger` are changed with new debug functions added. Mild modifications to existing internal functions and structures are made to avoid code redundancy and assure correct level of call stack depth (caller skip values).

Unit tests are adjusted with newly added debug function calls in various test cases.

Benchmark tests with `BenchmarkDebuglWithoutFields` are added in scenario_bench_test.go. The benchmark test runs all the new debug functions compared to existing debug functions with current log level set to `info`. Here is the result of a benchmark run:

```
Running tool: /usr/local/bin/go test -benchmem -run=^$ go.uber.org/zap/benchmarks -bench ^(BenchmarkDebuglWithoutFields)$

goos: darwin
goarch: amd64
pkg: go.uber.org/zap/benchmarks
BenchmarkDebuglWithoutFields/Zap.DebugOnInfo-12         	10000000	       164 ns/op	     529 B/op	       5 allocs/op
BenchmarkDebuglWithoutFields/Zap.DebuglOnInfo-12        	100000000	        21.9 ns/op	      16 B/op	       1 allocs/op
BenchmarkDebuglWithoutFields/Zap.DebugOnInfoWithBytesToString-12         	20000000	        93.2 ns/op	     416 B/op	       1 allocs/op
BenchmarkDebuglWithoutFields/Zap.DebuglOnInfoWithBytesToString-12        	100000000	        22.6 ns/op	      16 B/op	       1 allocs/op
BenchmarkDebuglWithoutFields/Zap.SugarDebugOnInfo-12                     	10000000	       188 ns/op	     545 B/op	       6 allocs/op
BenchmarkDebuglWithoutFields/Zap.SugarDebugflOnInfo-12                   	200000000	         9.55 ns/op	      16 B/op	       1 allocs/op
BenchmarkDebuglWithoutFields/Zap.DebugOnInfoWithBytesToString#01-12      	10000000	       123 ns/op	     432 B/op	       2 allocs/op
BenchmarkDebuglWithoutFields/Zap.DebuglOnInfoWithBytesToString#01-12     	100000000	        10.1 ns/op	      16 B/op	       1 allocs/op
PASS
ok  	go.uber.org/zap/benchmarks	15.610s
Success: Benchmarks passed.
```

This idea comes from Log4j2's `logger.debug()` method: https://logging.apache.org/log4j/2.x/log4j-api/apidocs/index.html