### PR TITLE
support Logger from Context

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -49,6 +50,8 @@ type Logger struct {
 	addStack  zapcore.LevelEnabler
 
 	callerSkip int
+
+	forCtxFn func(context.Context, *Logger) *Logger
 }
 
 // New constructs a new Logger from the provided zapcore.Core and Options. If
@@ -163,6 +166,15 @@ func (log *Logger) With(fields ...Field) *Logger {
 	l := log.clone()
 	l.core = l.core.With(fields)
 	return l
+}
+
+// For set a context before logging messages, obtain extra fields from context
+func (log *Logger) For(ctx context.Context) *Logger {
+	if log.forCtxFn == nil {
+		return log
+	}
+
+	return log.forCtxFn(ctx, log)
 }
 
 // Check returns a CheckedEntry if logging a message at the specified level

--- a/logger_test.go
+++ b/logger_test.go
@@ -129,6 +129,11 @@ func TestLoggerFor(t *testing.T) {
 		assert.Equal(t, expectedName, logs.AllUntimed()[1].Entry.LoggerName, "Unexpected logger name.")
 		assert.Equal(t, "", logs.AllUntimed()[2].Entry.LoggerName, "Unexpected logger name.")
 	})
+
+	withLogger(t, DebugLevel, nil, func(logger *Logger, logs *observer.ObservedLogs) {
+		logger.For(context.Background()).Info("")
+		assert.Equal(t, "", logs.AllUntimed()[0].Entry.LoggerName, "Unexpected logger name.")
+	})
 }
 
 func TestLoggerLogPanic(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"context"
 	"fmt"
 
 	"go.uber.org/zap/zapcore"
@@ -129,5 +130,13 @@ func IncreaseLevel(lvl zapcore.LevelEnabler) Option {
 		} else {
 			log.core = core
 		}
+	})
+}
+
+// ForContext configures the Logger to get specific inforamation from context for
+// all message
+func ForContext(forCtxFn func(context.Context, *Logger) *Logger) Option {
+	return optionFunc(func(log *Logger) {
+		log.forCtxFn = forCtxFn
 	})
 }

--- a/sugar.go
+++ b/sugar.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"context"
 	"fmt"
 
 	"go.uber.org/zap/zapcore"
@@ -90,6 +91,11 @@ func (s *SugaredLogger) Named(name string) *SugaredLogger {
 // panics in development and errors in production.
 func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
 	return &SugaredLogger{base: s.base.With(s.sweetenFields(args)...)}
+}
+
+// For set a context before logging messages, obtain extra fields from context
+func (s *SugaredLogger) For(ctx context.Context) *SugaredLogger {
+	return &SugaredLogger{base: s.base.For(ctx)}
 }
 
 // Debug uses fmt.Sprint to construct and log a message.

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"context"
 	"testing"
 
 	"go.uber.org/zap/internal/exit"
@@ -137,6 +138,23 @@ func TestSugarWith(t *testing.T) {
 			assert.Equal(t, tt.expected, output[len(tt.errLogs)].Context, "Unexpected message context in scenario %s.", tt.desc)
 		})
 	}
+}
+
+func TestSugarFor(t *testing.T) {
+	expectedName := "(0001)"
+	forOpts := opts(ForContext(
+		func(ctx context.Context, log *Logger) *Logger {
+			return log.Named(expectedName)
+		}))
+
+	withSugar(t, DebugLevel, forOpts, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+		logger.For(context.Background()).Info("")
+		logger.For(context.TODO()).Info("")
+		logger.Info("")
+		assert.Equal(t, expectedName, logs.AllUntimed()[0].Entry.LoggerName, "Unexpected logger name.")
+		assert.Equal(t, expectedName, logs.AllUntimed()[1].Entry.LoggerName, "Unexpected logger name.")
+		assert.Equal(t, "", logs.AllUntimed()[2].Entry.LoggerName, "Unexpected logger name.")
+	})
 }
 
 func TestSugarFieldsInvalidPairs(t *testing.T) {

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -155,6 +155,11 @@ func TestSugarFor(t *testing.T) {
 		assert.Equal(t, expectedName, logs.AllUntimed()[1].Entry.LoggerName, "Unexpected logger name.")
 		assert.Equal(t, "", logs.AllUntimed()[2].Entry.LoggerName, "Unexpected logger name.")
 	})
+
+	withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+		logger.For(context.Background()).Info("")
+		assert.Equal(t, "", logs.AllUntimed()[0].Entry.LoggerName, "Unexpected logger name.")
+	})
 }
 
 func TestSugarFieldsInvalidPairs(t *testing.T) {


### PR DESCRIPTION
A situation in which a program print logs in a context is increasingly common, such as user login and get user id from the context of this request,  get trace id from opentracing-context...

so We should implement the following code: 
```
logger := zap.New(core)
MyContextZap(ctx,logger).Infof("failed to fetch URL: %s", "http://example.com")

func MyContextZap(ctx context.Context, log *zap.Logger) *zap.Logger {
			// TODO:  get values from context
			return log.Named("(0001)")
		})

func MyContextZap2(ctx context.Context, log *zap.SugerLogger) *zap.SugerLogger {
			// TODO:  get values from context
			return log.Named("(0001)")
		})
```


Zap native support is a better choice.

```
logger := zap.New(core, zap.ForContext(
		func(ctx context.Context, log *zap.Logger) *zap.Logger {
			// TODO:  get values from context
			return log.Named("(0001)")
		}))

logger.For(ctx).Infof("failed to fetch URL: %s", "http://example.com")

logger.Sugar()
sugar.For(ctx).Infof("failed to fetch URL: %s", "http://example.com")
```

Output:
```
2020-06-16T14:50:03.168+0800	INFO	(0001)	failed to fetch URL: http://example.com
```

```
{"level":"info","ts":1592291078.254915,"logger":"(0001)","msg":"failed to fetch URL: http://example.com"}
```

@akshayjshah  what do you think? 