### PR TITLE
field/error: Handle panic in Error()

### DIFF
--- a/error.go
+++ b/error.go
@@ -21,8 +21,9 @@
 package zap
 
 import (
-	"go.uber.org/zap/zapcore"
 	"sync"
+
+	"go.uber.org/zap/zapcore"
 )
 
 var _errArrayElemPool = sync.Pool{New: func() interface{} {

--- a/error.go
+++ b/error.go
@@ -21,9 +21,8 @@
 package zap
 
 import (
-	"sync"
-
 	"go.uber.org/zap/zapcore"
+	"sync"
 )
 
 var _errArrayElemPool = sync.Pool{New: func() interface{} {

--- a/zapcore/error.go
+++ b/zapcore/error.go
@@ -49,7 +49,7 @@ func encodeError(key string, err error, enc ObjectEncoder) (retErr error) {
 	defer func() {
 		if rerr := recover(); rerr != nil {
 			// If it's a nil pointer, just say "<nil>". The likeliest causes are a
-			// Stringer that fails to guard against nil or a nil pointer for a
+			// error that fails to guard against nil or a nil pointer for a
 			// value receiver, and in either case, "<nil>" is a nice result.
 			if v := reflect.ValueOf(err); v.Kind() == reflect.Ptr && v.IsNil() {
 				enc.AddString(key, "<nil>")
@@ -65,7 +65,7 @@ func encodeError(key string, err error, enc ObjectEncoder) (retErr error) {
 
 	switch e := err.(type) {
 	case errorGroup:
-		retErr = enc.AddArray(key+"Causes", errArray(e.Errors()))
+		return enc.AddArray(key+"Causes", errArray(e.Errors()))
 	case fmt.Formatter:
 		verbose := fmt.Sprintf("%+v", e)
 		if verbose != basic {
@@ -74,7 +74,7 @@ func encodeError(key string, err error, enc ObjectEncoder) (retErr error) {
 			enc.AddString(key+"Verbose", verbose)
 		}
 	}
-	return retErr
+	return nil
 }
 
 type errorGroup interface {

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -167,7 +167,7 @@ func (f Field) AddTo(enc ObjectEncoder) {
 	case StringerType:
 		err = encodeStringer(f.Key, f.Interface, enc)
 	case ErrorType:
-		encodeError(f.Key, f.Interface.(error), enc)
+		err = encodeError(f.Key, f.Interface.(error), enc)
 	case SkipType:
 		break
 	default:
@@ -209,7 +209,7 @@ func encodeStringer(key string, stringer interface{}, enc ObjectEncoder) (retErr
 	// Try to capture panics (from nil references or otherwise) when calling
 	// the String() method, similar to https://golang.org/src/fmt/print.go#L540
 	defer func() {
-		if err := recover(); err != nil {
+		if rerr := recover(); rerr != nil {
 			// If it's a nil pointer, just say "<nil>". The likeliest causes are a
 			// Stringer that fails to guard against nil or a nil pointer for a
 			// value receiver, and in either case, "<nil>" is a nice result.
@@ -218,7 +218,7 @@ func encodeStringer(key string, stringer interface{}, enc ObjectEncoder) (retErr
 				return
 			}
 
-			retErr = fmt.Errorf("PANIC=%v", err)
+			retErr = fmt.Errorf("PANIC=%v", rerr)
 		}
 	}()
 

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -209,7 +209,7 @@ func encodeStringer(key string, stringer interface{}, enc ObjectEncoder) (retErr
 	// Try to capture panics (from nil references or otherwise) when calling
 	// the String() method, similar to https://golang.org/src/fmt/print.go#L540
 	defer func() {
-		if rerr := recover(); rerr != nil {
+		if err := recover(); err != nil {
 			// If it's a nil pointer, just say "<nil>". The likeliest causes are a
 			// Stringer that fails to guard against nil or a nil pointer for a
 			// value receiver, and in either case, "<nil>" is a nice result.
@@ -218,7 +218,7 @@ func encodeStringer(key string, stringer interface{}, enc ObjectEncoder) (retErr
 				return
 			}
 
-			retErr = fmt.Errorf("PANIC=%v", rerr)
+			retErr = fmt.Errorf("PANIC=%v", err)
 		}
 	}()
 

--- a/zapcore/field_test.go
+++ b/zapcore/field_test.go
@@ -81,11 +81,16 @@ func (o *obj) String() string {
 }
 
 type errObj struct {
-	errMessage string
+	kind   int
+	errMsg string
 }
 
 func (eobj *errObj) Error() string {
-	return eobj.errMessage
+	if eobj.kind == 1 {
+		panic("panic in Error() method")
+	} else {
+		return eobj.errMsg
+	}
 }
 
 func TestUnknownFieldType(t *testing.T) {
@@ -110,6 +115,7 @@ func TestFieldAddingError(t *testing.T) {
 		{t: StringerType, iface: &obj{1}, want: empty, err: "PANIC=panic with string"},
 		{t: StringerType, iface: &obj{2}, want: empty, err: "PANIC=panic with error"},
 		{t: StringerType, iface: &obj{3}, want: empty, err: "PANIC=<nil>"},
+		{t: ErrorType, iface: &errObj{kind: 1}, want: empty, err: "PANIC=panic in Error() method"},
 	}
 	for _, tt := range tests {
 		f := Field{Key: "k", Interface: tt.iface, Type: tt.t}

--- a/zapcore/field_test.go
+++ b/zapcore/field_test.go
@@ -80,6 +80,14 @@ func (o *obj) String() string {
 	return "obj"
 }
 
+type errObj struct {
+	errMessage string
+}
+
+func (eobj *errObj) Error() string {
+	return eobj.errMessage
+}
+
 func TestUnknownFieldType(t *testing.T) {
 	unknown := Field{Key: "k", String: "foo"}
 	assert.Equal(t, UnknownType, unknown.Type, "Expected zero value of FieldType to be UnknownType.")
@@ -150,6 +158,7 @@ func TestFields(t *testing.T) {
 		{t: SkipType, want: interface{}(nil)},
 		{t: StringerType, iface: (*url.URL)(nil), want: "<nil>"},
 		{t: StringerType, iface: (*users)(nil), want: "<nil>"},
+		{t: ErrorType, iface: (*errObj)(nil), want: "<nil>"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
We shouldn't panic if the `Error()` method of an `error` panics.

```
type T struct{ msg string }

func (t *T) Error() string { return t.msg }

// The following panics.
var n *T = nil
log.Info("panic", zap.Error(n))
```
