### PR TITLE
http: support additional content type

### DIFF
--- a/http_handler.go
+++ b/http_handler.go
@@ -44,13 +44,18 @@ import (
 //
 //    Content-Type: application/x-www-form-urlencoded
 //
-// With this content type, the request body is expected to be URL encoded like:
+// With this content type, the level can be provided through the request body or
+// a query parameter. The log level is URL encoded like:
 //
 //    level=debug
 //
-// This is the default content type for a curl PUT request. An example curl
-// request could look like this:
+// The request body takes precedence over the query parameter, if both are
+// specified.
 //
+// This content type is the default for a curl PUT request. Following are two
+// example curl requests that both set the logging level to debug.
+//
+//    curl -X PUT localhost:8080/log/level?level=debug
 //    curl -X PUT localhost:8080/log/level -d level=debug
 //
 // For any other content type, the payload is expected to be JSON encoded and

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -80,7 +80,7 @@ func TestAtomicLevelServeHTTP(t *testing.T) {
 			Method:       http.MethodPut,
 			ExpectedCode: http.StatusBadRequest,
 			ContentType:  "application/x-www-form-urlencoded",
-			Body:         "level",
+			Body:         "level=%",
 		},
 		"PUT JSON unspecified": {
 			Method:       http.MethodPut,


### PR DESCRIPTION
Support `application/x-www-form-urlencoded` as an additional content
type for `AtomicLevel.ServeHTTP`.

This is the default content type for `curl -X POST`.

With this change, interacting with the HTTP endpoint is a bit more
user friendly:

```
curl -X PUT localhost:8080/log/level -d level=debug
```

Additionally, the unit tests for the HTTP handler are transformed to
a table driven approach.

fixes #902

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uber-go/zap/903)
<!-- Reviewable:end -->
