### PR TITLE
Disable HTMLEscape in reflect JSON encoder

### DIFF
--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -137,6 +137,9 @@ func (enc *jsonEncoder) resetReflectBuf() {
 	if enc.reflectBuf == nil {
 		enc.reflectBuf = bufferpool.Get()
 		enc.reflectEnc = json.NewEncoder(enc.reflectBuf)
+
+		// For consistency with our custom JSON encoder.
+		enc.reflectEnc.SetEscapeHTML(false)
 	} else {
 		enc.reflectBuf.Reset()
 	}

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -195,9 +195,9 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 		},
 		{
 			desc:     "reflect (success)",
-			expected: `"k":{"loggable":"yes"}`,
+			expected: `"k":{"escape":"<&>","loggable":"yes"}`,
 			f: func(e Encoder) {
-				assert.NoError(t, e.AddReflected("k", map[string]string{"loggable": "yes"}), "Unexpected error JSON-serializing a map.")
+				assert.NoError(t, e.AddReflected("k", map[string]string{"escape": "<&>", "loggable": "yes"}), "Unexpected error JSON-serializing a map.")
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #700.

Zap's custom JSON encoder does not escape HTML, so make encoding
by the reflect-based JSON encoder work the same way.