### PR TITLE
Fix IncreaseLevel being reset after With

### DIFF
--- a/zapcore/increase_level.go
+++ b/zapcore/increase_level.go
@@ -23,8 +23,7 @@ package zapcore
 import "fmt"
 
 type levelFilterCore struct {
-	Core
-
+	core  Core
 	level LevelEnabler
 }
 
@@ -46,10 +45,22 @@ func (c *levelFilterCore) Enabled(lvl Level) bool {
 	return c.level.Enabled(lvl)
 }
 
+func (c *levelFilterCore) With(fields []Field) Core {
+	return &levelFilterCore{c.core.With(fields), c.level}
+}
+
 func (c *levelFilterCore) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
 	if !c.Enabled(ent.Level) {
 		return ce
 	}
 
-	return c.Core.Check(ent, ce)
+	return c.core.Check(ent, ce)
+}
+
+func (c *levelFilterCore) Write(ent Entry, fields []Field) error {
+	return c.core.Write(ent, fields)
+}
+
+func (c *levelFilterCore) Sync() error {
+	return c.core.Sync()
 }

--- a/zapcore/increase_level_test.go
+++ b/zapcore/increase_level_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	. "go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -35,6 +36,7 @@ func TestIncreaseLevel(t *testing.T) {
 		coreLevel     Level
 		increaseLevel Level
 		wantErr       bool
+		with          []Field
 	}{
 		{
 			coreLevel:     InfoLevel,
@@ -48,6 +50,11 @@ func TestIncreaseLevel(t *testing.T) {
 		{
 			coreLevel:     InfoLevel,
 			increaseLevel: ErrorLevel,
+		},
+		{
+			coreLevel:     InfoLevel,
+			increaseLevel: ErrorLevel,
+			with:          []Field{zap.String("k", "v")},
 		},
 		{
 			coreLevel:     ErrorLevel,
@@ -80,6 +87,10 @@ func TestIncreaseLevel(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "invalid increase level")
 				return
+			}
+
+			if len(tt.with) > 0 {
+				filteredLogger = filteredLogger.With(tt.with)
 			}
 
 			require.NoError(t, err)


### PR DESCRIPTION
Fixes #810

We missed implementing the increase-level logic in With
and since Core was embedded, we wended up using With from
the original core.

To avoid this sort of issue, avoid embedding and implement all
Core methods explicitly. This lets us consider the behaviour
of each method explicitly.