### PR TITLE
CI: Test with Go 1.16, 1.17 on Windows and Linux

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,13 +10,16 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ["1.15.x", "1.16.x"]
+        os: ["ubuntu-latest", "windows-latest"]
+        go: ["1.16.x", "1.17.x"]
         include:
-        - go: 1.16.x
+        - go: 1.17.x
+          os: ubuntu-latest
           latest: true
+          # Lint only on Ubuntu with the latest Go.
 
     steps:
     - name: Setup Go


### PR DESCRIPTION
Update the GitHub workflow configuration to test on both, Linux and
Windows with the latest releases of Go.
