### PR TITLE
feat: add support for toml tags

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,9 +37,9 @@ import (
 // Values configured here are per-second. See zapcore.NewSamplerWithOptions for
 // details.
 type SamplingConfig struct {
-	Initial    int                                           `json:"initial" yaml:"initial"`
-	Thereafter int                                           `json:"thereafter" yaml:"thereafter"`
-	Hook       func(zapcore.Entry, zapcore.SamplingDecision) `json:"-" yaml:"-"`
+	Initial    int                                           `json:"initial" yaml:"initial" toml:"initial"`
+	Thereafter int                                           `json:"thereafter" yaml:"thereafter" toml:"thereafter"`
+	Hook       func(zapcore.Entry, zapcore.SamplingDecision) `json:"-" yaml:"-" toml:"-"`
 }
 
 // Config offers a declarative way to construct a logger. It doesn't do
@@ -59,38 +59,38 @@ type Config struct {
 	// Level is the minimum enabled logging level. Note that this is a dynamic
 	// level, so calling Config.Level.SetLevel will atomically change the log
 	// level of all loggers descended from this config.
-	Level AtomicLevel `json:"level" yaml:"level"`
+	Level AtomicLevel `json:"level" yaml:"level" toml:"level"`
 	// Development puts the logger in development mode, which changes the
 	// behavior of DPanicLevel and takes stacktraces more liberally.
-	Development bool `json:"development" yaml:"development"`
+	Development bool `json:"development" yaml:"development" toml:"development"`
 	// DisableCaller stops annotating logs with the calling function's file
 	// name and line number. By default, all logs are annotated.
-	DisableCaller bool `json:"disableCaller" yaml:"disableCaller"`
+	DisableCaller bool `json:"disableCaller" yaml:"disableCaller" toml:"disableCaller"`
 	// DisableStacktrace completely disables automatic stacktrace capturing. By
 	// default, stacktraces are captured for WarnLevel and above logs in
 	// development and ErrorLevel and above in production.
-	DisableStacktrace bool `json:"disableStacktrace" yaml:"disableStacktrace"`
+	DisableStacktrace bool `json:"disableStacktrace" yaml:"disableStacktrace" toml:"disableStacktrace"`
 	// Sampling sets a sampling policy. A nil SamplingConfig disables sampling.
-	Sampling *SamplingConfig `json:"sampling" yaml:"sampling"`
+	Sampling *SamplingConfig `json:"sampling" yaml:"sampling" toml:"sampling"`
 	// Encoding sets the logger's encoding. Valid values are "json" and
 	// "console", as well as any third-party encodings registered via
 	// RegisterEncoder.
-	Encoding string `json:"encoding" yaml:"encoding"`
+	Encoding string `json:"encoding" yaml:"encoding" toml:"encoding"`
 	// EncoderConfig sets options for the chosen encoder. See
 	// zapcore.EncoderConfig for details.
-	EncoderConfig zapcore.EncoderConfig `json:"encoderConfig" yaml:"encoderConfig"`
+	EncoderConfig zapcore.EncoderConfig `json:"encoderConfig" yaml:"encoderConfig" toml:"encoderConfig"`
 	// OutputPaths is a list of URLs or file paths to write logging output to.
 	// See Open for details.
-	OutputPaths []string `json:"outputPaths" yaml:"outputPaths"`
+	OutputPaths []string `json:"outputPaths" yaml:"outputPaths" toml:"outputPaths"`
 	// ErrorOutputPaths is a list of URLs to write internal logger errors to.
 	// The default is standard error.
 	//
 	// Note that this setting only affects internal errors; for sample code that
 	// sends error-level logs to a different location from info- and debug-level
 	// logs, see the package-level AdvancedConfiguration example.
-	ErrorOutputPaths []string `json:"errorOutputPaths" yaml:"errorOutputPaths"`
+	ErrorOutputPaths []string `json:"errorOutputPaths" yaml:"errorOutputPaths" toml:"errorOutputPaths"`
 	// InitialFields is a collection of fields to add to the root logger.
-	InitialFields map[string]interface{} `json:"initialFields" yaml:"initialFields"`
+	InitialFields map[string]interface{} `json:"initialFields" yaml:"initialFields" toml:"initialFields"`
 }
 
 // NewProductionEncoderConfig returns an opinionated EncoderConfig for

--- a/example_test.go
+++ b/example_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -89,6 +90,43 @@ func Example_basicConfiguration() {
 
 	var cfg zap.Config
 	if err := json.Unmarshal(rawJSON, &cfg); err != nil {
+		panic(err)
+	}
+	logger, err := cfg.Build()
+	if err != nil {
+		panic(err)
+	}
+	defer logger.Sync()
+
+	logger.Info("logger construction succeeded")
+	// Output:
+	// {"level":"info","message":"logger construction succeeded","foo":"bar"}
+}
+
+func Example_tomlConfiguration() {
+	// For some users, the presets offered by the NewProduction, NewDevelopment,
+	// and NewExample constructors won't be appropriate. For most of those
+	// users, the bundled Config struct offers the right balance of flexibility
+	// and convenience. (For more complex needs, see the AdvancedConfiguration
+	// example.)
+	//
+	// See the documentation for Config and zapcore.EncoderConfig for all the
+	// available options.
+	rawTOML := `
+level = "debug"
+encoding = "json"
+outputPaths = ["stdout", "/tmp/logs"]
+errorOutputPaths = ["stderr"]
+[initialFields]
+	foo = "bar"
+[encoderConfig]
+    messageKey = "message"
+    levelKey = "level"
+    levelEncoder = "lowercase"
+`
+
+	var cfg zap.Config
+	if _, err := toml.Decode(rawTOML, &cfg); err != nil {
 		panic(err)
 	}
 	logger, err := cfg.Build()

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.uber.org/zap
 go 1.13
 
 require (
+	github.com/BurntSushi/toml v0.3.1
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/atomic v1.6.0

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -312,27 +312,27 @@ func (e *NameEncoder) UnmarshalText(text []byte) error {
 type EncoderConfig struct {
 	// Set the keys used for each log entry. If any key is empty, that portion
 	// of the entry is omitted.
-	MessageKey    string `json:"messageKey" yaml:"messageKey"`
-	LevelKey      string `json:"levelKey" yaml:"levelKey"`
-	TimeKey       string `json:"timeKey" yaml:"timeKey"`
-	NameKey       string `json:"nameKey" yaml:"nameKey"`
-	CallerKey     string `json:"callerKey" yaml:"callerKey"`
-	FunctionKey   string `json:"functionKey" yaml:"functionKey"`
-	StacktraceKey string `json:"stacktraceKey" yaml:"stacktraceKey"`
-	LineEnding    string `json:"lineEnding" yaml:"lineEnding"`
+	MessageKey    string `json:"messageKey" yaml:"messageKey" toml:"messageKey"`
+	LevelKey      string `json:"levelKey" yaml:"levelKey" toml:"levelKey"`
+	TimeKey       string `json:"timeKey" yaml:"timeKey" toml:"timeKey"`
+	NameKey       string `json:"nameKey" yaml:"nameKey" toml:"nameKey"`
+	CallerKey     string `json:"callerKey" yaml:"callerKey" toml:"callerKey"`
+	FunctionKey   string `json:"functionKey" yaml:"functionKey" toml:"functionKey"`
+	StacktraceKey string `json:"stacktraceKey" yaml:"stacktraceKey" toml:"stacktraceKey"`
+	LineEnding    string `json:"lineEnding" yaml:"lineEnding" toml:"lineEnding"`
 	// Configure the primitive representations of common complex types. For
 	// example, some users may want all time.Times serialized as floating-point
 	// seconds since epoch, while others may prefer ISO8601 strings.
-	EncodeLevel    LevelEncoder    `json:"levelEncoder" yaml:"levelEncoder"`
-	EncodeTime     TimeEncoder     `json:"timeEncoder" yaml:"timeEncoder"`
-	EncodeDuration DurationEncoder `json:"durationEncoder" yaml:"durationEncoder"`
-	EncodeCaller   CallerEncoder   `json:"callerEncoder" yaml:"callerEncoder"`
+	EncodeLevel    LevelEncoder    `json:"levelEncoder" yaml:"levelEncoder" toml:"levelEncoder"`
+	EncodeTime     TimeEncoder     `json:"timeEncoder" yaml:"timeEncoder" toml:"timeEncoder"`
+	EncodeDuration DurationEncoder `json:"durationEncoder" yaml:"durationEncoder" toml:"durationEncoder"`
+	EncodeCaller   CallerEncoder   `json:"callerEncoder" yaml:"callerEncoder" toml:"callerEncoder"`
 	// Unlike the other primitive type encoders, EncodeName is optional. The
 	// zero value falls back to FullNameEncoder.
-	EncodeName NameEncoder `json:"nameEncoder" yaml:"nameEncoder"`
+	EncodeName NameEncoder `json:"nameEncoder" yaml:"nameEncoder" toml:"nameEncoder"`
 	// Configures the field separator used by the console encoder. Defaults
 	// to tab.
-	ConsoleSeparator string `json:"consoleSeparator" yaml:"consoleSeparator"`
+	ConsoleSeparator string `json:"consoleSeparator" yaml:"consoleSeparator" toml:"consoleSeparator"`
 }
 
 // ObjectEncoder is a strongly-typed, encoding-agnostic interface for adding a


### PR DESCRIPTION
#### Added
+ TOML tags to `Config`, `SamplingConfig`, and `zapcore.EncoderConfig`.
+ Example test in `example_test.go` which introduces a test-dependency on `github.com/BurntSushi/toml` for decoding TOML info a `Config` struct.

See also: #853