### PR TITLE
support delimiter for console encoder

### DIFF
--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -123,7 +123,7 @@ func (c consoleEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 
 	// Add the message itself.
 	if c.MessageKey != "" {
-		c.addDelimitorIfNecessary(line)
+		c.addDelimiterIfNecessary(line)
 		line.AppendString(ent.Message)
 	}
 
@@ -155,13 +155,13 @@ func (c consoleEncoder) writeContext(line *buffer.Buffer, extra []Field) {
 		return
 	}
 
-	c.addDelimitorIfNecessary(line)
+	c.addDelimiterIfNecessary(line)
 	line.AppendByte('{')
 	line.Write(context.buf.Bytes())
 	line.AppendByte('}')
 }
 
-func (c consoleEncoder) addDelimitorIfNecessary(line *buffer.Buffer) {
+func (c consoleEncoder) addDelimiterIfNecessary(line *buffer.Buffer) {
 	if line.Len() > 0 {
 		line.AppendByte(delimiter)
 	}

--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -30,15 +30,15 @@ import (
 )
 
 const (
-	ZAP_CONSOLE_DELIMITER         = "ZAP_CONSOLE_DELIMITER"
-	ZAP_CONSOLE_DELIMITER_DEFAULT = "\t"
+	ZapConsoleDelimiter        = "ZAP_CONSOLE_DELIMITER"
+	ZapConsoleDelimiterDefault = "\t"
 )
 
 var delimiter byte
 
 func init() {
-	delimitorEnv := GetElementDelimitor()
-	if strings.EqualFold(delimitorEnv, ZAP_CONSOLE_DELIMITER_DEFAULT) {
+	delimitorEnv := getElementDelimitor()
+	if strings.EqualFold(delimitorEnv, ZapConsoleDelimiterDefault) {
 		delimiter = '\t'
 	} else if strings.EqualFold(delimitorEnv, " ") {
 		delimiter = ' '
@@ -167,14 +167,15 @@ func (c consoleEncoder) addDelimiterIfNecessary(line *buffer.Buffer) {
 	}
 }
 
-func GetElementDelimitor() string {
-	v, ok := os.LookupEnv("ZAP_CONSOLE_DELIMITER")
+func getElementDelimitor() string {
+	v, ok := os.LookupEnv(ZapConsoleDelimiter)
 	if !ok {
-		return ZAP_CONSOLE_DELIMITER_DEFAULT
+		return ZapConsoleDelimiter
 	}
 	return v
 }
 
+// Set delimiter of the console elements, default is '\t'
 func SetConsoleElementDelimiter(deli byte) {
 	delimiter = deli
 }

--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -175,6 +175,6 @@ func GetElementDelimitor() string {
 	return v
 }
 
-func SetConsoleElementDelimitor(deli byte) {
+func SetConsoleElementDelimiter(deli byte) {
 	delimiter = deli
 }

--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -30,7 +30,9 @@ import (
 )
 
 const (
-	ZapConsoleDelimiter        = "ZAP_CONSOLE_DELIMITER"
+	//ZapConsoleDelimiter  The key of console encoder element delimiter
+	ZapConsoleDelimiter = "ZAP_CONSOLE_DELIMITER"
+	//ZapConsoleDelimiterDefault Default value of console encoder
 	ZapConsoleDelimiterDefault = "\t"
 )
 
@@ -175,7 +177,7 @@ func getElementDelimitor() string {
 	return v
 }
 
-// Set delimiter of the console elements, default is '\t'
+//SetConsoleElementDelimiter Set delimiter of the console elements, default is '\t'
 func SetConsoleElementDelimiter(deli byte) {
 	delimiter = deli
 }


### PR DESCRIPTION
It would be nice to have a configurable delimiter for console encoder, tab by default.

For our cases, we prefer to have `space` as element delimiter.

Now user can set console delimiter through env var `ZAP_CONSOLE_DELIMITER= ` or directly call `zapcore.SetConsoleElementDelimiter(delimiter)`