### PR TITLE
consoleEncoder: put cloned jsonEncoder back to pool

### DIFF
--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -131,6 +131,8 @@ func (c consoleEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 func (c consoleEncoder) writeContext(line *buffer.Buffer, extra []Field) {
 	context := c.jsonEncoder.Clone().(*jsonEncoder)
 	defer func() {
+		// putJSONEncoder assumes the buffer is still used, but we write out the buffer so
+		// we can free it.
 		context.buf.Free()
 		putJSONEncoder(context)
 	}()

--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -130,7 +130,10 @@ func (c consoleEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 
 func (c consoleEncoder) writeContext(line *buffer.Buffer, extra []Field) {
 	context := c.jsonEncoder.Clone().(*jsonEncoder)
-	defer context.buf.Free()
+	defer func() {
+		context.buf.Free()
+		putJSONEncoder(context)
+	}()
 
 	addFields(context, extra)
 	context.closeOpenNamespaces()


### PR DESCRIPTION
This PR put back the cloned `jsonEncoder` in `consoleEncoder` to `_jsonPool` as mentioned in #851 

Tested and got no errors ( with race detector )
* `make test` 
* `go test -race -run="^$$" -bench="BenchmarkZapConsole" ./zapcore`