### PR TITLE
Correct complex encoding in json encoder (#995)

### DIFF
--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -228,7 +228,11 @@ func (enc *jsonEncoder) AppendComplex128(val complex128) {
 	// Because we're always in a quoted string, we can use strconv without
 	// special-casing NaN and +/-Inf.
 	enc.buf.AppendFloat(r, 64)
-	enc.buf.AppendByte('+')
+	// If imaginary part is less than 0, minus (-) sign is added by default
+	// by AppendFloat.
+	if i >= 0 {
+		enc.buf.AppendByte('+')
+	}
 	enc.buf.AppendFloat(i, 64)
 	enc.buf.AppendByte('i')
 	enc.buf.AppendByte('"')

--- a/zapcore/json_encoder_test.go
+++ b/zapcore/json_encoder_test.go
@@ -64,6 +64,7 @@ func TestJSONEncodeEntry(t *testing.T) {
 				"so": "passes",
 				"answer": 42,
 				"common_pie": 3.14,
+				"complex_value": "3.14-2.71i",
 				"null_value": null,
 				"array_with_null_elements": [{}, null, null, 2],
 				"such": {
@@ -86,6 +87,7 @@ func TestJSONEncodeEntry(t *testing.T) {
 				zap.String("so", "passes"),
 				zap.Int("answer", 42),
 				zap.Float64("common_pie", 3.14),
+				zap.Complex128("complex_value", 3.14-2.71i),
 				// Cover special-cased handling of nil in AddReflect() and
 				// AppendReflect(). Note that for the latter, we explicitly test
 				// correct results for both the nil static interface{} value


### PR DESCRIPTION
This PR fixes the encoding of complex number by zap's complex encoder. It also adds the necessary test to ensure the sanity of the change.

Fixes: #995 