### PR TITLE
Support multi-field encoding using zap.InlineObject

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -165,6 +165,29 @@ func ExampleNamespace() {
 	// {"level":"info","msg":"tracked some metrics","metrics":{"counter":1}}
 }
 
+type request struct {
+	URL string
+	IP  string
+}
+
+func (r request) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("url", r.URL)
+	enc.AddString("ip", r.IP)
+	return nil
+}
+
+func ExampleObject() {
+	logger := zap.NewExample()
+	defer logger.Sync()
+
+	req := &request{"/test", "127.0.0.1"}
+	logger.Info("new request, in nested object", zap.Object("req", req))
+	logger.Info("new request, inline", zap.InlineObject(req))
+	// Output:
+	// {"level":"info","msg":"new request, in nested object","req":{"url":"/test","ip":"127.0.0.1"}}
+	// {"level":"info","msg":"new request, inline","url":"/test","ip":"127.0.0.1"}
+}
+
 func ExampleNewStdLog() {
 	logger := zap.NewExample()
 	defer logger.Sync()

--- a/field.go
+++ b/field.go
@@ -400,6 +400,15 @@ func Object(key string, val zapcore.ObjectMarshaler) Field {
 	return Field{Key: key, Type: zapcore.ObjectMarshalerType, Interface: val}
 }
 
+// InlineObject is similar to Object, but does not nest the object under a field
+// name, but adds the fields to the current namespace inline.
+func InlineObject(val zapcore.ObjectMarshaler) Field {
+	return zapcore.Field{
+		Type:      zapcore.InlineObjectMarshalerType,
+		Interface: val,
+	}
+}
+
 // Any takes a key and an arbitrary value and chooses the best way to represent
 // them as a field, falling back to a reflection-based approach only if
 // necessary.

--- a/field_test.go
+++ b/field_test.go
@@ -123,6 +123,7 @@ func TestFieldConstructors(t *testing.T) {
 		{"Reflect", Field{Key: "k", Type: zapcore.ReflectType}, Reflect("k", nil)},
 		{"Stringer", Field{Key: "k", Type: zapcore.StringerType, Interface: addr}, Stringer("k", addr)},
 		{"Object", Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: name}, Object("k", name)},
+		{"InlineObject", Field{Type: zapcore.InlineObjectMarshalerType, Interface: name}, InlineObject(name)},
 		{"Any:ObjectMarshaler", Any("k", name), Object("k", name)},
 		{"Any:ArrayMarshaler", Any("k", bools([]bool{true})), Array("k", bools([]bool{true}))},
 		{"Any:Stringer", Any("k", addr), Stringer("k", addr)},

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -39,6 +39,9 @@ const (
 	ArrayMarshalerType
 	// ObjectMarshalerType indicates that the field carries an ObjectMarshaler.
 	ObjectMarshalerType
+	// InlineObjectMarshalerType indicates that the field carries an ObjectMarshaler
+	// that should be inlined.
+	InlineObjectMarshalerType
 	// BinaryType indicates that the field carries an opaque binary blob.
 	BinaryType
 	// BoolType indicates that the field carries a bool.
@@ -115,6 +118,8 @@ func (f Field) AddTo(enc ObjectEncoder) {
 		err = enc.AddArray(f.Key, f.Interface.(ArrayMarshaler))
 	case ObjectMarshalerType:
 		err = enc.AddObject(f.Key, f.Interface.(ObjectMarshaler))
+	case InlineObjectMarshalerType:
+		err = f.Interface.(ObjectMarshaler).MarshalLogObject(enc)
 	case BinaryType:
 		enc.AddBinary(f.Key, f.Interface.([]byte))
 	case BoolType:


### PR DESCRIPTION
Fixes #876

Currently, a `zap.Field` can only represent a single key-value. Add
`zap.InlineObject` so to allow adding multiple fields to the current
namespace from a type implementing `zap.ObjectMarshaler`.

This also solves a more general problem: a single `zap.Field` can now
be used to add multiple key/value pairs.