### PR TITLE
export OpenSinks/BuildEncoder/BuildOptions

### DIFF
--- a/config.go
+++ b/config.go
@@ -176,7 +176,7 @@ func (cfg Config) Build(opts ...Option) (*Logger, error) {
 
 	log := New(
 		zapcore.NewCore(enc, sink, cfg.Level),
-		cfg.buildOptions(errSink)...,
+		cfg.BuildOptions(errSink)...,
 	)
 	if len(opts) > 0 {
 		log = log.WithOptions(opts...)
@@ -184,7 +184,8 @@ func (cfg Config) Build(opts ...Option) (*Logger, error) {
 	return log, nil
 }
 
-func (cfg Config) buildOptions(errSink zapcore.WriteSyncer) []Option {
+// BuildOptions for building options from cfg
+func (cfg Config) BuildOptions(errSink zapcore.WriteSyncer) []Option {
 	opts := []Option{ErrorOutput(errSink)}
 
 	if cfg.Development {

--- a/config.go
+++ b/config.go
@@ -164,12 +164,12 @@ func NewDevelopmentConfig() Config {
 
 // Build constructs a logger from the Config and Options.
 func (cfg Config) Build(opts ...Option) (*Logger, error) {
-	enc, err := cfg.buildEncoder()
+	enc, err := cfg.BuildEncoder()
 	if err != nil {
 		return nil, err
 	}
 
-	sink, errSink, err := cfg.openSinks()
+	sink, errSink, err := cfg.OpenSinks()
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,8 @@ func (cfg Config) buildOptions(errSink zapcore.WriteSyncer) []Option {
 	return opts
 }
 
-func (cfg Config) openSinks() (zapcore.WriteSyncer, zapcore.WriteSyncer, error) {
+// OpenSinks opens the sinks from the Config
+func (cfg Config) OpenSinks() (zapcore.WriteSyncer, zapcore.WriteSyncer, error) {
 	sink, closeOut, err := Open(cfg.OutputPaths...)
 	if err != nil {
 		return nil, nil, err
@@ -238,6 +239,7 @@ func (cfg Config) openSinks() (zapcore.WriteSyncer, zapcore.WriteSyncer, error) 
 	return sink, errSink, nil
 }
 
-func (cfg Config) buildEncoder() (zapcore.Encoder, error) {
+// BuildEncoder builds the encoder from the Config
+func (cfg Config) BuildEncoder() (zapcore.Encoder, error) {
 	return newEncoder(cfg.Encoding, cfg.EncoderConfig)
 }


### PR DESCRIPTION
When trying to implement a logger that will separate info and error logs based on `zap.NewTee`, I found that these three methods are very necessary:

https://github.com/zhiqiangxu/util/blob/master/logger/zap.go


Users will have to duplicate such code everywhere if these three methods are not exported.