### PR TITLE
Added `None` level logs

### DIFF
--- a/global.go
+++ b/global.go
@@ -139,6 +139,8 @@ func redirectStdLogAt(l *Logger, level zapcore.Level) (func(), error) {
 
 func levelToFunc(logger *Logger, lvl zapcore.Level) (func(string, ...Field), error) {
 	switch lvl {
+	case NoneLevel:
+		return logger.None, nil
 	case DebugLevel:
 		return logger.Debug, nil
 	case InfoLevel:

--- a/global_test.go
+++ b/global_test.go
@@ -104,9 +104,9 @@ func TestNewStdLog(t *testing.T) {
 
 func TestNewStdLogAt(t *testing.T) {
 	// include DPanicLevel here, but do not include Development in options
-	levels := []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
+	levels := []zapcore.Level{NoneLevel, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
 	for _, level := range levels {
-		withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
+		withLogger(t, NoneLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
 			std, err := NewStdLogAt(l, level)
 			require.NoError(t, err, "Unexpected error.")
 			std.Print("redirected")
@@ -180,9 +180,9 @@ func TestRedirectStdLogAt(t *testing.T) {
 	initialPrefix := log.Prefix()
 
 	// include DPanicLevel here, but do not include Development in options
-	levels := []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
+	levels := []zapcore.Level{NoneLevel, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
 	for _, level := range levels {
-		withLogger(t, DebugLevel, nil, func(l *Logger, logs *observer.ObservedLogs) {
+		withLogger(t, NoneLevel, nil, func(l *Logger, logs *observer.ObservedLogs) {
 			restore, err := RedirectStdLogAt(l, level)
 			require.NoError(t, err, "Unexpected error.")
 			defer restore()
@@ -201,9 +201,9 @@ func TestRedirectStdLogAt(t *testing.T) {
 
 func TestRedirectStdLogAtCaller(t *testing.T) {
 	// include DPanicLevel here, but do not include Development in options
-	levels := []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
+	levels := []zapcore.Level{NoneLevel, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
 	for _, level := range levels {
-		withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
+		withLogger(t, NoneLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
 			restore, err := RedirectStdLogAt(l, level)
 			require.NoError(t, err, "Unexpected error.")
 			defer restore()

--- a/level.go
+++ b/level.go
@@ -26,6 +26,9 @@ import (
 )
 
 const (
+	// NoneLevel logs are meant to be surpressed/muted, instead of configuring
+	// DebugLevel to be used for this.
+	NoneLevel = zapcore.NoneLevel
 	// DebugLevel logs are typically voluminous, and are usually disabled in
 	// production.
 	DebugLevel = zapcore.DebugLevel

--- a/level.go
+++ b/level.go
@@ -111,7 +111,7 @@ func (lvl AtomicLevel) String() string {
 }
 
 // UnmarshalText unmarshals the text to an AtomicLevel. It uses the same text
-// representations as the static zapcore.Levels ("debug", "info", "warn",
+// representations as the static zapcore.Levels ("none", "debug", "info", "warn",
 // "error", "dpanic", "panic", and "fatal").
 func (lvl *AtomicLevel) UnmarshalText(text []byte) error {
 	if lvl.l == nil {
@@ -128,7 +128,7 @@ func (lvl *AtomicLevel) UnmarshalText(text []byte) error {
 }
 
 // MarshalText marshals the AtomicLevel to a byte slice. It uses the same
-// text representation as the static zapcore.Levels ("debug", "info", "warn",
+// text representation as the static zapcore.Levels ("none", "debug", "info", "warn",
 // "error", "dpanic", "panic", and "fatal").
 func (lvl AtomicLevel) MarshalText() (text []byte, err error) {
 	return lvl.Level().MarshalText()

--- a/level_test.go
+++ b/level_test.go
@@ -35,6 +35,7 @@ func TestLevelEnablerFunc(t *testing.T) {
 		level   zapcore.Level
 		enabled bool
 	}{
+		{NoneLevel, false},
 		{DebugLevel, false},
 		{InfoLevel, true},
 		{WarnLevel, false},
@@ -81,6 +82,7 @@ func TestAtomicLevelText(t *testing.T) {
 		expect zapcore.Level
 		err    bool
 	}{
+		{"none", NoneLevel, false},
 		{"debug", DebugLevel, false},
 		{"info", InfoLevel, false},
 		{"", InfoLevel, false},

--- a/logger.go
+++ b/logger.go
@@ -176,6 +176,14 @@ func (log *Logger) Check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 	return log.check(lvl, msg)
 }
 
+// None logs a message at NoneLevel. The message includes any fields passed
+// at the log site, as well as any fields accumulated on the logger.
+func (log *Logger) None(msg string, fields ...Field) {
+	if ce := log.check(NoneLevel, msg); ce != nil {
+		ce.Write(fields...)
+	}
+}
+
 // Debug logs a message at DebugLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
 func (log *Logger) Debug(msg string, fields ...Field) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -474,6 +474,7 @@ func TestLoggerReplaceCore(t *testing.T) {
 		return zapcore.NewNopCore()
 	})
 	withLogger(t, DebugLevel, opts(replace), func(logger *Logger, logs *observer.ObservedLogs) {
+		logger.None("")
 		logger.Debug("")
 		logger.Info("")
 		logger.Warn("")

--- a/sugar.go
+++ b/sugar.go
@@ -133,6 +133,11 @@ func (s *SugaredLogger) Fatal(args ...interface{}) {
 	s.log(FatalLevel, "", args, nil)
 }
 
+// Nonef uses fmt.Sprintf to log a templated message.
+func (s *SugaredLogger) Nonef(template string, args ...interface{}) {
+	s.log(NoneLevel, template, args, nil)
+}
+
 // Debugf uses fmt.Sprintf to log a templated message.
 func (s *SugaredLogger) Debugf(template string, args ...interface{}) {
 	s.log(DebugLevel, template, args, nil)
@@ -167,6 +172,12 @@ func (s *SugaredLogger) Panicf(template string, args ...interface{}) {
 // Fatalf uses fmt.Sprintf to log a templated message, then calls os.Exit.
 func (s *SugaredLogger) Fatalf(template string, args ...interface{}) {
 	s.log(FatalLevel, template, args, nil)
+}
+
+// Nonew logs a message with some additional context. The variadic key-value
+// pairs are treated as they are in With.
+func (s *SugaredLogger) Nonew(msg string, keysAndValues ...interface{}) {
+	s.log(NoneLevel, msg, nil, keysAndValues)
 }
 
 // Debugw logs a message with some additional context. The variadic key-value

--- a/sugar.go
+++ b/sugar.go
@@ -92,6 +92,11 @@ func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
 	return &SugaredLogger{base: s.base.With(s.sweetenFields(args)...)}
 }
 
+// None uses fmt.Sprint to construct and log a message.
+func (s *SugaredLogger) None(args ...interface{}) {
+	s.log(NoneLevel, "", args, nil)
+}
+
 // Debug uses fmt.Sprint to construct and log a message.
 func (s *SugaredLogger) Debug(args ...interface{}) {
 	s.log(DebugLevel, "", args, nil)

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -175,6 +175,7 @@ func TestSugarStructuredLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+			logger.With(context...).Nonew(tt.msg, extra...)
 			logger.With(context...).Debugw(tt.msg, extra...)
 			logger.With(context...).Infow(tt.msg, extra...)
 			logger.With(context...).Warnw(tt.msg, extra...)
@@ -207,6 +208,7 @@ func TestSugarConcatenatingLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+			logger.With(context...).None(tt.args...)
 			logger.With(context...).Debug(tt.args...)
 			logger.With(context...).Info(tt.args...)
 			logger.With(context...).Warn(tt.args...)
@@ -243,6 +245,7 @@ func TestSugarTemplatedLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+			logger.With(context...).Nonef(tt.format, tt.args...)
 			logger.With(context...).Debugf(tt.format, tt.args...)
 			logger.With(context...).Infof(tt.format, tt.args...)
 			logger.With(context...).Warnf(tt.format, tt.args...)

--- a/zapcore/level.go
+++ b/zapcore/level.go
@@ -34,10 +34,10 @@ type Level int8
 const (
 	// NoneLevel logs are meant to be surpressed/muted, instead of configuring
 	// DebugLevel to be used for this.
-	NoneLevel Level = iota - 10
+	NoneLevel Level = iota - 2
 	// DebugLevel logs are typically voluminous, and are usually disabled in
 	// production.
-	DebugLevel Level = iota - 1
+	DebugLevel
 	// InfoLevel is the default logging priority.
 	InfoLevel
 	// WarnLevel logs are more important than Info, but don't need individual
@@ -61,6 +61,8 @@ const (
 // String returns a lower-case ASCII representation of the log level.
 func (l Level) String() string {
 	switch l {
+	case NoneLevel:
+		return "none"
 	case DebugLevel:
 		return "debug"
 	case InfoLevel:
@@ -85,6 +87,8 @@ func (l Level) CapitalString() string {
 	// Printing levels in all-caps is common enough that we should export this
 	// functionality.
 	switch l {
+	case NoneLevel:
+		return "NONE"
 	case DebugLevel:
 		return "DEBUG"
 	case InfoLevel:
@@ -128,6 +132,8 @@ func (l *Level) UnmarshalText(text []byte) error {
 
 func (l *Level) unmarshalText(text []byte) bool {
 	switch string(text) {
+	case "none", "NONE":
+		*l = NoneLevel
 	case "debug", "DEBUG":
 		*l = DebugLevel
 	case "info", "INFO", "": // make the zero value useful

--- a/zapcore/level.go
+++ b/zapcore/level.go
@@ -32,6 +32,9 @@ var errUnmarshalNilLevel = errors.New("can't unmarshal a nil *Level")
 type Level int8
 
 const (
+	// NoneLevel logs are meant to be surpressed/muted, instead of configuring
+	// DebugLevel to be used for this.
+	NoneLevel Level = iota - 10
 	// DebugLevel logs are typically voluminous, and are usually disabled in
 	// production.
 	DebugLevel Level = iota - 1
@@ -51,7 +54,7 @@ const (
 	// FatalLevel logs a message, then calls os.Exit(1).
 	FatalLevel
 
-	_minLevel = DebugLevel
+	_minLevel = NoneLevel
 	_maxLevel = FatalLevel
 )
 

--- a/zapcore/level_strings.go
+++ b/zapcore/level_strings.go
@@ -24,6 +24,7 @@ import "go.uber.org/zap/internal/color"
 
 var (
 	_levelToColor = map[Level]color.Color{
+		NoneLevel:   color.White,
 		DebugLevel:  color.Magenta,
 		InfoLevel:   color.Blue,
 		WarnLevel:   color.Yellow,


### PR DESCRIPTION
This PR adds a new level of log messages, as requested in #729. The request was to added a new level of logging, below Debug, which could be pretty much muted/ignored.