### PR TITLE
Added support for console encoder to configure whether it should json escape strings

### DIFF
--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -333,6 +333,8 @@ type EncoderConfig struct {
 	// Configures the field separator used by the console encoder. Defaults
 	// to tab.
 	ConsoleSeparator string `json:"consoleSeparator" yaml:"consoleSeparator"`
+	// Sets whether the console encoder will ignore json escaped strings.
+	ConsoleIgnoreJSONEscapes bool `json:"consoleIgnoreJSONEscapes" yaml:"consoleIgnoreJSONEscapes"`
 }
 
 // ObjectEncoder is a strongly-typed, encoding-agnostic interface for adding a


### PR DESCRIPTION
Allowing console encoders to avoid json escaping strings allows an easy way for the default formatting to provide more legible error output.