### PR TITLE
Add FilterFieldKey to zaptest/observer

### DIFF
--- a/zaptest/observer/observer.go
+++ b/zaptest/observer/observer.go
@@ -104,6 +104,18 @@ func (o *ObservedLogs) FilterField(field zapcore.Field) *ObservedLogs {
 	})
 }
 
+// FilterFieldKey filters entries to those that have the specified key.
+func (o *ObservedLogs) FilterFieldKey(key string) *ObservedLogs {
+	return o.filter(func(e LoggedEntry) bool {
+		for _, ctxField := range e.Context {
+			if ctxField.Key == key {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 func (o *ObservedLogs) filter(match func(LoggedEntry) bool) *ObservedLogs {
 	o.mu.RLock()
 	defer o.mu.RUnlock()

--- a/zaptest/observer/observer_test.go
+++ b/zaptest/observer/observer_test.go
@@ -149,6 +149,14 @@ func TestFilters(t *testing.T) {
 			Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "any slice"},
 			Context: []zapcore.Field{zap.Any("slice", []string{"a"})},
 		},
+		{
+			Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "msg 2"},
+			Context: []zapcore.Field{zap.Int("b", 2), zap.Namespace("filterMe")},
+		},
+		{
+			Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "any slice"},
+			Context: []zapcore.Field{zap.Any("filterMe", []string{"b"})},
+		},
 	}
 
 	logger, sink := New(zap.InfoLevel)
@@ -205,6 +213,11 @@ func TestFilters(t *testing.T) {
 			msg:      "filter for slice",
 			filtered: sink.FilterField(zap.Any("slice", []string{"a"})),
 			want:     logs[6:7],
+		},
+		{
+			msg:      "filter field key",
+			filtered: sink.FilterFieldKey("filterMe"),
+			want:     logs[7:9],
 		},
 	}
 


### PR DESCRIPTION
Adds functionality to filter zap.Field by key. This makes testing for
field existence regardless of value more convenient.

resolves https://github.com/uber-go/zap/issues/816