### PR TITLE
add millisecond duration encoder

### DIFF
--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -168,6 +168,12 @@ func NanosDurationEncoder(d time.Duration, enc PrimitiveArrayEncoder) {
 	enc.AppendInt64(int64(d))
 }
 
+// MillisDurationEncoder serializes a time.Duration to an integer number of
+// milliseconds elapsed.
+func MillisDurationEncoder(d time.Duration, enc PrimitiveArrayEncoder) {
+	enc.AppendInt64(d.Nanoseconds() / 1e6)
+}
+
 // StringDurationEncoder serializes a time.Duration using its built-in String
 // method.
 func StringDurationEncoder(d time.Duration, enc PrimitiveArrayEncoder) {
@@ -183,6 +189,8 @@ func (e *DurationEncoder) UnmarshalText(text []byte) error {
 		*e = StringDurationEncoder
 	case "nanos":
 		*e = NanosDurationEncoder
+	case "ms":
+		*e = MillisDurationEncoder
 	default:
 		*e = SecondsDurationEncoder
 	}

--- a/zapcore/encoder_test.go
+++ b/zapcore/encoder_test.go
@@ -566,6 +566,7 @@ func TestDurationEncoders(t *testing.T) {
 	}{
 		{"string", "1.0000005s"},
 		{"nanos", int64(1000000500)},
+		{"ms", int64(1000)},
 		{"", 1.0000005},
 		{"something-random", 1.0000005},
 	}


### PR DESCRIPTION
Since network requests are always in milliseconds level, if procTime shows in seconds, it may look like `0.003`, to many zeros. While if the procTime shows in nanoseconds, it may look like `12312312323`, too big to identify. So it'd be better to support milliseconds encoder, something like `30.5`, pretty intuisive. 