### PR TITLE
Optimize the process of getting/putting a jsonEncoder from/to _jsonPool

### DIFF
--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -40,10 +40,7 @@ var _jsonPool = sync.Pool{New: func() interface{} {
 }}
 
 func getJSONEncoder() *jsonEncoder {
-	return _jsonPool.Get().(*jsonEncoder)
-}
-
-func putJSONEncoder(enc *jsonEncoder) {
+	enc := _jsonPool.Get().(*jsonEncoder)
 	if enc.reflectBuf != nil {
 		enc.reflectBuf.Free()
 	}
@@ -53,6 +50,10 @@ func putJSONEncoder(enc *jsonEncoder) {
 	enc.openNamespaces = 0
 	enc.reflectBuf = nil
 	enc.reflectEnc = nil
+	return enc
+}
+
+func putJSONEncoder(enc *jsonEncoder) {
 	_jsonPool.Put(enc)
 }
 


### PR DESCRIPTION
Any item stored in the Pool may be removed automatically at any time without notification.  it will  be better ，if  the process of getting/putting a jsonEncoder is modified.