### PR TITLE
zapcore/FieldType: Don't change enum values

### DIFF
--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -39,9 +39,6 @@ const (
 	ArrayMarshalerType
 	// ObjectMarshalerType indicates that the field carries an ObjectMarshaler.
 	ObjectMarshalerType
-	// InlineMarshalerType indicates that the field carries an ObjectMarshaler
-	// that should be inlined.
-	InlineMarshalerType
 	// BinaryType indicates that the field carries an opaque binary blob.
 	BinaryType
 	// BoolType indicates that the field carries a bool.
@@ -95,6 +92,10 @@ const (
 	ErrorType
 	// SkipType indicates that the field is a no-op.
 	SkipType
+
+	// InlineMarshalerType indicates that the field carries an ObjectMarshaler
+	// that should be inlined.
+	InlineMarshalerType
 )
 
 // A Field is a marshaling operation used to add a key-value pair to a logger's


### PR DESCRIPTION
Although the values of the FieldType enums aren't part of the Zap
contract, changing existing values is still a risky change.

[apidiff] considers this a brekaing change.

```
Incompatible changes:
- BinaryType: value changed from 3 to 4
- BoolType: value changed from 4 to 5
- ByteStringType: value changed from 5 to 6
- Complex128Type: value changed from 6 to 7
- Complex64Type: value changed from 7 to 8
- DurationType: value changed from 8 to 9
- ErrorType: value changed from 26 to 27
- Float32Type: value changed from 10 to 11
- Float64Type: value changed from 9 to 10
- Int16Type: value changed from 13 to 14
- Int32Type: value changed from 12 to 13
- Int64Type: value changed from 11 to 12
- Int8Type: value changed from 14 to 15
- NamespaceType: value changed from 24 to 25
- ReflectType: value changed from 23 to 24
- SkipType: value changed from 27 to 28
- StringType: value changed from 15 to 16
- StringerType: value changed from 25 to 26
- TimeFullType: value changed from 17 to 18
- TimeType: value changed from 16 to 17
- Uint16Type: value changed from 20 to 21
- Uint32Type: value changed from 19 to 20
- Uint64Type: value changed from 18 to 19
- Uint8Type: value changed from 21 to 22
- UintptrType: value changed from 22 to 23
```

  [apidiff]: https://github.com/golang/exp/blob/master/apidiff/README.md

Again, although maintianing these values is not part of the Zap
contract, in the interest of erring on the side of safety, I'm moving
the new FieldType (added in #912) to the bottom to avoid changing the
values of the other items.
