### PR TITLE
Make API for omitting keys more approachable.

### DIFF
--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -31,6 +31,9 @@ import (
 // behavior.
 const DefaultLineEnding = "\n"
 
+// OmitKey defines the key to use when callers want to remove a key from log output.
+const OmitKey = ""
+
 // A LevelEncoder serializes a Level to a primitive type.
 type LevelEncoder func(Level, PrimitiveArrayEncoder)
 

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -343,6 +343,7 @@ type Encoder interface {
 	Clone() Encoder
 
 	// EncodeEntry encodes an entry and fields, along with any accumulated
-	// context, into a byte buffer and returns it.
+	// context, into a byte buffer and returns it. Any fields that are empty,
+	// including fields on the `Entry` type, should be omitted.
 	EncodeEntry(Entry, []Field) (*buffer.Buffer, error)
 }

--- a/zapcore/encoder_test.go
+++ b/zapcore/encoder_test.go
@@ -121,7 +121,7 @@ func TestEncoderConfiguration(t *testing.T) {
 		{
 			desc: "skip level if LevelKey is omitted",
 			cfg: EncoderConfig{
-				LevelKey:       "",
+				LevelKey:       OmitKey,
 				TimeKey:        "T",
 				MessageKey:     "M",
 				NameKey:        "N",
@@ -140,7 +140,7 @@ func TestEncoderConfiguration(t *testing.T) {
 			desc: "skip timestamp if TimeKey is omitted",
 			cfg: EncoderConfig{
 				LevelKey:       "L",
-				TimeKey:        "",
+				TimeKey:        OmitKey,
 				MessageKey:     "M",
 				NameKey:        "N",
 				CallerKey:      "C",
@@ -159,7 +159,7 @@ func TestEncoderConfiguration(t *testing.T) {
 			cfg: EncoderConfig{
 				LevelKey:       "L",
 				TimeKey:        "T",
-				MessageKey:     "",
+				MessageKey:     OmitKey,
 				NameKey:        "N",
 				CallerKey:      "C",
 				StacktraceKey:  "S",
@@ -178,7 +178,7 @@ func TestEncoderConfiguration(t *testing.T) {
 				LevelKey:       "L",
 				TimeKey:        "T",
 				MessageKey:     "M",
-				NameKey:        "",
+				NameKey:        OmitKey,
 				CallerKey:      "C",
 				StacktraceKey:  "S",
 				LineEnding:     base.LineEnding,
@@ -197,7 +197,7 @@ func TestEncoderConfiguration(t *testing.T) {
 				TimeKey:        "T",
 				MessageKey:     "M",
 				NameKey:        "N",
-				CallerKey:      "",
+				CallerKey:      OmitKey,
 				StacktraceKey:  "S",
 				LineEnding:     base.LineEnding,
 				EncodeTime:     base.EncodeTime,
@@ -216,7 +216,7 @@ func TestEncoderConfiguration(t *testing.T) {
 				MessageKey:     "M",
 				NameKey:        "N",
 				CallerKey:      "C",
-				StacktraceKey:  "",
+				StacktraceKey:  OmitKey,
 				LineEnding:     base.LineEnding,
 				EncodeTime:     base.EncodeTime,
 				EncodeDuration: base.EncodeDuration,

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -136,7 +136,8 @@ func (ec EntryCaller) TrimmedPath() string {
 
 // An Entry represents a complete log message. The entry's structured context
 // is already serialized, but the log level, time, message, and call site
-// information are available for inspection and modification.
+// information are available for inspection and modification. Any fields left
+// empty will be omitted when encoding.
 //
 // Entries are pooled, so any functions that accept them MUST be careful not to
 // retain references to them.


### PR DESCRIPTION
The way to omit keys from log lines can be more obvious to package consumers.

This addresses #724.