### PR TITLE
zapcore: add stopped for Stop method called exactly once

### DIFF
--- a/zapcore/buffered_write_syncer.go
+++ b/zapcore/buffered_write_syncer.go
@@ -179,6 +179,7 @@ func (s *BufferedWriteSyncer) Stop() (err error) {
 		<-s.done      // and wait until it has
 	}()
 
+	// Don't call Sync on consecutive Stops.
 	if !stopped {
 		err = s.Sync()
 	}

--- a/zapcore/buffered_write_syncer_test.go
+++ b/zapcore/buffered_write_syncer_test.go
@@ -53,6 +53,14 @@ func TestBufferWriter(t *testing.T) {
 		assert.Equal(t, "foo", buf.String(), "Unexpected log string")
 	})
 
+	t.Run("stop twice", func(t *testing.T) {
+		ws := &BufferedWriteSyncer{WS: &ztest.FailWriter{}}
+		_, err := ws.Write([]byte("foo"))
+		require.NoError(t, err, "Unexpected error writing to WriteSyncer.")
+		assert.Error(t, ws.Stop(), "Expected stop to fail.")
+		assert.NoError(t, ws.Stop(), "Expected stop to not fail.")
+	})
+
 	t.Run("wrap twice", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		bufsync := &BufferedWriteSyncer{WS: AddSync(buf)}


### PR DESCRIPTION
Add `stopOnce` field to `BufferedWriteSyncer` for Stop method called exactly once.

benchmark results mostly no-op:

```
name                                           old time/op    new time/op    delta
BufferedWriteSyncer/write_file_with_buffer-20     137ns ± 1%     139ns ± 2%    ~     (p=0.082 n=5+6)
MultiWriteSyncer/2_discarder-20                  8.05ns ± 6%    7.93ns ± 2%    ~     (p=0.662 n=6+5)
MultiWriteSyncer/4_discarder-20                  9.15ns ± 4%    9.14ns ± 4%    ~     (p=1.000 n=5+5)
MultiWriteSyncer/4_discarder_with_buffer-20       131ns ± 2%     130ns ± 0%    ~     (p=0.370 n=6+6)
WriteSyncer/write_file_with_no_buffer-20         4.36µs ± 1%    4.24µs ± 2%  -2.96%  (p=0.004 n=5+6)
ZapConsole-20                                     787ns ± 1%     800ns ± 2%    ~     (p=0.052 n=5+6)
JSONLogMarshalerFunc-20                           738ns ± 1%     737ns ± 0%    ~     (p=0.970 n=6+6)
ZapJSON-20                                        586ns ± 4%     582ns ± 3%    ~     (p=0.818 n=6+6)
StandardJSON-20                                   991ns ± 9%     977ns ± 2%    ~     (p=0.892 n=6+5)
Sampler_Check/7_keys-20                          8.58ns ± 3%    8.49ns ± 2%    ~     (p=0.485 n=6+6)
Sampler_Check/50_keys-20                         8.18ns ± 1%    8.20ns ± 1%    ~     (p=0.690 n=5+5)
Sampler_Check/100_keys-20                        8.02ns ± 4%    8.02ns ± 2%    ~     (p=0.589 n=6+6)
Sampler_CheckWithHook/7_keys-20                  23.4ns ± 2%    23.2ns ± 2%    ~     (p=0.370 n=6+6)
Sampler_CheckWithHook/50_keys-20                 24.3ns ± 3%    24.8ns ± 7%    ~     (p=0.732 n=6+6)
Sampler_CheckWithHook/100_keys-20                24.1ns ± 2%    24.2ns ± 1%    ~     (p=0.662 n=5+6)
TeeCheck-20                                       118ns ± 1%     120ns ± 5%    ~     (p=1.000 n=4+6)
[Geo mean]                                       77.7ns         77.6ns       -0.08%

name                                           old alloc/op   new alloc/op   delta
BufferedWriteSyncer/write_file_with_buffer-20     16.0B ± 0%     16.0B ± 0%    ~     (all equal)
MultiWriteSyncer/2_discarder-20                   16.0B ± 0%     16.0B ± 0%    ~     (all equal)
MultiWriteSyncer/4_discarder-20                   16.0B ± 0%     16.0B ± 0%    ~     (all equal)
MultiWriteSyncer/4_discarder_with_buffer-20       16.0B ± 0%     16.0B ± 0%    ~     (all equal)
WriteSyncer/write_file_with_no_buffer-20          16.0B ± 0%     16.0B ± 0%    ~     (all equal)
ZapConsole-20                                    1.36kB ± 0%    1.36kB ± 0%    ~     (all equal)
JSONLogMarshalerFunc-20                          1.31kB ± 0%    1.31kB ± 0%    ~     (all equal)
ZapJSON-20                                       1.25kB ± 0%    1.25kB ± 0%    ~     (all equal)
StandardJSON-20                                  1.45kB ± 0%    1.45kB ± 0%    ~     (all equal)
Sampler_Check/7_keys-20                           0.00B          0.00B         ~     (all equal)
Sampler_Check/50_keys-20                          0.00B          0.00B         ~     (all equal)
Sampler_Check/100_keys-20                         0.00B          0.00B         ~     (all equal)
Sampler_CheckWithHook/7_keys-20                   0.00B          0.00B         ~     (all equal)
Sampler_CheckWithHook/50_keys-20                  0.00B          0.00B         ~     (all equal)
Sampler_CheckWithHook/100_keys-20                 0.00B          0.00B         ~     (all equal)
TeeCheck-20                                       64.0B ± 0%     64.0B ± 0%    ~     (all equal)
[Geo mean]                                         108B           108B       +0.00%

name                                           old allocs/op  new allocs/op  delta
BufferedWriteSyncer/write_file_with_buffer-20      1.00 ± 0%      1.00 ± 0%    ~     (all equal)
MultiWriteSyncer/2_discarder-20                    1.00 ± 0%      1.00 ± 0%    ~     (all equal)
MultiWriteSyncer/4_discarder-20                    1.00 ± 0%      1.00 ± 0%    ~     (all equal)
MultiWriteSyncer/4_discarder_with_buffer-20        1.00 ± 0%      1.00 ± 0%    ~     (all equal)
WriteSyncer/write_file_with_no_buffer-20           1.00 ± 0%      1.00 ± 0%    ~     (all equal)
ZapConsole-20                                      7.00 ± 0%      7.00 ± 0%    ~     (all equal)
JSONLogMarshalerFunc-20                            5.00 ± 0%      5.00 ± 0%    ~     (all equal)
ZapJSON-20                                         3.00 ± 0%      3.00 ± 0%    ~     (all equal)
StandardJSON-20                                    27.0 ± 0%      27.0 ± 0%    ~     (all equal)
Sampler_Check/7_keys-20                            0.00           0.00         ~     (all equal)
Sampler_Check/50_keys-20                           0.00           0.00         ~     (all equal)
Sampler_Check/100_keys-20                          0.00           0.00         ~     (all equal)
Sampler_CheckWithHook/7_keys-20                    0.00           0.00         ~     (all equal)
Sampler_CheckWithHook/50_keys-20                   0.00           0.00         ~     (all equal)
Sampler_CheckWithHook/100_keys-20                  0.00           0.00         ~     (all equal)
TeeCheck-20                                        1.00 ± 0%      1.00 ± 0%    ~     (all equal)
[Geo mean]                                         2.21           2.21       +0.00%
```