### PR TITLE
zapcore: Cleanup copy in NewMultiWriteSyncer

### DIFF
--- a/zapcore/write_syncer.go
+++ b/zapcore/write_syncer.go
@@ -91,8 +91,7 @@ func NewMultiWriteSyncer(ws ...WriteSyncer) WriteSyncer {
 	if len(ws) == 1 {
 		return ws[0]
 	}
-	// Copy to protect against https://github.com/golang/go/issues/7809
-	return multiWriteSyncer(append([]WriteSyncer(nil), ws...))
+	return multiWriteSyncer(ws)
 }
 
 // See https://golang.org/src/io/multi.go


### PR DESCRIPTION
The copy was originally in place due to https://github.com/golang/go/issues/7809

Since that issue was fixed in Go 1.3 a few years ago, it seems safe to
drop the copy.