### PR TITLE
Honor CallerSkip when taking stack traces & add the StackSkip field

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -52,7 +52,7 @@ func TestConfig(t *testing.T) {
 			expectRe: "DEBUG\tzap/config_test.go:" + `\d+` + "\tdebug\t" + `{"k": "v", "z": "zz"}` + "\n" +
 				"INFO\tzap/config_test.go:" + `\d+` + "\tinfo\t" + `{"k": "v", "z": "zz"}` + "\n" +
 				"WARN\tzap/config_test.go:" + `\d+` + "\twarn\t" + `{"k": "v", "z": "zz"}` + "\n" +
-				`testing.\w+`,
+				`go.uber.org/zap.TestConfig.\w+`,
 		},
 	}
 

--- a/field.go
+++ b/field.go
@@ -371,11 +371,8 @@ func Stack(key string) Field {
 	return String(key, takeStacktrace(0))
 }
 
-// StackSkip constructs a field that stores a stacktrace of the current
-// goroutine under provided key, skipping the given number of frames from the
-// top of the stacktrace. Keep in mind that taking a stacktrace is eager and
-// expensive (relatively speaking); this function both makes an allocation and
-// takes about two microseconds.
+// StackSkip constructs a field similarly to Stack, but also skips the given
+// number of frames from the top of the stacktrace.
 func StackSkip(key string, skip int) Field {
 	// Returning the stacktrace as a string costs an allocation, but saves us
 	// from expanding the zapcore.Field union struct to include a byte slice. Since

--- a/field.go
+++ b/field.go
@@ -364,26 +364,17 @@ func Timep(key string, val *time.Time) Field {
 // expensive (relatively speaking); this function both makes an allocation and
 // takes about two microseconds.
 func Stack(key string) Field {
-	// Returning the stacktrace as a string costs an allocation, but saves us
-	// from expanding the zapcore.Field union struct to include a byte slice. Since
-	// taking a stacktrace is already so expensive (~10us), the extra allocation
-	// is okay.
-	return String(key, takeStacktrace(0))
+	return StackSkip(key, 1) // skip Stack
 }
 
 // StackSkip constructs a field similarly to Stack, but also skips the given
 // number of frames from the top of the stacktrace.
 func StackSkip(key string, skip int) Field {
-	// Skip the call to StackSkip
-	if skip != 0 {
-		skip++
-	}
-
 	// Returning the stacktrace as a string costs an allocation, but saves us
 	// from expanding the zapcore.Field union struct to include a byte slice. Since
 	// taking a stacktrace is already so expensive (~10us), the extra allocation
 	// is okay.
-	return String(key, takeStacktrace(skip))
+	return String(key, takeStacktrace(skip+1)) // skip StackSkip
 }
 
 // Duration constructs a field with the given key and value. The encoder

--- a/field.go
+++ b/field.go
@@ -368,7 +368,20 @@ func Stack(key string) Field {
 	// from expanding the zapcore.Field union struct to include a byte slice. Since
 	// taking a stacktrace is already so expensive (~10us), the extra allocation
 	// is okay.
-	return String(key, takeStacktrace())
+	return String(key, takeStacktrace(nil))
+}
+
+// StackSkip constructs a field that stores a stacktrace of the current
+// goroutine under provided key, skipping the given number of frames from the
+// top of the stacktrace. Keep in mind that taking a stacktrace is eager and
+// expensive (relatively speaking); this function both makes an allocation and
+// takes about two microseconds.
+func StackSkip(key string, skip int) Field {
+	// Returning the stacktrace as a string costs an allocation, but saves us
+	// from expanding the zapcore.Field union struct to include a byte slice. Since
+	// taking a stacktrace is already so expensive (~10us), the extra allocation
+	// is okay.
+	return String(key, takeStacktrace(&skip))
 }
 
 // Duration constructs a field with the given key and value. The encoder

--- a/field.go
+++ b/field.go
@@ -374,6 +374,11 @@ func Stack(key string) Field {
 // StackSkip constructs a field similarly to Stack, but also skips the given
 // number of frames from the top of the stacktrace.
 func StackSkip(key string, skip int) Field {
+	// Skip the call to StackSkip
+	if skip != 0 {
+		skip++
+	}
+
 	// Returning the stacktrace as a string costs an allocation, but saves us
 	// from expanding the zapcore.Field union struct to include a byte slice. Since
 	// taking a stacktrace is already so expensive (~10us), the extra allocation

--- a/field.go
+++ b/field.go
@@ -368,7 +368,7 @@ func Stack(key string) Field {
 	// from expanding the zapcore.Field union struct to include a byte slice. Since
 	// taking a stacktrace is already so expensive (~10us), the extra allocation
 	// is okay.
-	return String(key, takeStacktrace(nil))
+	return String(key, takeStacktrace(0))
 }
 
 // StackSkip constructs a field that stores a stacktrace of the current
@@ -381,7 +381,7 @@ func StackSkip(key string, skip int) Field {
 	// from expanding the zapcore.Field union struct to include a byte slice. Since
 	// taking a stacktrace is already so expensive (~10us), the extra allocation
 	// is okay.
-	return String(key, takeStacktrace(&skip))
+	return String(key, takeStacktrace(skip))
 }
 
 // Duration constructs a field with the given key and value. The encoder

--- a/field_test.go
+++ b/field_test.go
@@ -259,6 +259,6 @@ func TestStackField(t *testing.T) {
 	f := Stack("stacktrace")
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
-	assert.Equal(t, takeStacktrace(nil), f.String, "Unexpected stack trace")
+	assert.Equal(t, takeStacktrace(0), f.String, "Unexpected stack trace")
 	assertCanBeReused(t, f)
 }

--- a/field_test.go
+++ b/field_test.go
@@ -259,6 +259,6 @@ func TestStackField(t *testing.T) {
 	f := Stack("stacktrace")
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
-	assert.Equal(t, takeStacktrace(), f.String, "Unexpected stack trace")
+	assert.Equal(t, takeStacktrace(nil), f.String, "Unexpected stack trace")
 	assertCanBeReused(t, f)
 }

--- a/field_test.go
+++ b/field_test.go
@@ -262,3 +262,19 @@ func TestStackField(t *testing.T) {
 	assert.Equal(t, takeStacktrace(0), f.String, "Unexpected stack trace")
 	assertCanBeReused(t, f)
 }
+
+func TestStackSkipField(t *testing.T) {
+	f := StackSkip("stacktrace", 0)
+	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
+	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
+	assert.Equal(t, takeStacktrace(0), f.String, "Unexpected stack trace")
+	assertCanBeReused(t, f)
+}
+
+func TestStackSkipFieldWithSkip(t *testing.T) {
+	f := StackSkip("stacktrace", 1)
+	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
+	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
+	assert.Equal(t, takeStacktrace(1), f.String, "Unexpected stack trace")
+	assertCanBeReused(t, f)
+}

--- a/field_test.go
+++ b/field_test.go
@@ -266,10 +266,11 @@ func TestStackField(t *testing.T) {
 }
 
 func TestStackSkipField(t *testing.T) {
-	f := StackSkip("stacktrace", 1)
+	f := StackSkip("stacktrace", 0)
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
-	assert.Equal(t, takeStacktrace(1), f.String, "Unexpected stack trace")
+	r := regexp.MustCompile(`field_test.go:(\d+)`)
+	assert.Equal(t, r.ReplaceAllString(takeStacktrace(0), "field_test.go"), r.ReplaceAllString(f.String, "field_test.go"), f.String, "Unexpected stack trace")
 	assertCanBeReused(t, f)
 }
 

--- a/field_test.go
+++ b/field_test.go
@@ -23,6 +23,7 @@ package zap
 import (
 	"math"
 	"net"
+	"regexp"
 	"sync"
 	"testing"
 	"time"
@@ -259,15 +260,16 @@ func TestStackField(t *testing.T) {
 	f := Stack("stacktrace")
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
-	assert.Equal(t, takeStacktrace(0), f.String, "Unexpected stack trace")
+	r := regexp.MustCompile(`field_test.go:(\d+)`)
+	assert.Equal(t, r.ReplaceAllString(takeStacktrace(0), "field_test.go"), r.ReplaceAllString(f.String, "field_test.go"), "Unexpected stack trace")
 	assertCanBeReused(t, f)
 }
 
 func TestStackSkipField(t *testing.T) {
-	f := StackSkip("stacktrace", 0)
+	f := StackSkip("stacktrace", 1)
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
-	assert.Equal(t, takeStacktrace(0), f.String, "Unexpected stack trace")
+	assert.Equal(t, takeStacktrace(1), f.String, "Unexpected stack trace")
 	assertCanBeReused(t, f)
 }
 

--- a/logger.go
+++ b/logger.go
@@ -306,7 +306,7 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 	}
 	if log.addStack.Enabled(ce.Entry.Level) {
 		if log.useCallerSkipForStack {
-			ce.Entry.Stack = StackSkip("", log.callerSkip).String
+			ce.Entry.Stack = StackSkip("", log.callerSkip+callerSkipOffset).String
 		} else {
 			ce.Entry.Stack = Stack("").String
 		}

--- a/logger.go
+++ b/logger.go
@@ -48,8 +48,7 @@ type Logger struct {
 	addCaller bool
 	addStack  zapcore.LevelEnabler
 
-	callerSkip            int
-	useCallerSkipForStack bool
+	callerSkip int
 }
 
 // New constructs a new Logger from the provided zapcore.Core and Options. If
@@ -305,11 +304,7 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 		}
 	}
 	if log.addStack.Enabled(ce.Entry.Level) {
-		if log.useCallerSkipForStack {
-			ce.Entry.Stack = StackSkip("", log.callerSkip+callerSkipOffset).String
-		} else {
-			ce.Entry.Stack = Stack("").String
-		}
+		ce.Entry.Stack = StackSkip("", log.callerSkip+callerSkipOffset).String
 	}
 
 	return ce

--- a/logger.go
+++ b/logger.go
@@ -48,7 +48,8 @@ type Logger struct {
 	addCaller bool
 	addStack  zapcore.LevelEnabler
 
-	callerSkip int
+	callerSkip            int
+	useCallerSkipForStack bool
 }
 
 // New constructs a new Logger from the provided zapcore.Core and Options. If
@@ -304,7 +305,11 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 		}
 	}
 	if log.addStack.Enabled(ce.Entry.Level) {
-		ce.Entry.Stack = Stack("").String
+		if log.useCallerSkipForStack {
+			ce.Entry.Stack = StackSkip("", log.callerSkip).String
+		} else {
+			ce.Entry.Stack = Stack("").String
+		}
 	}
 
 	return ce

--- a/options.go
+++ b/options.go
@@ -119,14 +119,6 @@ func AddStacktrace(lvl zapcore.LevelEnabler) Option {
 	})
 }
 
-// UseCallerSkipForStacktrace configures the logger to use the number of frames
-// that should be skipped for caller (CallerSkip) annotation when taking stacktraces.
-func UseCallerSkipForStacktrace(enabled bool) Option {
-	return optionFunc(func(log *Logger) {
-		log.useCallerSkipForStack = enabled
-	})
-}
-
 // IncreaseLevel increase the level of the logger. It has no effect if
 // the passed in level tries to decrease the level of the logger.
 func IncreaseLevel(lvl zapcore.LevelEnabler) Option {

--- a/options.go
+++ b/options.go
@@ -119,6 +119,14 @@ func AddStacktrace(lvl zapcore.LevelEnabler) Option {
 	})
 }
 
+// UseCallerSkipForStacktrace configures the logger to use the number of frames
+// that should be skipped for caller (CallerSkip) annotation when taking stacktraces.
+func UseCallerSkipForStacktrace(enabled bool) Option {
+	return optionFunc(func(log *Logger) {
+		log.useCallerSkipForStack = enabled
+	})
+}
+
 // IncreaseLevel increase the level of the logger. It has no effect if
 // the passed in level tries to decrease the level of the logger.
 func IncreaseLevel(lvl zapcore.LevelEnabler) Option {

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -43,7 +43,7 @@ var (
 	_zapStacktraceVendorContains = addPrefix("/vendor/", _zapStacktracePrefixes...)
 )
 
-func takeStacktrace(skip *int) string {
+func takeStacktrace(skip int) string {
 	buffer := bufferpool.Get()
 	defer buffer.Free()
 	programCounters := _stacktracePool.Get().(*programCounters)
@@ -69,10 +69,6 @@ func takeStacktrace(skip *int) string {
 	// Note: On the last iteration, frames.Next() returns false, with a valid
 	// frame, but we ignore this frame. The last frame is a a runtime frame which
 	// adds noise, since it's only either runtime.main or runtime.goexit.
-	toSkip := 0
-	if skip != nil {
-		toSkip = *skip
-	}
 	for frame, more := frames.Next(); more; frame, more = frames.Next() {
 		if skipZapFrames && isZapFrame(frame.Function) {
 			continue
@@ -80,8 +76,8 @@ func takeStacktrace(skip *int) string {
 			skipZapFrames = false
 		}
 
-		if toSkip > 0 {
-			toSkip--
+		if skip > 0 {
+			skip--
 			continue
 		}
 

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -51,7 +51,7 @@ func takeStacktrace(skip int) string {
 
 	var numFrames int
 	for {
-		// Skip the call to runtime.Counters and takeStacktrace so that the
+		// Skip the call to runtime.Callers and takeStacktrace so that the
 		// program counters start at the caller of takeStacktrace.
 		numFrames = runtime.Callers(2, programCounters.pcs)
 		if numFrames < len(programCounters.pcs) {
@@ -62,8 +62,9 @@ func takeStacktrace(skip int) string {
 		programCounters = newProgramCounters(len(programCounters.pcs) * 2)
 	}
 
+	// Skip all consecutive zap frames at the beginning if no skip is set.
+	skipZapFrames := skip == 0
 	i := 0
-	skipZapFrames := true // skip all consecutive zap frames at the beginning.
 	frames := runtime.CallersFrames(programCounters.pcs[:numFrames])
 
 	// Note: On the last iteration, frames.Next() returns false, with a valid

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -45,7 +45,7 @@ func takeStacktrace(skip int) string {
 	for {
 		// Skip the call to runtime.Callers and takeStacktrace so that the
 		// program counters start at the caller of takeStacktrace.
-		numFrames = runtime.Callers(2, programCounters.pcs)
+		numFrames = runtime.Callers(skip+2, programCounters.pcs)
 		if numFrames < len(programCounters.pcs) {
 			break
 		}
@@ -61,11 +61,6 @@ func takeStacktrace(skip int) string {
 	// frame, but we ignore this frame. The last frame is a a runtime frame which
 	// adds noise, since it's only either runtime.main or runtime.goexit.
 	for frame, more := frames.Next(); more; frame, more = frames.Next() {
-		if skip > 0 {
-			skip--
-			continue
-		}
-
 		if i != 0 {
 			buffer.AppendByte('\n')
 		}

--- a/stacktrace_ext_test.go
+++ b/stacktrace_ext_test.go
@@ -127,7 +127,6 @@ func TestStacktraceWithoutCallerSkip(t *testing.T) {
 		}()
 
 		require.Contains(t, out.String(), "TestStacktraceWithoutCallerSkip.", "Should not skip too much")
-		require.Contains(t, out.String(), "TestStacktraceWithoutCallerSkip", "Should not skip too much")
 		verifyNoZap(t, out.String())
 	})
 }

--- a/stacktrace_ext_test.go
+++ b/stacktrace_ext_test.go
@@ -120,28 +120,27 @@ func TestStacktraceFiltersVendorZap(t *testing.T) {
 	})
 }
 
-func TestStacktraceUseCallerSkipForStacktraceWithoutCallerSkip(t *testing.T) {
+func TestStacktraceWithoutCallerSkip(t *testing.T) {
 	withLogger(t, func(logger *zap.Logger, out *bytes.Buffer) {
-		logger = logger.WithOptions(zap.UseCallerSkipForStacktrace(true))
 		func() {
 			logger.Error("test log")
 		}()
 
-		require.Contains(t, out.String(), "TestStacktraceUseCallerSkipForStacktraceWithoutCallerSkip.", "Should not skip too much")
-		require.Contains(t, out.String(), "TestStacktraceUseCallerSkipForStacktraceWithoutCallerSkip", "Should not skip too much")
+		require.Contains(t, out.String(), "TestStacktraceWithoutCallerSkip.", "Should not skip too much")
+		require.Contains(t, out.String(), "TestStacktraceWithoutCallerSkip", "Should not skip too much")
 		verifyNoZap(t, out.String())
 	})
 }
 
-func TestStacktraceUseCallerSkipForStacktraceWithCallerSkip(t *testing.T) {
+func TestStacktraceWithCallerSkip(t *testing.T) {
 	withLogger(t, func(logger *zap.Logger, out *bytes.Buffer) {
-		logger = logger.WithOptions(zap.UseCallerSkipForStacktrace(true), zap.AddCallerSkip(2))
+		logger = logger.WithOptions(zap.AddCallerSkip(2))
 		func() {
 			logger.Error("test log")
 		}()
 
-		require.NotContains(t, out.String(), "TestStacktraceUseCallerSkipForStacktraceWithCallerSkip.", "Should skip as requested by caller skip")
-		require.Contains(t, out.String(), "TestStacktraceUseCallerSkipForStacktraceWithCallerSkip", "Should not skip too much")
+		require.NotContains(t, out.String(), "TestStacktraceWithCallerSkip.", "Should skip as requested by caller skip")
+		require.Contains(t, out.String(), "TestStacktraceWithCallerSkip", "Should not skip too much")
 		verifyNoZap(t, out.String())
 	})
 }

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestTakeStacktrace(t *testing.T) {
-	trace := takeStacktrace()
+	trace := takeStacktrace(nil)
 	lines := strings.Split(trace, "\n")
 	require.True(t, len(lines) > 0, "Expected stacktrace to have at least one frame.")
 	assert.Contains(
@@ -70,6 +70,6 @@ func TestIsZapFrame(t *testing.T) {
 
 func BenchmarkTakeStacktrace(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		takeStacktrace()
+		takeStacktrace(nil)
 	}
 }

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -31,24 +31,24 @@ import (
 func TestTakeStacktrace(t *testing.T) {
 	trace := takeStacktrace(0)
 	lines := strings.Split(trace, "\n")
-	require.True(t, len(lines) > 0, "Expected stacktrace to have at least one frame.")
+	require.NotEmpty(t, lines, "Expected stacktrace to have at least one frame.")
 	assert.Contains(
 		t,
 		lines[0],
 		"go.uber.org/zap.TestTakeStacktrace",
-		"Expected stacktrace to start with the test %s.", lines[0],
+		"Expected stacktrace to start with the test.",
 	)
 }
 
 func TestTakeStacktraceWithSkip(t *testing.T) {
 	trace := takeStacktrace(1)
 	lines := strings.Split(trace, "\n")
-	require.True(t, len(lines) > 0, "Expected stacktrace to have at least one frame.")
+	require.NotEmpty(t, lines, "Expected stacktrace to have at least one frame.")
 	assert.Contains(
 		t,
 		lines[0],
 		"testing.",
-		"Expected stacktrace to start with the test runner (skipping our own frame) %s.", lines[0],
+		"Expected stacktrace to start with the test runner (skipping our own frame).",
 	)
 }
 
@@ -58,12 +58,12 @@ func TestTakeStacktraceWithSkipInnerFunc(t *testing.T) {
 		trace = takeStacktrace(2)
 	}()
 	lines := strings.Split(trace, "\n")
-	require.True(t, len(lines) > 0, "Expected stacktrace to have at least one frame.")
+	require.NotEmpty(t, lines, "Expected stacktrace to have at least one frame.")
 	assert.Contains(
 		t,
 		lines[0],
 		"testing.",
-		"Expected stacktrace to start with the test function (skipping the test function) %s.", lines[0],
+		"Expected stacktrace to start with the test function (skipping the test function).",
 	)
 }
 

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -35,37 +35,9 @@ func TestTakeStacktrace(t *testing.T) {
 	assert.Contains(
 		t,
 		lines[0],
-		"testing.",
-		"Expected stacktrace to start with the test runner (zap frames are filtered out) %s.", lines[0],
+		"go.uber.org/zap.TestTakeStacktrace",
+		"Expected stacktrace to start with the test %s.", lines[0],
 	)
-}
-
-func TestIsZapFrame(t *testing.T) {
-	zapFrames := []string{
-		"go.uber.org/zap.Stack",
-		"go.uber.org/zap.(*SugaredLogger).log",
-		"go.uber.org/zap/zapcore.(ArrayMarshalerFunc).MarshalLogArray",
-		"github.com/uber/tchannel-go/vendor/go.uber.org/zap.Stack",
-		"github.com/uber/tchannel-go/vendor/go.uber.org/zap.(*SugaredLogger).log",
-		"github.com/uber/tchannel-go/vendor/go.uber.org/zap/zapcore.(ArrayMarshalerFunc).MarshalLogArray",
-	}
-	nonZapFrames := []string{
-		"github.com/uber/tchannel-go.NewChannel",
-		"go.uber.org/not-zap.New",
-		"go.uber.org/zapext.ctx",
-		"go.uber.org/zap_ext/ctx.New",
-	}
-
-	t.Run("zap frames", func(t *testing.T) {
-		for _, f := range zapFrames {
-			require.True(t, isZapFrame(f), f)
-		}
-	})
-	t.Run("non-zap frames", func(t *testing.T) {
-		for _, f := range nonZapFrames {
-			require.False(t, isZapFrame(f), f)
-		}
-	})
 }
 
 func TestTakeStacktraceWithSkip(t *testing.T) {

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -68,6 +68,33 @@ func TestIsZapFrame(t *testing.T) {
 	})
 }
 
+func TestTakeStacktraceWithSkip(t *testing.T) {
+	trace := takeStacktrace(1)
+	lines := strings.Split(trace, "\n")
+	require.True(t, len(lines) > 0, "Expected stacktrace to have at least one frame.")
+	assert.Contains(
+		t,
+		lines[0],
+		"testing.",
+		"Expected stacktrace to start with the test runner (skipping our own frame) %s.", lines[0],
+	)
+}
+
+func TestTakeStacktraceWithSkipInnerFunc(t *testing.T) {
+	var trace string
+	func() {
+		trace = takeStacktrace(1)
+	}()
+	lines := strings.Split(trace, "\n")
+	require.True(t, len(lines) > 0, "Expected stacktrace to have at least one frame.")
+	assert.Contains(
+		t,
+		lines[0],
+		"testing.",
+		"Expected stacktrace to start with the test function (skipping the inner func) %s.", lines[0],
+	)
+}
+
 func BenchmarkTakeStacktrace(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		takeStacktrace(0)

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestTakeStacktrace(t *testing.T) {
-	trace := takeStacktrace(nil)
+	trace := takeStacktrace(0)
 	lines := strings.Split(trace, "\n")
 	require.True(t, len(lines) > 0, "Expected stacktrace to have at least one frame.")
 	assert.Contains(
@@ -70,6 +70,6 @@ func TestIsZapFrame(t *testing.T) {
 
 func BenchmarkTakeStacktrace(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		takeStacktrace(nil)
+		takeStacktrace(0)
 	}
 }

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -83,7 +83,7 @@ func TestTakeStacktraceWithSkip(t *testing.T) {
 func TestTakeStacktraceWithSkipInnerFunc(t *testing.T) {
 	var trace string
 	func() {
-		trace = takeStacktrace(1)
+		trace = takeStacktrace(2)
 	}()
 	lines := strings.Split(trace, "\n")
 	require.True(t, len(lines) > 0, "Expected stacktrace to have at least one frame.")
@@ -91,7 +91,7 @@ func TestTakeStacktraceWithSkipInnerFunc(t *testing.T) {
 		t,
 		lines[0],
 		"testing.",
-		"Expected stacktrace to start with the test function (skipping the inner func) %s.", lines[0],
+		"Expected stacktrace to start with the test function (skipping the test function) %s.", lines[0],
 	)
 }
 


### PR DESCRIPTION
* Honor `CallerSkip` when taking a stack trace. Both the caller and stack trace will now point to the same frame.
* Add `StackSkip` which is similar to `Stack` but allows skipping frames from the top of the stack.

This removes the internal behavior of skipping zap specific stack frames when taking a stack trace, and instead relies on the same behavior used to calculate the number of frames to skip for getting the caller to also skip frames in the stack trace.

Fixes #512, fixes #727