### PR TITLE
zapcore: Unflake TestSamplerConcurrent

### DIFF
--- a/internal/ztest/clock.go
+++ b/internal/ztest/clock.go
@@ -18,27 +18,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package zapcore
+package ztest
 
 import (
-	"testing"
 	"time"
 
-	"go.uber.org/zap/internal/ztest"
+	"github.com/benbjohnson/clock"
 )
 
-// Verify that the mock clock satisfies the Clock interface.
-var _ Clock = (*ztest.MockClock)(nil)
+// MockClock provides control over the time.
+type MockClock struct{ m *clock.Mock }
 
-func TestSystemClock_NewTicker(t *testing.T) {
-	want := 3
+// NewMockClock builds a new mock clock that provides control of time.
+func NewMockClock() *MockClock {
+	return &MockClock{clock.NewMock()}
+}
 
-	var n int
-	timer := DefaultClock.NewTicker(time.Millisecond)
-	for range timer.C {
-		n++
-		if n == want {
-			return
-		}
-	}
+// Now reports the current time.
+func (c *MockClock) Now() time.Time {
+	return c.m.Now()
+}
+
+// NewTicker returns a time.Ticker that ticks at the specified frequency.
+func (c *MockClock) NewTicker(d time.Duration) *time.Ticker {
+	return &time.Ticker{C: c.m.Ticker(d).C}
+}
+
+// Add progresses time by the given duration.
+func (c *MockClock) Add(d time.Duration) {
+	c.m.Add(d)
 }

--- a/zapcore/buffered_write_syncer_test.go
+++ b/zapcore/buffered_write_syncer_test.go
@@ -107,7 +107,7 @@ func TestBufferWriter(t *testing.T) {
 
 	t.Run("flush timer", func(t *testing.T) {
 		buf := &bytes.Buffer{}
-		clock := newControlledClock()
+		clock := ztest.NewMockClock()
 		ws := &BufferedWriteSyncer{
 			WS:            AddSync(buf),
 			Size:          6,

--- a/zapcore/clock.go
+++ b/zapcore/clock.go
@@ -20,9 +20,7 @@
 
 package zapcore
 
-import (
-	"time"
-)
+import "time"
 
 // DefaultClock is the default clock used by Zap in operations that require
 // time. This clock uses the system clock for all operations.


### PR DESCRIPTION
The TestSamplerConcurrent test frequently fails with the following error
in CI:

    --- FAIL: TestSamplerConcurrent (0.25s)
        sampler_test.go:198:
        	    Error Trace:	sampler_test.go:198
        	    Error:      	Max difference between 1250 and 1004 allowed is 125, but difference was 246
        	    Test:       	TestSamplerConcurrent
        	    Messages:   	Unexpected number of logs
    FAIL

The test is intended to verify that
despite an onsalught of messages from multiple goroutines,
we only allow at most `logsPerTick` messages per `tick`.

This was accompilshed by spin-looping 10 goroutines for `numTicks`,
each logging one of `numMessages` different messages,
and then verifying the final log count.

The source of flakiness here was the non-determinism in
how far a goroutine would get in logging enough messages such that
the sampler would be engaged.

In #948, we added a `zapcore.Clock` interface with a ticker and
a mock implementation.
Move that to `ztest` for use here.

To unflake the test, use the mock clock to control time and
for each goroutine, log `logsPerTick*2` messages `numTicks` times.
This gives us,

    for numGoroutines (10)
        for numTicks (25)
            log logsPerTick * 2 (50) messages

We end up attempting to log a total of,

    (numGoroutines * numTicks * logsPerTick * 2) messages
    = (10 * 25 * 50) messages
    = 12500 messages

Of these, the following should be sampled:

    numMessages * numTicks * logsPerTick
    = 5 * 10 * 25
    = 1250

Everything else should be dropped.

For extra confidence, use a SamplerHook (added in #813) to verify that
the number of sampled and dropped messages meet expectations.

Refs GO-873
