### PR TITLE
Added SkipLineEnding to zapcore.EncoderConfig

### DIFF
--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -125,13 +125,7 @@ func (c consoleEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 		line.AppendString(ent.Stack)
 	}
 
-	if !c.SkipLineEnding {
-		if c.LineEnding != "" {
-			line.AppendString(c.LineEnding)
-		} else {
-			line.AppendString(DefaultLineEnding)
-		}
-	}
+	line.AppendString(c.LineEnding)
 	return line, nil
 }
 

--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -125,10 +125,12 @@ func (c consoleEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 		line.AppendString(ent.Stack)
 	}
 
-	if c.LineEnding != "" {
-		line.AppendString(c.LineEnding)
-	} else {
-		line.AppendString(DefaultLineEnding)
+	if !c.SkipLineEnding {
+		if c.LineEnding != "" {
+			line.AppendString(c.LineEnding)
+		} else {
+			line.AppendString(DefaultLineEnding)
+		}
 	}
 	return line, nil
 }

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -312,14 +312,15 @@ func (e *NameEncoder) UnmarshalText(text []byte) error {
 type EncoderConfig struct {
 	// Set the keys used for each log entry. If any key is empty, that portion
 	// of the entry is omitted.
-	MessageKey    string `json:"messageKey" yaml:"messageKey"`
-	LevelKey      string `json:"levelKey" yaml:"levelKey"`
-	TimeKey       string `json:"timeKey" yaml:"timeKey"`
-	NameKey       string `json:"nameKey" yaml:"nameKey"`
-	CallerKey     string `json:"callerKey" yaml:"callerKey"`
-	FunctionKey   string `json:"functionKey" yaml:"functionKey"`
-	StacktraceKey string `json:"stacktraceKey" yaml:"stacktraceKey"`
-	LineEnding    string `json:"lineEnding" yaml:"lineEnding"`
+	MessageKey     string `json:"messageKey" yaml:"messageKey"`
+	LevelKey       string `json:"levelKey" yaml:"levelKey"`
+	TimeKey        string `json:"timeKey" yaml:"timeKey"`
+	NameKey        string `json:"nameKey" yaml:"nameKey"`
+	CallerKey      string `json:"callerKey" yaml:"callerKey"`
+	FunctionKey    string `json:"functionKey" yaml:"functionKey"`
+	StacktraceKey  string `json:"stacktraceKey" yaml:"stacktraceKey"`
+	SkipLineEnding bool   `json:"skipLineEnding" yaml:"skipLineEnding"`
+	LineEnding     string `json:"lineEnding" yaml:"lineEnding"`
 	// Configure the primitive representations of common complex types. For
 	// example, some users may want all time.Times serialized as floating-point
 	// seconds since epoch, while others may prefer ISO8601 strings.

--- a/zapcore/encoder_test.go
+++ b/zapcore/encoder_test.go
@@ -115,6 +115,26 @@ func TestEncoderConfiguration(t *testing.T) {
 			expectedConsole: "0\tinfo\tmain\tfoo.go:42\tfoo.Foo\thello\nfake-stack\n",
 		},
 		{
+			desc: "skip line ending if SkipLineEnding is 'true'",
+			cfg: EncoderConfig{
+				LevelKey:       "L",
+				TimeKey:        "T",
+				MessageKey:     "M",
+				NameKey:        "N",
+				CallerKey:      "C",
+				FunctionKey:    "F",
+				StacktraceKey:  "S",
+				LineEnding:     base.LineEnding,
+				SkipLineEnding: true,
+				EncodeTime:     base.EncodeTime,
+				EncodeDuration: base.EncodeDuration,
+				EncodeLevel:    base.EncodeLevel,
+				EncodeCaller:   base.EncodeCaller,
+			},
+			expectedJSON:    `{"L":"info","T":0,"N":"main","C":"foo.go:42","F":"foo.Foo","M":"hello","S":"fake-stack"}`,
+			expectedConsole: "0\tinfo\tmain\tfoo.go:42\tfoo.Foo\thello\nfake-stack",
+		},
+		{
 			desc: "skip level if LevelKey is omitted",
 			cfg: EncoderConfig{
 				LevelKey:       OmitKey,

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -82,6 +82,12 @@ func NewJSONEncoder(cfg EncoderConfig) Encoder {
 }
 
 func newJSONEncoder(cfg EncoderConfig, spaced bool) *jsonEncoder {
+	if cfg.SkipLineEnding {
+		cfg.LineEnding = ""
+	} else if cfg.LineEnding == "" {
+		cfg.LineEnding = DefaultLineEnding
+	}
+
 	return &jsonEncoder{
 		EncoderConfig: &cfg,
 		buf:           bufferpool.Get(),
@@ -396,13 +402,7 @@ func (enc *jsonEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 		final.AddString(final.StacktraceKey, ent.Stack)
 	}
 	final.buf.AppendByte('}')
-	if !final.SkipLineEnding {
-		if final.LineEnding != "" {
-			final.buf.AppendString(final.LineEnding)
-		} else {
-			final.buf.AppendString(DefaultLineEnding)
-		}
-	}
+	final.buf.AppendString(final.LineEnding)
 
 	ret := final.buf
 	putJSONEncoder(final)

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -396,10 +396,12 @@ func (enc *jsonEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 		final.AddString(final.StacktraceKey, ent.Stack)
 	}
 	final.buf.AppendByte('}')
-	if final.LineEnding != "" {
-		final.buf.AppendString(final.LineEnding)
-	} else {
-		final.buf.AppendString(DefaultLineEnding)
+	if !final.SkipLineEnding {
+		if final.LineEnding != "" {
+			final.buf.AppendString(final.LineEnding)
+		} else {
+			final.buf.AppendString(DefaultLineEnding)
+		}
 	}
 
 	ret := final.buf


### PR DESCRIPTION
Setting`config.EncoderConfig.SkipLineEnding = true` avoids adding any further symbol to the end of the line.

My use-case is the one of a CGO library internally using zap and redirecting the logs to a custom C/C++ function. The calling function expects a string as output and does not expect a newline, or any other symbol, added.