### PR TITLE
optimize sructs with memory alignment / padding

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -33,8 +33,8 @@ const _size = 1024 // by default, create 1 KiB buffers
 // Buffer is a thin wrapper around a byte slice. It's intended to be pooled, so
 // the only way to construct one is via a Pool.
 type Buffer struct {
-	bs   []byte
 	pool Pool
+	bs   []byte
 }
 
 // AppendByte writes a single byte to the Buffer.

--- a/config.go
+++ b/config.go
@@ -37,9 +37,9 @@ import (
 // Values configured here are per-second. See zapcore.NewSamplerWithOptions for
 // details.
 type SamplingConfig struct {
+	Hook       func(zapcore.Entry, zapcore.SamplingDecision) `json:"-" yaml:"-"`
 	Initial    int                                           `json:"initial" yaml:"initial"`
 	Thereafter int                                           `json:"thereafter" yaml:"thereafter"`
-	Hook       func(zapcore.Entry, zapcore.SamplingDecision) `json:"-" yaml:"-"`
 }
 
 // Config offers a declarative way to construct a logger. It doesn't do

--- a/internal/exit/exit.go
+++ b/internal/exit/exit.go
@@ -34,8 +34,8 @@ func Exit() {
 
 // A StubbedExit is a testing fake for os.Exit.
 type StubbedExit struct {
-	Exited bool
 	prev   func()
+	Exited bool
 }
 
 // Stub substitutes a fake for the call to os.Exit(1).

--- a/internal/ztest/writer.go
+++ b/internal/ztest/writer.go
@@ -79,8 +79,8 @@ func (w ShortWriter) Write(b []byte) (int, error) {
 // a bytes.Buffer. It has convenience methods to split the accumulated buffer
 // on newlines.
 type Buffer struct {
-	bytes.Buffer
 	Syncer
+	bytes.Buffer
 }
 
 // Lines returns the current buffer contents, split on newlines.

--- a/logger.go
+++ b/logger.go
@@ -40,18 +40,19 @@ import (
 type Logger struct {
 	core zapcore.Core
 
-	development bool
-	addCaller   bool
-	onFatal     zapcore.CheckWriteAction // default is WriteThenFatal
+	clock Clock
 
-	name        string
 	errorOutput zapcore.WriteSyncer
 
 	addStack zapcore.LevelEnabler
 
+	name string
+
 	callerSkip int
 
-	clock Clock
+	onFatal     zapcore.CheckWriteAction // default is WriteThenFatal
+	development bool
+	addCaller   bool
 }
 
 // New constructs a new Logger from the provided zapcore.Core and Options. If

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -71,11 +71,11 @@ func NewEntryCaller(pc uintptr, file string, line int, ok bool) EntryCaller {
 
 // EntryCaller represents the caller of a logging function.
 type EntryCaller struct {
-	Defined  bool
-	PC       uintptr
 	File     string
-	Line     int
 	Function string
+	PC       uintptr
+	Line     int
+	Defined  bool
 }
 
 // String returns the full path and line number of the caller.
@@ -144,12 +144,12 @@ func (ec EntryCaller) TrimmedPath() string {
 // Entries are pooled, so any functions that accept them MUST be careful not to
 // retain references to them.
 type Entry struct {
-	Level      Level
 	Time       time.Time
 	LoggerName string
 	Message    string
-	Caller     EntryCaller
 	Stack      string
+	Caller     EntryCaller
+	Level      Level
 }
 
 // CheckWriteAction indicates what action to take after a log entry is
@@ -175,11 +175,11 @@ const (
 // nil *CheckedEntry. References are returned to a pool after Write, and MUST
 // NOT be retained after calling their Write method.
 type CheckedEntry struct {
-	Entry
 	ErrorOutput WriteSyncer
-	dirty       bool // best-effort detection of pool misuse
-	should      CheckWriteAction
 	cores       []Core
+	Entry
+	dirty  bool // best-effort detection of pool misuse
+	should CheckWriteAction
 }
 
 func (ce *CheckedEntry) reset() {

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -98,11 +98,11 @@ const (
 // context. Most fields are lazily marshaled, so it's inexpensive to add fields
 // to disabled debug-level log statements.
 type Field struct {
-	Key       string
-	Type      FieldType
-	Integer   int64
-	String    string
 	Interface interface{}
+	Key       string
+	String    string
+	Integer   int64
+	Type      FieldType
 }
 
 // AddTo exports a field through the ObjectEncoder interface. It's primarily

--- a/zapcore/write_syncer.go
+++ b/zapcore/write_syncer.go
@@ -47,8 +47,8 @@ func AddSync(w io.Writer) WriteSyncer {
 }
 
 type lockedWriteSyncer struct {
-	sync.Mutex
 	ws WriteSyncer
+	sync.Mutex
 }
 
 // Lock wraps a WriteSyncer in a mutex to make it safe for concurrent use. In

--- a/zapgrpc/zapgrpc.go
+++ b/zapgrpc/zapgrpc.go
@@ -116,9 +116,9 @@ func NewLogger(l *zap.Logger, options ...Option) *Logger {
 // respectively.
 type printer struct {
 	enab   zapcore.LevelEnabler
-	level  zapcore.Level
 	print  func(...interface{})
 	printf func(string, ...interface{})
+	level  zapcore.Level
 }
 
 func (v *printer) Print(args ...interface{}) {


### PR DESCRIPTION
I think optimizing sructs with memory alignment / padding for a logger is interesting  : 

- buffer/buffer.go : struct with 32 pointer bytes to 16 bytes
- config.go : struct with 24 pointer bytes to 8 bytes
- internal/exit/exit.go : struct with 16 pointer bytes to 8 bytes
- internal/ztest/writer.go : struct with 56 pointer bytes to 32 bytes
- logger.go : struct with 96 pointer bytes to 72 bytes
- zapcore/entry.go : 
   - struct with 48 pointer bytes to 24 bytes
   - struct with 128 pointer bytes to 96 bytes
   - struct with 168 pointer bytes to 136 bytes
- zapcore/field.go : struct with 64 pointer bytes to 40 byes
- zapcore/write_syncer.go : struct with 24 pointer bytes to 16 bytes
- zapgrpc/zapgrpc.go : struct with 40 pointer bytes to 32 bytes

