### PR TITLE
Add options to customize Fatal behaviour for better testability

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -49,6 +49,7 @@ type Logger struct {
 	addStack  zapcore.LevelEnabler
 
 	callerSkip int
+	onFatal    zapcore.CheckWriteAction // default is WriteThenFatal.
 }
 
 // New constructs a new Logger from the provided zapcore.Core and Options. If
@@ -280,7 +281,11 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 	case zapcore.PanicLevel:
 		ce = ce.Should(ent, zapcore.WriteThenPanic)
 	case zapcore.FatalLevel:
-		ce = ce.Should(ent, zapcore.WriteThenFatal)
+		onFatal := log.onFatal
+		if onFatal == 0 {
+			onFatal = zapcore.WriteThenFatal
+		}
+		ce = ce.Should(ent, onFatal)
 	case zapcore.DPanicLevel:
 		if log.development {
 			ce = ce.Should(ent, zapcore.WriteThenPanic)

--- a/logger.go
+++ b/logger.go
@@ -282,7 +282,7 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 		ce = ce.Should(ent, zapcore.WriteThenPanic)
 	case zapcore.FatalLevel:
 		onFatal := log.onFatal
-		if onFatal == 0 {
+		if onFatal == zapcore.WriteThenNoop {
 			onFatal = zapcore.WriteThenFatal
 		}
 		ce = ce.Should(ent, onFatal)

--- a/logger.go
+++ b/logger.go
@@ -282,6 +282,8 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 		ce = ce.Should(ent, zapcore.WriteThenPanic)
 	case zapcore.FatalLevel:
 		onFatal := log.onFatal
+		// Noop is the default value for CheckWriteAction, and it leads to
+		// continued execution after a Fatal which is unexpected.
 		if onFatal == zapcore.WriteThenNoop {
 			onFatal = zapcore.WriteThenFatal
 		}

--- a/logger.go
+++ b/logger.go
@@ -49,7 +49,7 @@ type Logger struct {
 	addStack  zapcore.LevelEnabler
 
 	callerSkip int
-	onFatal    zapcore.CheckWriteAction // default is WriteThenFatal.
+	onFatal    zapcore.CheckWriteAction // default is WriteThenFatal
 }
 
 // New constructs a new Logger from the provided zapcore.Core and Options. If

--- a/options.go
+++ b/options.go
@@ -131,3 +131,10 @@ func IncreaseLevel(lvl zapcore.LevelEnabler) Option {
 		}
 	})
 }
+
+// OnFatal sets the action to take on fatal logs.
+func OnFatal(action zapcore.CheckWriteAction) Option {
+	return optionFunc(func(log *Logger) {
+		log.onFatal = action
+	})
+}

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -22,6 +22,7 @@ package zapcore
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -163,6 +164,8 @@ const (
 	WriteThenPanic
 	// WriteThenFatal causes a fatal os.Exit after Write.
 	WriteThenFatal
+	// WriteThenGoexit runs runtime.Goexit after Write.
+	WriteThenGoexit
 )
 
 // CheckedEntry is an Entry together with a collection of Cores that have
@@ -231,6 +234,8 @@ func (ce *CheckedEntry) Write(fields ...Field) {
 		panic(msg)
 	case WriteThenFatal:
 		exit.Exit()
+	case WriteThenGoexit:
+		runtime.Goexit()
 	}
 }
 

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -160,12 +160,12 @@ const (
 	// WriteThenNoop indicates that nothing special needs to be done. It's the
 	// default behavior.
 	WriteThenNoop CheckWriteAction = iota
+	// WriteThenGoexit runs runtime.Goexit after Write.
+	WriteThenGoexit
 	// WriteThenPanic causes a panic after Write.
 	WriteThenPanic
 	// WriteThenFatal causes a fatal os.Exit after Write.
 	WriteThenFatal
-	// WriteThenGoexit runs runtime.Goexit after Write.
-	WriteThenGoexit
 )
 
 // CheckedEntry is an Entry together with a collection of Cores that have


### PR DESCRIPTION
Fixes #846.

There's currently no easy way to test Fatal from outside of zap, as it
triggers an os.Exit(1). Add options to customize the behaviour (allowing
for panic, or Goexit), which can be used with `recover()` in tests.