### PR TITLE
Share callstack b/w Caller and Stack

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -302,16 +302,27 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 		return ce
 	}
 
+	// If a stack trace was requested, capture the entire stack.
+	stackLimit := 0
+
+	// For historical reasons, stack traces reported by Zap don't respect
+	// CallerSkip. See also #727.
+	stackSkip := callerSkipOffset
+
+	if !addStack {
+		stackLimit = 1
+		stackSkip += log.callerSkip
+	}
+
 	programCounters := newProgramCounters()
 	defer programCounters.Release()
 
-	pcs := programCounters.Callers(callerSkipOffset)
+	pcs := programCounters.Callers(stackSkip, stackLimit)
 	if log.addCaller {
-		callerIdx := log.callerSkip
-		if len(pcs) <= callerIdx {
+		if len(pcs) == 0 {
 			ce.Entry.Caller = zapcore.NewEntryCaller(0, "", 0, false)
 		} else {
-			frame, _ := runtime.CallersFrames(pcs[callerIdx:]).Next()
+			frame, _ := runtime.CallersFrames(pcs).Next()
 			ce.Entry.Caller = zapcore.NewEntryCaller(frame.PC, frame.File, frame.Line, true)
 		}
 

--- a/logger.go
+++ b/logger.go
@@ -333,7 +333,7 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 	}
 
 	if addStack {
-		ce.Entry.Stack = makeStacktrace(pcs)
+		ce.Entry.Stack = makeStacktrace(pcs, true /* skip zap */)
 	}
 
 	return ce

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -179,6 +179,41 @@ func BenchmarkAddCallerHook(b *testing.B) {
 	})
 }
 
+func BenchmarkAddStack(b *testing.B) {
+	logger := New(
+		zapcore.NewCore(
+			zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
+			&ztest.Discarder{},
+			InfoLevel,
+		),
+		AddStacktrace(InfoLevel),
+	)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("foo")
+		}
+	})
+}
+
+func BenchmarkAddCallerAndStack(b *testing.B) {
+	logger := New(
+		zapcore.NewCore(
+			zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
+			&ztest.Discarder{},
+			InfoLevel,
+		),
+		AddCaller(),
+		AddStacktrace(InfoLevel),
+	)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			logger.Info("foo")
+		}
+	})
+}
+
 func Benchmark10Fields(b *testing.B) {
 	withBenchedLogger(b, func(log *Logger) {
 		log.Info("Ten fields, passed at the log site.",

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -31,12 +31,6 @@ import (
 const _zapPackage = "go.uber.org/zap"
 
 var (
-	_stacktracePool = sync.Pool{
-		New: func() interface{} {
-			return newProgramCounters(64)
-		},
-	}
-
 	// We add "." and "/" suffixes to the package name to ensure we only match
 	// the exact package and not any package with the same prefix.
 	_zapStacktracePrefixes       = addPrefix(_zapPackage, ".", "/")
@@ -44,27 +38,19 @@ var (
 )
 
 func takeStacktrace() string {
+	pcs := newProgramCounters()
+	defer pcs.Release()
+
+	return makeStacktrace(pcs.Callers(1))
+}
+
+func makeStacktrace(pcs []uintptr) string {
 	buffer := bufferpool.Get()
 	defer buffer.Free()
-	programCounters := _stacktracePool.Get().(*programCounters)
-	defer _stacktracePool.Put(programCounters)
-
-	var numFrames int
-	for {
-		// Skip the call to runtime.Counters and takeStacktrace so that the
-		// program counters start at the caller of takeStacktrace.
-		numFrames = runtime.Callers(2, programCounters.pcs)
-		if numFrames < len(programCounters.pcs) {
-			break
-		}
-		// Don't put the too-short counter slice back into the pool; this lets
-		// the pool adjust if we consistently take deep stacktraces.
-		programCounters = newProgramCounters(len(programCounters.pcs) * 2)
-	}
 
 	i := 0
 	skipZapFrames := true // skip all consecutive zap frames at the beginning.
-	frames := runtime.CallersFrames(programCounters.pcs[:numFrames])
+	frames := runtime.CallersFrames(pcs)
 
 	// Note: On the last iteration, frames.Next() returns false, with a valid
 	// frame, but we ignore this frame. The last frame is a a runtime frame which
@@ -113,8 +99,34 @@ type programCounters struct {
 	pcs []uintptr
 }
 
-func newProgramCounters(size int) *programCounters {
-	return &programCounters{make([]uintptr, size)}
+var _stacktracePool = sync.Pool{
+	New: func() interface{} {
+		return &programCounters{make([]uintptr, 64)}
+	},
+}
+
+func newProgramCounters() *programCounters {
+	return _stacktracePool.Get().(*programCounters)
+}
+
+func (pcs *programCounters) Release() {
+	_stacktracePool.Put(pcs)
+}
+
+func (pcs *programCounters) Callers(skip int) []uintptr {
+	var numFrames int
+	for {
+		// Skip the call to runtime.Callers and programCounter.Callers
+		// so that the program counters start at our caller.
+		numFrames = runtime.Callers(skip+2, pcs.pcs)
+		if numFrames < len(pcs.pcs) {
+			return pcs.pcs[:numFrames]
+		}
+
+		// Don't put the too-short counter slice back into the pool; this lets
+		// the pool adjust if we consistently take deep stacktraces.
+		pcs.pcs = make([]uintptr, len(pcs.pcs)*2)
+	}
 }
 
 func addPrefix(prefix string, ss ...string) []string {


### PR DESCRIPTION
A log entry that includes both, the caller and the stack trace requests
stack information twice: once to determine the caller and once to build
the stack trace.

This change optimizes this by requesting call stack information once and
sharing it for both cases.

---

I ran the benchmarks with `-count 3`.

**Before**

```
BenchmarkAddCallerHook-4         1262595               886 ns/op             248 B/op          3 allocs/op
BenchmarkAddCallerHook-4         1344021               889 ns/op             248 B/op          3 allocs/op
BenchmarkAddCallerHook-4         1000000              1085 ns/op             248 B/op          3 allocs/op
BenchmarkAddStack-4               483288              2160 ns/op             304 B/op          2 allocs/op
BenchmarkAddStack-4               550969              1993 ns/op             304 B/op          2 allocs/op
BenchmarkAddStack-4               614550              2000 ns/op             304 B/op          2 allocs/op
BenchmarkAddCallerAndStack-4      397208              2554 ns/op             552 B/op          5 allocs/op
BenchmarkAddCallerAndStack-4      462566              2578 ns/op             552 B/op          5 allocs/op
BenchmarkAddCallerAndStack-4      459589              2980 ns/op             552 B/op          5 allocs/op
```

**After**

```
BenchmarkAddCallerHook-4         1138980               960 ns/op             240 B/op          2 allocs/op
BenchmarkAddCallerHook-4         1096950               965 ns/op             240 B/op          2 allocs/op
BenchmarkAddCallerHook-4         1242375               978 ns/op             240 B/op          2 allocs/op
BenchmarkAddStack-4               868773              1388 ns/op             304 B/op          2 allocs/op
BenchmarkAddStack-4               857756              1438 ns/op             304 B/op          2 allocs/op
BenchmarkAddStack-4               865842              1348 ns/op             304 B/op          2 allocs/op
BenchmarkAddCallerAndStack-4      701884              1715 ns/op             544 B/op          4 allocs/op
BenchmarkAddCallerAndStack-4      698002              1709 ns/op             544 B/op          4 allocs/op
BenchmarkAddCallerAndStack-4      608336              1712 ns/op             544 B/op          4 allocs/op
```

On average,

1. Adding caller alone is ~14 nanoseconds (~1.5%) *slower*
2. Adding stack alone is ~659 nanoseconds (~32%) *faster*
3. Adding both, caller and stack is ~992 nanoseconds (~36%) *faster*

The second of these rightfully raises eyebrows because it was expected
to have no changes at best. A cursory investigation doesn't reveal
any obvious reason for the speed up unless there's something incredibly
wrong with the change.