### PR TITLE
core/sampler: Support decision hook

### DIFF
--- a/benchmarks/zap_test.go
+++ b/benchmarks/zap_test.go
@@ -116,7 +116,7 @@ func newZapLogger(lvl zapcore.Level) *zap.Logger {
 }
 
 func newSampledLogger(lvl zapcore.Level) *zap.Logger {
-	return zap.New(zapcore.NewSampler(
+	return zap.New(zapcore.NewSamplerWithOptions(
 		newZapLogger(zap.DebugLevel).Core(),
 		100*time.Millisecond,
 		10, // first

--- a/benchmarks/zap_test.go
+++ b/benchmarks/zap_test.go
@@ -116,7 +116,7 @@ func newZapLogger(lvl zapcore.Level) *zap.Logger {
 }
 
 func newSampledLogger(lvl zapcore.Level) *zap.Logger {
-	return zap.New(zapcore.NewSamplerWithOptions(
+	return zap.New(zapcore.NewSampler(
 		newZapLogger(zap.DebugLevel).Core(),
 		100*time.Millisecond,
 		10, // first

--- a/config.go
+++ b/config.go
@@ -32,15 +32,14 @@ import (
 // global CPU and I/O load that logging puts on your process while attempting
 // to preserve a representative subset of your logs.
 //
-// Hook is called whenever a Sampler makes a decision. Currently, whenever a
-// log is dropped.
+// If specified, the Sampler will invoke the Hook after each decision.
 //
 // Values configured here are per-second. See zapcore.NewSamplerWithOptions for
 // details.
 type SamplingConfig struct {
 	Initial    int `json:"initial" yaml:"initial"`
 	Thereafter int `json:"thereafter" yaml:"thereafter"`
-	Hook       func(zapcore.Entry, zapcore.SamplingDecision)
+	Hook       func(zapcore.Entry, zapcore.SamplingDecision) `json:"-" yaml:"-"`
 }
 
 // Config offers a declarative way to construct a logger. It doesn't do

--- a/config.go
+++ b/config.go
@@ -32,7 +32,8 @@ import (
 // global CPU and I/O load that logging puts on your process while attempting
 // to preserve a representative subset of your logs.
 //
-//
+// Hook is called whenever a Sampler makes a decision. Currently, whenever a
+// log is dropped.
 //
 // Values configured here are per-second. See zapcore.NewSamplerWithOptions for
 // details.

--- a/config.go
+++ b/config.go
@@ -37,8 +37,8 @@ import (
 // Values configured here are per-second. See zapcore.NewSamplerWithOptions for
 // details.
 type SamplingConfig struct {
-	Initial    int `json:"initial" yaml:"initial"`
-	Thereafter int `json:"thereafter" yaml:"thereafter"`
+	Initial    int                                           `json:"initial" yaml:"initial"`
+	Thereafter int                                           `json:"thereafter" yaml:"thereafter"`
 	Hook       func(zapcore.Entry, zapcore.SamplingDecision) `json:"-" yaml:"-"`
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -148,8 +148,8 @@ func TestConfigWithMissingAttributes(t *testing.T) {
 
 func makeSamplerCountingHook() (func(zapcore.Entry, zapcore.SamplingDecision),
 	*atomic.Int64, *atomic.Int64) {
-	droppedCount := &atomic.Int64{}
-	sampledCount := &atomic.Int64{}
+	droppedCount := new(atomic.Int64)
+	sampledCount := new(atomic.Int64)
 	h := func(_ zapcore.Entry, dec zapcore.SamplingDecision) {
 		if dec == zapcore.LogDropped {
 			droppedCount.Inc()

--- a/config_test.go
+++ b/config_test.go
@@ -155,7 +155,6 @@ func makeSamplerCountingHook() (func(zapcore.Entry, zapcore.SamplingDecision) er
 	return h, count
 }
 
-
 func TestConfigWithSamplingHook(t *testing.T) {
 	shook, scount := makeSamplerCountingHook()
 	cfg := Config{
@@ -164,7 +163,7 @@ func TestConfigWithSamplingHook(t *testing.T) {
 		Sampling: &SamplingConfig{
 			Initial:    100,
 			Thereafter: 100,
-			Hook: shook,
+			Hook:       shook,
 		},
 		Encoding:         "json",
 		EncoderConfig:    NewProductionEncoderConfig(),

--- a/config_test.go
+++ b/config_test.go
@@ -175,7 +175,6 @@ func TestConfigWithSamplingHook(t *testing.T) {
 		OutputPaths:      []string{"stderr"},
 		ErrorOutputPaths: []string{"stderr"},
 	}
-	expectN := 2 + 101 // out of 203 logs: 3 types (debug, info, warn), 2 (debug + warn) + 101 (100 initial + 200th thereafter)
 	expectRe := `{"level":"info","caller":"zap/config_test.go:\d+","msg":"info","k":"v","z":"zz"}` + "\n" +
 		`{"level":"warn","caller":"zap/config_test.go:\d+","msg":"warn","k":"v","z":"zz"}` + "\n"
 	expectDropped := 99  // 200 - 100 initial - 1 thereafter
@@ -194,8 +193,7 @@ func TestConfigWithSamplingHook(t *testing.T) {
 	cfg.EncoderConfig.TimeKey = "" // no timestamps in tests
 	cfg.InitialFields = map[string]interface{}{"z": "zz", "k": "v"}
 
-	hook, count := makeCountingHook()
-	logger, err := cfg.Build(Hooks(hook))
+	logger, err := cfg.Build()
 	require.NoError(t, err, "Unexpected error constructing logger.")
 
 	logger.Debug("debug")
@@ -210,7 +208,6 @@ func TestConfigWithSamplingHook(t *testing.T) {
 	for i := 0; i < 200; i++ {
 		logger.Info("sampling")
 	}
-	assert.Equal(t, int64(expectN), count.Load(), "Hook called an unexpected number of times.")
 	assert.Equal(t, int64(expectDropped), dcount.Load())
 	assert.Equal(t, int64(expectSampled), scount.Load())
 }

--- a/config_test.go
+++ b/config_test.go
@@ -151,9 +151,9 @@ func makeSamplerCountingHook() (h func(zapcore.Entry, zapcore.SamplingDecision),
 	dropped = new(atomic.Int64)
 	sampled = new(atomic.Int64)
 	h = func(_ zapcore.Entry, dec zapcore.SamplingDecision) {
-		if dec & zapcore.LogDropped > 0  {
+		if dec&zapcore.LogDropped > 0 {
 			dropped.Inc()
-		} else if dec & zapcore.LogSampled > 0 {
+		} else if dec&zapcore.LogSampled > 0 {
 			sampled.Inc()
 		}
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -151,9 +151,9 @@ func makeSamplerCountingHook() (h func(zapcore.Entry, zapcore.SamplingDecision),
 	dropped = new(atomic.Int64)
 	sampled = new(atomic.Int64)
 	h = func(_ zapcore.Entry, dec zapcore.SamplingDecision) {
-		if dec == zapcore.LogDropped {
+		if dec & zapcore.LogDropped > 0  {
 			dropped.Inc()
-		} else if dec == zapcore.LogSampled {
+		} else if dec & zapcore.LogSampled > 0 {
 			sampled.Inc()
 		}
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -158,7 +158,6 @@ func makeSamplerCountingHook() (func(zapcore.Entry, zapcore.SamplingDecision) er
 
 func TestConfigWithSamplingHook(t *testing.T) {
 	shook, scount := makeSamplerCountingHook()
-	// desc: "config with a sampler hook",
 	cfg := Config{
 		Level:       NewAtomicLevelAt(InfoLevel),
 		Development: false,

--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -98,17 +98,19 @@ type SamplerOption interface {
 	apply(*sampler)
 }
 
+// NopSamplingHook is the default hook used by sampler.
 func NopSamplingHook(_ Entry, _ SamplingDecision) error {
 	return nil
 }
 
-// SampleHook registers a which will be called when Sampler makes a decision.
-// Currently a hook is called when a log is dropped zapcore.Dropped is sent.
+// SamplerHook registers a which will be called when Sampler makes a decision.
+// Currently a hook is called when a log is dropped and zapcore.Dropped decision
+// is emitted.
 //
 // This hook is useful for side effects, for example emitting number of dropped
 // logs. Note, there is no access to Fields in this hook. In the future, this
-// can be expanded to log whether this is first entry that was dropped, first
-// after a period, etc.
+// hook can be expanded to emit whether this is first entry that was dropped,
+// first after a period, etc.
 func SamplerHook(hook func(entry Entry, dec SamplingDecision) error) SamplerOption {
 	return optionFunc(func(s *sampler) {
 		s.hook = hook

--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -21,6 +21,7 @@
 package zapcore
 
 import (
+	"fmt"
 	"time"
 
 	"go.uber.org/atomic"
@@ -129,6 +130,8 @@ func (s *sampler) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
 	n := counter.IncCheckReset(ent.Time, s.tick)
 	if n > s.first && (n-s.first)%s.thereafter != 0 {
 		return ce
+	} else if s.thereafter > 0 && s.first > 0 && (n-s.first)%s.thereafter == 0 {
+		ent.Message = fmt.Sprintf("%s dropped %d logs", ent.Message, uint64(s.thereafter - 1))
 	}
 	return s.Core.Check(ent, ce)
 }

--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -159,7 +159,18 @@ type sampler struct {
 	hook              func(Entry, SamplingDecision) error
 }
 
-// NewSampler is deprecated: use NewSamplerWithOptions.
+// NewSampler creates a Core that samples incoming entries, which
+// caps the CPU and I/O load of logging while attempting to preserve a
+// representative subset of your logs.
+//
+// Zap samples by logging the first N entries with a given level and message
+// each tick. If more Entries with the same level and message are seen during
+// the same interval, every Mth message is logged and the rest are dropped.
+//
+// Keep in mind that zap's sampling implementation is optimized for speed over
+// absolute precision; under load, each tick may be slightly over- or
+// under-sampled.
+// Deprecated: use NewSamplerWithOptions.
 func NewSampler(core Core, tick time.Duration, first, thereafter int) Core {
 	return &sampler{
 		Core:       core,

--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -86,7 +86,7 @@ type SamplingDecision uint8
 
 const (
 	// LogDropped indicates that the Sampler dropped a log entry.
-	LogDropped SamplingDecision = iota
+	LogDropped SamplingDecision = 1 << iota
 	// LogSampled indicates that the Sampler sampled a log entry.
 	LogSampled
 )

--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -112,6 +112,13 @@ func nopSamplingHook(Entry, SamplingDecision) {}
 //
 // This hook may be used to get visibility into the performance of the sampler.
 // For example, use it to track metrics of dropped versus sampled logs.
+//
+//  var dropped atomic.Int64
+//  zapcore.SamplerHook(func(ent zapcore.Entry, dec zapcore.SamplingDecision) {
+//    if dec&zapcore.LogDropped > 0 {
+//      dropped.Inc()
+//    }
+//  })
 func SamplerHook(hook func(entry Entry, dec SamplingDecision)) SamplerOption {
 	return optionFunc(func(s *sampler) {
 		s.hook = hook

--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -81,13 +81,13 @@ func (c *counter) IncCheckReset(t time.Time, tick time.Duration) uint64 {
 	return 1
 }
 
-// SamplingDecision represents a decision made by sampler.
+// SamplingDecision is a decision made by sampler.
 type SamplingDecision uint8
 
 const (
-	// LogDropped means that a log was dropped.
+	// LogSampled indicates that the Sampler dropped a log entry.
 	LogDropped SamplingDecision = iota
-	// LogSampled means that a log was successfully sampled.
+	// LogSampled indicates that the Sampler sampled a log entry.
 	LogSampled
 )
 
@@ -98,22 +98,19 @@ func (f optionFunc) apply(s *sampler) {
 	f(s)
 }
 
-// SamplerOption configures a Sampler option.
+// SamplerOption configures a Sampler.
 type SamplerOption interface {
 	apply(*sampler)
 }
 
 // NopSamplingHook is the default hook used by sampler.
-func NopSamplingHook(_ Entry, _ SamplingDecision) {}
+func NopSamplingHook(Entry, SamplingDecision) {}
 
 // SamplerHook registers a function  which will be called when Sampler makes a
-// decision. Currently a hook is called when a log is dropped and
-// zapcore.LogDropped decision is emitted.
+// decision.
 //
-// This hook is useful for side effects, for example emitting number of dropped
-// logs. Note, there is no access to Fields in this hook. In the future, this
-// hook can be expanded to emit whether this is first entry that was dropped,
-// first after a period, etc.
+// This hook may be used to get visibility into the performance of the sampler.
+// For example, use it to track metrics of dropped versus sampled logs.
 func SamplerHook(hook func(entry Entry, dec SamplingDecision)) SamplerOption {
 	return optionFunc(func(s *sampler) {
 		s.hook = hook
@@ -128,8 +125,8 @@ func SamplerHook(hook func(entry Entry, dec SamplingDecision)) SamplerOption {
 // each tick. If more Entries with the same level and message are seen during
 // the same interval, every Mth message is logged and the rest are dropped.
 //
-// Sampler also accepts an optional hook that can be used to count number of
-// dropped logs.
+// Sampler can be configured to report sampling decisions with the SamplerHook
+// option.
 //
 // Keep in mind that zap's sampling implementation is optimized for speed over
 // absolute precision; under load, each tick may be slightly over- or
@@ -173,14 +170,7 @@ type sampler struct {
 //
 // Deprecated: use NewSamplerWithOptions.
 func NewSampler(core Core, tick time.Duration, first, thereafter int) Core {
-	return &sampler{
-		Core:       core,
-		tick:       tick,
-		counts:     newCounters(),
-		first:      uint64(first),
-		thereafter: uint64(thereafter),
-		hook:       NopSamplingHook,
-	}
+	return NewSamplerWithOptions(core, tick, first, thereafter)
 }
 
 func (s *sampler) With(fields []Field) Core {

--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -85,7 +85,7 @@ func (c *counter) IncCheckReset(t time.Time, tick time.Duration) uint64 {
 type SamplingDecision uint8
 
 const (
-	// LogSampled indicates that the Sampler dropped a log entry.
+	// LogDropped indicates that the Sampler dropped a log entry.
 	LogDropped SamplingDecision = iota
 	// LogSampled indicates that the Sampler sampled a log entry.
 	LogSampled

--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -81,8 +81,9 @@ func (c *counter) IncCheckReset(t time.Time, tick time.Duration) uint64 {
 	return 1
 }
 
-// SamplingDecision is a decision made by sampler.
-type SamplingDecision uint8
+// SamplingDecision is a decision represented as a bit field made by sampler.
+// More decisions may be added in the future.
+type SamplingDecision uint32
 
 const (
 	// LogDropped indicates that the Sampler dropped a log entry.
@@ -103,8 +104,8 @@ type SamplerOption interface {
 	apply(*sampler)
 }
 
-// NopSamplingHook is the default hook used by sampler.
-func NopSamplingHook(Entry, SamplingDecision) {}
+// nopSamplingHook is the default hook used by sampler.
+func nopSamplingHook(Entry, SamplingDecision) {}
 
 // SamplerHook registers a function  which will be called when Sampler makes a
 // decision.
@@ -138,7 +139,7 @@ func NewSamplerWithOptions(core Core, tick time.Duration, first, thereafter int,
 		counts:     newCounters(),
 		first:      uint64(first),
 		thereafter: uint64(thereafter),
-		hook:       NopSamplingHook,
+		hook:       nopSamplingHook,
 	}
 	for _, opt := range opts {
 		opt.apply(s)

--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -136,6 +136,7 @@ func NewSamplerWithOptions(core Core, tick time.Duration, first, thereafter int,
 		counts:     newCounters(),
 		first:      uint64(first),
 		thereafter: uint64(thereafter),
+		hook:       NopSamplingHook,
 	}
 	for _, opt := range opts {
 		opt.apply(s)

--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -161,6 +161,7 @@ func NewSampler(core Core, tick time.Duration, first, thereafter int) Core {
 		counts:     newCounters(),
 		first:      uint64(first),
 		thereafter: uint64(thereafter),
+		hook:       NopSamplingHook,
 	}
 }
 
@@ -184,7 +185,8 @@ func (s *sampler) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
 	n := counter.IncCheckReset(ent.Time, s.tick)
 	if n > s.first && (n-s.first)%s.thereafter != 0 {
 		err := s.hook(ent, Dropped)
-		if err != nil {}
+		if err != nil {
+		}
 		return ce
 	}
 

--- a/zapcore/sampler_bench_test.go
+++ b/zapcore/sampler_bench_test.go
@@ -203,7 +203,7 @@ var counterTestCases = [][]string{
 func BenchmarkSampler_Check(b *testing.B) {
 	for _, keys := range counterTestCases {
 		b.Run(fmt.Sprintf("%v keys", len(keys)), func(b *testing.B) {
-			fac := NewSampler(
+			fac := NewSamplerWithOptions(
 				NewCore(
 					NewJSONEncoder(testEncoderConfig()),
 					&ztest.Discarder{},

--- a/zapcore/sampler_bench_test.go
+++ b/zapcore/sampler_bench_test.go
@@ -235,9 +235,9 @@ func makeSamplerCountingHook() (func(_ Entry, dec SamplingDecision), *atomic.Int
 	droppedCount := new(atomic.Int64)
 	sampledCount := new(atomic.Int64)
 	h := func(_ Entry, dec SamplingDecision) {
-		if dec & LogDropped > 0 {
+		if dec&LogDropped > 0 {
 			droppedCount.Inc()
-		} else if dec & LogSampled > 0 {
+		} else if dec&LogSampled > 0 {
 			sampledCount.Inc()
 		}
 	}

--- a/zapcore/sampler_bench_test.go
+++ b/zapcore/sampler_bench_test.go
@@ -257,7 +257,7 @@ func BenchmarkSampler_CheckWithHook(b *testing.B) {
 				1,
 				1000,
 				SamplerHook(hook),
-				)
+			)
 			b.ResetTimer()
 			b.RunParallel(func(pb *testing.PB) {
 				i := 0

--- a/zapcore/sampler_bench_test.go
+++ b/zapcore/sampler_bench_test.go
@@ -235,9 +235,9 @@ func makeSamplerCountingHook() (func(_ Entry, dec SamplingDecision), *atomic.Int
 	droppedCount := new(atomic.Int64)
 	sampledCount := new(atomic.Int64)
 	h := func(_ Entry, dec SamplingDecision) {
-		if dec == LogDropped {
+		if dec & LogDropped > 0 {
 			droppedCount.Inc()
-		} else if dec == LogSampled {
+		} else if dec & LogSampled > 0 {
 			sampledCount.Inc()
 		}
 	}

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -37,7 +37,7 @@ import (
 
 func fakeSampler(lvl LevelEnabler, tick time.Duration, first, thereafter int) (Core, *observer.ObservedLogs) {
 	core, logs := observer.New(lvl)
-	core = NewSampler(core, tick, first, thereafter)
+	core = NewSamplerWithOptions(core, tick, first, thereafter, SamplerHook(NopSamplingHook))
 	return core, logs
 }
 
@@ -162,7 +162,8 @@ func TestSamplerConcurrent(t *testing.T) {
 
 	tick := ztest.Timeout(10 * time.Millisecond)
 	cc := &countingCore{}
-	sampler := NewSampler(cc, tick, logsPerTick, 100000)
+	sampler := NewSamplerWithOptions(cc, tick, logsPerTick, 100000,
+		SamplerHook(NopSamplingHook))
 
 	var (
 		done atomic.Bool

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -37,7 +37,7 @@ import (
 
 func fakeSampler(lvl LevelEnabler, tick time.Duration, first, thereafter int) (Core, *observer.ObservedLogs) {
 	core, logs := observer.New(lvl)
-	core = NewSamplerWithOptions(core, tick, first, thereafter, SamplerHook(NopSamplingHook))
+	core = NewSamplerWithOptions(core, tick, first, thereafter)
 	return core, logs
 }
 
@@ -162,8 +162,7 @@ func TestSamplerConcurrent(t *testing.T) {
 
 	tick := ztest.Timeout(10 * time.Millisecond)
 	cc := &countingCore{}
-	sampler := NewSamplerWithOptions(cc, tick, logsPerTick, 100000,
-		SamplerHook(NopSamplingHook))
+	sampler := NewSamplerWithOptions(cc, tick, logsPerTick, 100000)
 
 	var (
 		done atomic.Bool

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -37,7 +37,8 @@ import (
 
 func fakeSampler(lvl LevelEnabler, tick time.Duration, first, thereafter int) (Core, *observer.ObservedLogs) {
 	core, logs := observer.New(lvl)
-	core = NewSamplerWithOptions(core, tick, first, thereafter)
+	// Keep using deprecated constructor for cc.
+	core = NewSampler(core, tick, first, thereafter)
 	return core, logs
 }
 


### PR DESCRIPTION
This adds support for monitoring sampling decisions made by the Sampler
core with a `func(Entry, SamplingDecision)` where `SamplingDecision` is
a bit field.

To allow plumbing the hook to the sampler, this additionally deprecates
the `NewSampler` constructor in favor of `NewSamplerWithOptions`.

    type SamplerOption

    func SamplerHook(func(Entry, SamplingDecision))

    func NewSamplerWithOptions(/* ... */, opts ...SamplerOption)

This functionality is usable from the `zap` package via the new `Hook`
field of `zap.SamplingConfig`.

Refs T5056227