### PR TITLE
feat: add config  option handler

### DIFF
--- a/config.go
+++ b/config.go
@@ -117,8 +117,8 @@ func NewProductionEncoderConfig() zapcore.EncoderConfig {
 //
 // It uses a JSON encoder, writes to standard error, and enables sampling.
 // Stacktraces are automatically included on logs of ErrorLevel and above.
-func NewProductionConfig() Config {
-	return Config{
+func NewProductionConfig(opts ...ConfOptionHandler) Config {
+	c := Config{
 		Level:       NewAtomicLevelAt(InfoLevel),
 		Development: false,
 		Sampling: &SamplingConfig{
@@ -130,6 +130,12 @@ func NewProductionConfig() Config {
 		OutputPaths:      []string{"stderr"},
 		ErrorOutputPaths: []string{"stderr"},
 	}
+	// option
+	for _, opt := range opts {
+		opt(&c)
+	}
+	return c
+
 }
 
 // NewDevelopmentEncoderConfig returns an opinionated EncoderConfig for
@@ -158,8 +164,8 @@ func NewDevelopmentEncoderConfig() zapcore.EncoderConfig {
 // It enables development mode (which makes DPanicLevel logs panic), uses a
 // console encoder, writes to standard error, and disables sampling.
 // Stacktraces are automatically included on logs of WarnLevel and above.
-func NewDevelopmentConfig() Config {
-	return Config{
+func NewDevelopmentConfig(opts ...ConfOptionHandler) Config {
+	c := Config{
 		Level:            NewAtomicLevelAt(DebugLevel),
 		Development:      true,
 		Encoding:         "console",
@@ -167,6 +173,11 @@ func NewDevelopmentConfig() Config {
 		OutputPaths:      []string{"stderr"},
 		ErrorOutputPaths: []string{"stderr"},
 	}
+	// option
+	for _, opt := range opts {
+		opt(&c)
+	}
+	return c
 }
 
 // Build constructs a logger from the Config and Options.

--- a/config_options.go
+++ b/config_options.go
@@ -1,0 +1,10 @@
+package zap
+
+type ConfOptionHandler func(*Config)
+
+// WithConfEncoding configures encoding of  the config  to  the given  one.
+func WithConfEncoding(encoding string) ConfOptionHandler {
+	return func(c *Config) {
+		c.Encoding = encoding
+	}
+}

--- a/config_options.go
+++ b/config_options.go
@@ -1,8 +1,28 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package zap
 
 type ConfOptionHandler func(*Config)
 
-// WithConfEncoding configures encoding of  the config  to  the given  one.
+// WithConfEncoding configures encoding of the config to the given one.
 func WithConfEncoding(encoding string) ConfOptionHandler {
 	return func(c *Config) {
 		c.Encoding = encoding


### PR DESCRIPTION
during my work. I  use  `Development` mode  ( zap.NewDevelopmentConfig )  with  `Encoding = 'console'` and `EncoderConfig = XXXXEncoderConfig`,so i  have to change code like it
```
cnf := NewDevelopmentConfig()
cnf.Encoding = "console"
cnf.EncoderConfig = zapcore.EncoderConfig{ 
}
```
or  i  new a config  with  many  attributes to be assigned like the below:
```
c = &Config{
			Level:             AtomicLevel{},
			Development:       false,
			DisableCaller:     false,
			DisableStacktrace: false,
			Sampling:          &SamplingConfig{},
			Encoding:          encoding,
			EncoderConfig:     zapcore.EncoderConfig{
				MessageKey:    "",
				LevelKey:      "",
				TimeKey:       "",
				NameKey:       "",
				CallerKey:     "",
				FunctionKey:   "",
				StacktraceKey: "",
				LineEnding:    "",
				EncodeLevel: func( zapcore.Level,  zapcore.PrimitiveArrayEncoder) {
				},
				EncodeTime: func( time.Time,  zapcore.PrimitiveArrayEncoder) {
				},
				EncodeDuration: func( time.Duration,  zapcore.PrimitiveArrayEncoder) {
				},
				EncodeCaller: func( zapcore.EntryCaller,  zapcore.PrimitiveArrayEncoder) {
				},
				EncodeName: func( string,  zapcore.PrimitiveArrayEncoder) {
				},
				ConsoleSeparator: "",
			},
			OutputPaths:       []string{},
			ErrorOutputPaths:  []string{},
			InitialFields:     map[string]interface{}{},
		}

```
i dont think it is so graceful. 
why not  support   `option`  to change  attributes which users want .


