### PR TITLE
Discard counters for out-of-bounds levels

### DIFF
--- a/zapcore/sampler.go
+++ b/zapcore/sampler.go
@@ -197,12 +197,14 @@ func (s *sampler) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
 		return ce
 	}
 
-	counter := s.counts.get(ent.Level, ent.Message)
-	n := counter.IncCheckReset(ent.Time, s.tick)
-	if n > s.first && (n-s.first)%s.thereafter != 0 {
-		s.hook(ent, LogDropped)
-		return ce
+	if ent.Level >= _minLevel && ent.Level <= _maxLevel {
+		counter := s.counts.get(ent.Level, ent.Message)
+		n := counter.IncCheckReset(ent.Time, s.tick)
+		if n > s.first && (n-s.first)%s.thereafter != 0 {
+			s.hook(ent, LogDropped)
+			return ce
+		}
+		s.hook(ent, LogSampled)
 	}
-	s.hook(ent, LogSampled)
 	return s.Core.Check(ent, ce)
 }

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -225,8 +225,22 @@ func TestSamplerRaces(t *testing.T) {
 	wg.Wait()
 }
 
-func TestSamplerBounds(t *testing.T) {
-	// Prove that out-of-bounds levels don't crash.
-	sampler, _ := fakeSampler(DebugLevel-1, time.Minute, 2, 3)
-	writeSequence(sampler, 1, DebugLevel-1)
+func TestSamplerUnknownLevels(t *testing.T) {
+	// Prove that out-of-bounds levels don't panic.
+	unknownLevels := []Level{
+		DebugLevel - 1,
+		FatalLevel + 1,
+	}
+
+	for _, lvl := range unknownLevels {
+		t.Run(lvl.String(), func(t *testing.T) {
+			sampler, logs := fakeSampler(lvl, time.Minute, 2, 3)
+			for i := 1; i < 10; i++ {
+				writeSequence(sampler, i, lvl)
+			}
+
+			// Expect no sampling for unknown levels.
+			assertSequence(t, logs.TakeAll(), lvl, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+		})
+	}
 }

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -224,3 +224,9 @@ func TestSamplerRaces(t *testing.T) {
 	close(start)
 	wg.Wait()
 }
+
+func TestSamplerBounds(t *testing.T) {
+	// Prove that out-of-bounds levels don't crash.
+	sampler, _ := fakeSampler(DebugLevel-1, time.Minute, 2, 3)
+	writeSequence(sampler, 1, DebugLevel-1)
+}


### PR DESCRIPTION
Previously this just crashed.

Fixes #972 