### PR TITLE
CI: Test with Go 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.15.x", "1.16.x"]
+        go: ["1.15.x", "1.16.x", "1.17.x"]
         include:
-        - go: 1.16.x
+        - go: 1.17.x
           latest: true
 
     steps:

--- a/global_go112.go
+++ b/global_go112.go
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 // See #682 for more information.
+//go:build go1.12
 // +build go1.12
 
 package zap

--- a/global_prego112.go
+++ b/global_prego112.go
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 // See #682 for more information.
+//go:build !go1.12
 // +build !go1.12
 
 package zap

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
Add Go 1.17 to the list of versions we test with. `gofmt` all files to
add the new `//go:build` directives meant to replace `// +build`.

This supersedes the Go version upgrade in #999. That PR will be narrowed
down just to Windows support.
