### PR TITLE
json: AppendTimeLayout should add field separators

### DIFF
--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -267,6 +267,7 @@ func (enc *jsonEncoder) AppendString(val string) {
 }
 
 func (enc *jsonEncoder) AppendTimeLayout(time time.Time, layout string) {
+	enc.addElementSeparator()
 	enc.buf.AppendByte('"')
 	enc.buf.AppendTime(time, layout)
 	enc.buf.AppendByte('"')


### PR DESCRIPTION
In #786, we added support for improving the performance of encoding time
by allowing encoder implementations to implement AppendTimeLayout.

If the encoder implements, `AppendTimeLayout(time.Time, string)`, some
of the time encoders shipped with Zap will use that method, which in
turn can make use of `Buffer.AppendTime`.

That change inadvertently broke the JSON output for arrays of time that
make use of that functionality.

Compare the old version of AppendTimeLayout with AppendString (both
operations append a string to the array).

    func (enc *jsonEncoder) AppendString(val string) {
      enc.addElementSeparator()
      enc.buf.AppendByte('"')
      // ...
    }

    func (enc *jsonEncoder) AppendTimeLayout(time time.Time, layout string) {
      enc.buf.AppendByte('"')
      // ...
    }

Without the `enc.addElementSeparator` call, `AppendTimeLayout` does not
include the `,` separator between array elements, instead yielding the
following.

    ["2001-12-19T00:00:00Z""2002-12-18T00:00:00Z""2003-12-17T00:00:00Z"]

Fixes #798