### PR TITLE
Remove outdated information, make dependencies is no longer necessary.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,6 @@ git remote add upstream https://github.com/uber-go/zap.git
 git fetch upstream
 ```
 
-Install zap's dependencies:
-
-```
-make dependencies
-```
-
 Make sure that the tests and the linters pass:
 
 ```


### PR DESCRIPTION
This commit https://github.com/uber-go/zap/commit/672336fffe89dc92675790ac2d8284be067b9328#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L21-L38 removed the `dependencies` target and this step is no longer necessary.