### PR TITLE
Add FAQ question on zap dropping logs due to sampling

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -27,6 +27,13 @@ abstraction, and it lets us add methods without introducing breaking changes.
 Your applications should define and depend upon an interface that includes
 just the methods you use.
 
+### Why are some of my logs missing?
+
+Logs are dropped intentionally by zap when sampling is enabled. The production
+configuration (as returned by `NewProductionConfig()` enables sampling which will
+cause repeated logs within a second to be sampled. See more details on why sampling
+is enabled in [Why sample application logs](https://github.com/uber-go/zap/blob/master/FAQ.md#why-sample-application-logs).
+
 ### Why sample application logs?
 
 Applications often experience runs of errors, either because of a bug or


### PR DESCRIPTION
Multiple issues have been opened about missing logs (e.g., #874, #588).

While sampling is mentioned in the API documentation for `NewProductionConfig`,
it may help to add an FAQ question as well.