### PR TITLE
Move addFields to ObjectEncoder  to let logger#With be extendible

### DIFF
--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -128,7 +128,7 @@ func (c consoleEncoder) writeContext(line *buffer.Buffer, extra []Field) {
 	context := c.jsonEncoder.Clone().(*jsonEncoder)
 	defer context.buf.Free()
 
-	addFields(context, extra)
+	context.AddFields(extra)
 	context.closeOpenNamespaces()
 	if context.buf.Len() == 0 {
 		return

--- a/zapcore/core.go
+++ b/zapcore/core.go
@@ -71,7 +71,7 @@ type ioCore struct {
 
 func (c *ioCore) With(fields []Field) Core {
 	clone := c.clone()
-	addFields(clone.enc, fields)
+	clone.enc.AddFields(fields)
 	return clone
 }
 

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -279,6 +279,8 @@ type ObjectEncoder interface {
 	// be added. Applications can use namespaces to prevent key collisions when
 	// injecting loggers into sub-components or third-party libraries.
 	OpenNamespace(key string)
+	// AddFields adds more than multiple fields in once.
+	AddFields(fields []Field)
 }
 
 // ArrayEncoder is a strongly-typed, encoding-agnostic interface for adding

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -193,9 +193,3 @@ func (f Field) Equals(other Field) bool {
 		return f == other
 	}
 }
-
-func addFields(enc ObjectEncoder, fields []Field) {
-	for i := range fields {
-		fields[i].AddTo(enc)
-	}
-}

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -160,6 +160,12 @@ func (enc *jsonEncoder) OpenNamespace(key string) {
 	enc.openNamespaces++
 }
 
+func (enc *jsonEncoder) AddFields(fields []Field) {
+	for _, field := range fields {
+		field.AddTo(enc)
+	}
+}
+
 func (enc *jsonEncoder) AddString(key, val string) {
 	enc.addKey(key)
 	enc.AppendString(val)
@@ -358,7 +364,7 @@ func (enc *jsonEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 		final.addElementSeparator()
 		final.buf.Write(enc.buf.Bytes())
 	}
-	addFields(final, fields)
+	final.AddFields(fields)
 	final.closeOpenNamespaces()
 	if ent.Stack != "" && final.StacktraceKey != "" {
 		final.AddString(final.StacktraceKey, ent.Stack)

--- a/zapcore/memory_encoder.go
+++ b/zapcore/memory_encoder.go
@@ -132,6 +132,13 @@ func (m *MapObjectEncoder) OpenNamespace(k string) {
 	m.cur = ns
 }
 
+// AddFields implements ObjectEncoder.
+func (m *MapObjectEncoder) AddFields(fields []Field) {
+	for _, field := range fields {
+		field.AddTo(m)
+	}
+}
+
 // sliceArrayEncoder is an ArrayEncoder backed by a simple []interface{}. Like
 // the MapObjectEncoder, it's not designed for production use.
 type sliceArrayEncoder struct {

--- a/zapcore/memory_encoder_test.go
+++ b/zapcore/memory_encoder_test.go
@@ -290,3 +290,12 @@ func TestMapObjectEncoderReflectionFailures(t *testing.T) {
 		"Expected encoder to use empty values on errors.",
 	)
 }
+
+func TestMapObjectEncoderAddaFields(t *testing.T) {
+	enc := NewMapObjectEncoder()
+	enc.AddFields([]Field{
+		{Key: "AddStr", Type: StringType, String: "StrVal"},
+		{Key: "AddInt", Type: Int64Type, Integer: int64(1)},
+	})
+	assert.Equal(t, 2, len(enc.Fields))
+}


### PR DESCRIPTION
1. What did you do?

we write a [TextEncoder](https://github.com/pingcap/log/blob/master/zap_text_encoder.go#L124) to let log be formated as

```
[2019/03/04 23:00:05.943 +08:00] [ERROR] [log_test.go:209] [common=comval] [k=v]
```

but found that `With` method cannot add `[ ]`

```
newLogger := logger.With(zap.String("c", "c1"))
newLogger.Error("", zap.String("k", "v"))
```

will got 

```
[2019/03/04 23:00:05.943 +08:00] [ERROR] [log_test.go:209],c=c1 [k=v]
```

2. What's the problem

found that `addFields` at

https://github.com/uber-go/zap/blob/master/zapcore/field.go#L197

maybe better move to  `objectEncoder` at

https://github.com/uber-go/zap/blob/master/zapcore/encoder.go#L247

so transfer the responsibility of how to print multiple field  to objectEncoder, so other people can customize it, eg. we can add `[` `]` sourrounding each field even them add via [logger#With](https://github.com/uber-go/zap/blob/master/logger.go#L159)

3. What is changed

move addFields to ObjectEncoder  and let current implements it.


ref https://github.com/pingcap/log/issues/3, https://github.com/pingcap/tidb/pull/9548




