### PR TITLE
fossa: Run separately, only on push

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,0 +1,17 @@
+name: FOSSA Analysis
+on: push
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'uber-go'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: FOSSA analysis
+        uses: fossas/fossa-action@v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,11 +26,6 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v2
-      
-    - name: FOSSA analysis
-      uses: fossas/fossa-action@v1
-      with:
-        api-key: ${{ secrets.FOSSA_API_KEY }}
 
     - name: Load cached dependencies
       uses: actions/cache@v1


### PR DESCRIPTION
Currently, the FOSSA analysis is set to run as part of CI. Minus the
fact that it's not really part of the build, its reliance on a secret
means that it won't run for any pull requests made from external forks.

Resolve this by running the FOSSA analysis only when we push to a
branch of the Zap repository.
