### PR TITLE
Add "UnmarshalFlag" to x/zapcore/Level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.uber.org/zap
 go 1.13
 
 require (
+	github.com/jessevdk/go-flags v1.4.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/atomic v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/x/zapcore/level.go
+++ b/x/zapcore/level.go
@@ -1,0 +1,11 @@
+package zapcore
+
+import "go.uber.org/zap/zapcore"
+
+type Level struct {
+	zapcore.Level
+}
+
+func (l *Level) UnmarshalFlag(value string) error {
+	return l.UnmarshalText([]byte(value))
+}

--- a/x/zapcore/level_test.go
+++ b/x/zapcore/level_test.go
@@ -1,0 +1,80 @@
+package zapcore
+
+import (
+	"testing"
+
+	goflags "github.com/jessevdk/go-flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+type testFlags struct {
+	Level Level `long:"log-level"`
+}
+
+func TestUnmarshalFlag(t *testing.T) {
+	tests := []struct {
+		level     string
+		wantLevel zapcore.Level
+		wantErr   string
+	}{
+		{
+			level:     "debug",
+			wantLevel: zapcore.DebugLevel,
+		},
+		{
+			level:   "not-a-level",
+			wantErr: `unrecognized level: "not-a-level"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.level, func(t *testing.T) {
+			var unmarshaled Level
+
+			err := unmarshaled.UnmarshalFlag(tt.level)
+			if tt.wantErr != "" {
+				require.Error(t, err, "error expected")
+				assert.EqualError(t, err, tt.wantErr, "unexpected error message")
+				return
+			}
+
+			assert.NoError(t, err, "no err expected")
+			assert.Equal(t, tt.wantLevel, unmarshaled.Level, "unexpected unmarshaled level")
+		})
+	}
+}
+
+func TestFlagsParse(t *testing.T) {
+	tests := []struct {
+		level     string
+		wantLevel zapcore.Level
+		wantErr   string
+	}{
+		{
+			level:     "warn",
+			wantLevel: zapcore.WarnLevel,
+		},
+		{
+			level:   "fake",
+			wantErr: "invalid argument for flag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.level, func(t *testing.T) {
+			var flags testFlags
+
+			_, err := goflags.ParseArgs(&flags, []string{"--log-level", tt.level})
+			if tt.wantErr != "" {
+				require.Error(t, err, "error expected")
+				assert.Contains(t, err.Error(), tt.wantErr, "unexpected error message")
+				return
+			}
+
+			assert.NoError(t, err, "no err expected")
+			assert.Equal(t, tt.wantLevel, flags.Level.Level, "unexpeted parsed level")
+		})
+	}
+}


### PR DESCRIPTION
https://pkg.go.dev/github.com/jessevdk/go-flags#Unmarshaler requires a
`UnmarshalFlag` to satisfy the interface for parsing purposes.  Provide this
method so that a x/zapcore/Level could be used as a type when trying to parse
flags.