### PR TITLE
add precision to EncoderConfig with default value as -1

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -74,6 +74,12 @@ func (b *Buffer) AppendFloat(f float64, bitSize int) {
 	b.bs = strconv.AppendFloat(b.bs, f, 'f', -1, bitSize)
 }
 
+// AppendFloatWithPrecision appends a float with precision to the underlying buffer. It doesn't quote NaN
+// or +/- Inf.
+func (b *Buffer) AppendFloatWithPrecision(f float64, bitSize int, prec int) {
+	b.bs = strconv.AppendFloat(b.bs, f, 'f', prec, bitSize)
+}
+
 // Len returns the length of the underlying byte slice.
 func (b *Buffer) Len() int {
 	return len(b.bs)

--- a/config.go
+++ b/config.go
@@ -109,6 +109,7 @@ func NewProductionEncoderConfig() zapcore.EncoderConfig {
 		EncodeTime:     zapcore.EpochTimeEncoder,
 		EncodeDuration: zapcore.SecondsDurationEncoder,
 		EncodeCaller:   zapcore.ShortCallerEncoder,
+		Precision:      zapcore.DefaultPrecision,
 	}
 }
 
@@ -149,6 +150,7 @@ func NewDevelopmentEncoderConfig() zapcore.EncoderConfig {
 		EncodeTime:     zapcore.ISO8601TimeEncoder,
 		EncodeDuration: zapcore.StringDurationEncoder,
 		EncodeCaller:   zapcore.ShortCallerEncoder,
+		Precision:      zapcore.DefaultPrecision,
 	}
 }
 

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -31,6 +31,7 @@ import (
 // Alternate line endings specified in EncoderConfig can override this
 // behavior.
 const DefaultLineEnding = "\n"
+const DefaultPrecision = -1
 
 // OmitKey defines the key to use when callers want to remove a key from log output.
 const OmitKey = ""
@@ -333,6 +334,9 @@ type EncoderConfig struct {
 	// Configures the field separator used by the console encoder. Defaults
 	// to tab.
 	ConsoleSeparator string `json:"consoleSeparator" yaml:"consoleSeparator"`
+
+	// float precision
+	Precision int `json:"precision" yaml:"precision"`
 }
 
 // ObjectEncoder is a strongly-typed, encoding-agnostic interface for adding a

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -82,6 +82,9 @@ func NewJSONEncoder(cfg EncoderConfig) Encoder {
 }
 
 func newJSONEncoder(cfg EncoderConfig, spaced bool) *jsonEncoder {
+	if cfg.Precision == 0 {
+		cfg.Precision = -1
+	}
 	return &jsonEncoder{
 		EncoderConfig: &cfg,
 		buf:           bufferpool.Get(),
@@ -454,7 +457,7 @@ func (enc *jsonEncoder) appendFloat(val float64, bitSize int) {
 	case math.IsInf(val, -1):
 		enc.buf.AppendString(`"-Inf"`)
 	default:
-		enc.buf.AppendFloat(val, bitSize)
+		enc.buf.AppendFloatWithPrecision(val, bitSize, enc.Precision)
 	}
 }
 

--- a/zapcore/json_encoder_test.go
+++ b/zapcore/json_encoder_test.go
@@ -167,3 +167,100 @@ func TestJSONEmptyConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestJSONEncodeWithPrecision(t *testing.T) {
+	type bar struct {
+		Key string  `json:"key"`
+		Val float64 `json:"val"`
+	}
+
+	type foo struct {
+		A string  `json:"aee"`
+		B int     `json:"bee"`
+		C float64 `json:"cee"`
+		D []bar   `json:"dee"`
+	}
+
+	tests := []struct {
+		desc     string
+		expected string
+		ent      zapcore.Entry
+		fields   []zapcore.Field
+	}{
+		{
+			desc: "info entry with some fields",
+			expected: `{
+				"L": "info",
+				"T": "2018-06-19T16:33:42.000Z",
+				"N": "bob",
+				"M": "lob law",
+				"so": "passes",
+				"answer": 42,
+				"common_pie": 3.14,
+				"null_value": null,
+				"array_with_null_elements": [{}, null, null, 2],
+				"such": {
+					"aee": "lol",
+					"bee": 123,
+					"cee": 0.9999,
+					"dee": [
+						{"key": "pi", "val": 3.141592653589793},
+						{"key": "tau", "val": 6.283185307179586}
+					]
+				}
+			}`,
+			ent: zapcore.Entry{
+				Level:      zapcore.InfoLevel,
+				Time:       time.Date(2018, 6, 19, 16, 33, 42, 99, time.UTC),
+				LoggerName: "bob",
+				Message:    "lob law",
+			},
+			fields: []zapcore.Field{
+				zap.String("so", "passes"),
+				zap.Int("answer", 42),
+				zap.Float64("common_pie", 3.1415),
+				// Cover special-cased handling of nil in AddReflect() and
+				// AppendReflect(). Note that for the latter, we explicitly test
+				// correct results for both the nil static interface{} value
+				// (`nil`), as well as the non-nil interface value with a
+				// dynamic type and nil value (`(*struct{})(nil)`).
+				zap.Reflect("null_value", nil),
+				zap.Reflect("array_with_null_elements", []interface{}{&struct{}{}, nil, (*struct{})(nil), 2}),
+				zap.Reflect("such", foo{
+					A: "lol",
+					B: 123,
+					C: 0.9999,
+					D: []bar{
+						{"pi", 3.141592653589793},
+						{"tau", 6.283185307179586},
+					},
+				}),
+			},
+		},
+	}
+
+	enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+		MessageKey:     "M",
+		LevelKey:       "L",
+		TimeKey:        "T",
+		NameKey:        "N",
+		CallerKey:      "C",
+		FunctionKey:    "F",
+		StacktraceKey:  "S",
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+		Precision:      2,
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			buf, err := enc.EncodeEntry(tt.ent, tt.fields)
+			if assert.NoError(t, err, "Unexpected JSON encoding error.") {
+				assert.JSONEq(t, tt.expected, buf.String(), "Incorrect encoded JSON entry.")
+			}
+			buf.Free()
+		})
+	}
+}


### PR DESCRIPTION
This is my implementation of this [issue](https://github.com/uber-go/zap/issues/918). 
The problem is I can not control float in reflections.
I think if this needs to take effect in **reflections**, much more jobs need to be done.
Check this out and see if this can work.
Thanks a lot !
@prashantv 