### PR TITLE
zap.BuildForTest allows injection of an output WriteSyncer 

### DIFF
--- a/config.go
+++ b/config.go
@@ -164,12 +164,16 @@ func NewDevelopmentConfig() Config {
 
 // Build constructs a logger from the Config and Options.
 func (cfg Config) Build(opts ...Option) (*Logger, error) {
-	enc, err := cfg.buildEncoder()
+	sink, errSink, err := cfg.openSinks()
 	if err != nil {
 		return nil, err
 	}
 
-	sink, errSink, err := cfg.openSinks()
+	return BuildForTest(cfg, sink, errSink, opts...)
+}
+
+func BuildForTest(cfg Config, sink, errSink zapcore.WriteSyncer, opts ...Option) (*Logger, error) {
+	enc, err := cfg.buildEncoder()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I wanted to test some context sensitive custom fields. However there does not currently exist a method to test the output of a logger constructed from the handy New[Development|Production]Logger.

This adds a public function that accepts the WriteSyncers directly so that buffers can be supplied and then reviewed after a message is logged.