### PR TITLE
lint: Check that 'go mod tidy' was run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,12 @@ lint: $(GOLINT) $(STATICCHECK)
 	@echo "Checking for license headers..."
 	@./checklicense.sh | tee -a lint.log
 	@[ ! -s lint.log ]
+	@echo "Checking 'go mod tidy'..."
+	@make tidy
+	@if ! git diff --quiet; then \
+		echo "'go mod tidy' resulted in changes or working tree is dirty:"; \
+		git --no-pager diff; \
+	fi
 
 $(GOLINT):
 	cd tools && go install golang.org/x/lint/golint
@@ -61,3 +67,7 @@ bench:
 updatereadme:
 	rm -f README.md
 	cat .readme.tmpl | go run internal/readme/readme.go > README.md
+
+.PHONY: tidy
+tidy:
+	@$(foreach dir,$(MODULE_DIRS),(cd $(dir) && go mod tidy) &&) true


### PR DESCRIPTION
In #948, we noticed that some `go.sum` files were outdated. To avoid
this in the future, add a `lint` check that verifies that `go mod tidy`
does not cause any changes.

This will fail with a dirty working tree as well, but in CI, we don't
expect that.
