### PR TITLE
ci: Test against Go 1.13 and 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
 
 matrix:
   include:
-  - go: 1.12.x
   - go: 1.13.x
+  - go: 1.14.x
     env: LINT=1
 
 script:


### PR DESCRIPTION
This switches CI to test against Go 1.13 and 1.14, and linting against
the latter.