### PR TITLE
stop time.Now().UTC() escape to heap

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -299,7 +299,8 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 	if log.addCaller {
 		ce.Entry.Caller = zapcore.NewEntryCaller(runtime.Caller(log.callerSkip + callerSkipOffset))
 		if !ce.Entry.Caller.Defined {
-			fmt.Fprintf(log.errorOutput, "%v Logger.check error: failed to get caller\n", time.Now().UTC())
+			m := time.Now().UTC().String() + " Logger.check error: failed to get caller\n"
+			fmt.Fprintf(log.errorOutput, m)
 			log.errorOutput.Sync()
 		}
 	}


### PR DESCRIPTION
### Problem
* `time.Now().UTC()` use to escape to heap because it was passed as argument for an interface param
* Old `go build -gcflags='-m -m'` shows :- 
```
./logger.go:302:96: time.Now().UTC() escapes to heap
```
### Solution
Passing error message as string argument for string param of `fmt.Fprintf`  stopped `escape to heap`
**Result**:
```
./logger.go:302:36: (*Logger).check time.Time(~R0).String() + " Logger.check error: failed to get caller\n" does not escape
```


Am not sure if this change worth merging because it doesn't make any significant difference. However, I think it improves something. So thought of raising this one-liner PR.