### PR TITLE
Add TraceLevel at -2

### DIFF
--- a/level.go
+++ b/level.go
@@ -26,6 +26,10 @@ import (
 )
 
 const (
+	// TraceLevel logs are for copious amounts of output i.e. when you
+	// select data from a dbms and you want to output every single record.
+	// This is usualy only activated on demand even in development.
+	TraceLevel = zapcore.TraceLevel
 	// DebugLevel logs are typically voluminous, and are usually disabled in
 	// production.
 	DebugLevel = zapcore.DebugLevel
@@ -108,8 +112,8 @@ func (lvl AtomicLevel) String() string {
 }
 
 // UnmarshalText unmarshals the text to an AtomicLevel. It uses the same text
-// representations as the static zapcore.Levels ("debug", "info", "warn",
-// "error", "dpanic", "panic", and "fatal").
+// representations as the static zapcore.Levels ("trace", "debug",
+// "info", "warn", "error", "dpanic", "panic", and "fatal").
 func (lvl *AtomicLevel) UnmarshalText(text []byte) error {
 	if lvl.l == nil {
 		lvl.l = &atomic.Int32{}
@@ -125,8 +129,8 @@ func (lvl *AtomicLevel) UnmarshalText(text []byte) error {
 }
 
 // MarshalText marshals the AtomicLevel to a byte slice. It uses the same
-// text representation as the static zapcore.Levels ("debug", "info", "warn",
-// "error", "dpanic", "panic", and "fatal").
+// representations as the static zapcore.Levels ("trace", "debug",
+// "info", "warn", "error", "dpanic", "panic", and "fatal").
 func (lvl AtomicLevel) MarshalText() (text []byte, err error) {
 	return lvl.Level().MarshalText()
 }

--- a/level_test.go
+++ b/level_test.go
@@ -35,6 +35,7 @@ func TestLevelEnablerFunc(t *testing.T) {
 		level   zapcore.Level
 		enabled bool
 	}{
+		{TraceLevel, false},
 		{DebugLevel, false},
 		{InfoLevel, true},
 		{WarnLevel, false},
@@ -81,6 +82,7 @@ func TestAtomicLevelText(t *testing.T) {
 		expect zapcore.Level
 		err    bool
 	}{
+		{"trace", TraceLevel, false},
 		{"debug", DebugLevel, false},
 		{"info", InfoLevel, false},
 		{"", InfoLevel, false},
@@ -91,7 +93,6 @@ func TestAtomicLevelText(t *testing.T) {
 		{"fatal", FatalLevel, false},
 		{"foobar", InfoLevel, true},
 	}
-
 	for _, tt := range tests {
 		var lvl AtomicLevel
 		// Test both initial unmarshaling and overwriting existing value.

--- a/logger.go
+++ b/logger.go
@@ -177,6 +177,14 @@ func (log *Logger) Check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 	return log.check(lvl, msg)
 }
 
+// Trace logs a message at TraceLevel. The message includes any fields passed
+// at the log site, as well as any fields accumulated on the logger.
+func (log *Logger) Trace(msg string, fields ...Field) {
+	if ce := log.check(TraceLevel, msg); ce != nil {
+		ce.Write(fields...)
+	}
+}
+
 // Debug logs a message at DebugLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
 func (log *Logger) Debug(msg string, fields ...Field) {

--- a/sugar.go
+++ b/sugar.go
@@ -92,6 +92,11 @@ func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
 	return &SugaredLogger{base: s.base.With(s.sweetenFields(args)...)}
 }
 
+// Trace uses fmt.Sprint to construct and log a message.
+func (s *SugaredLogger) Trace(args ...interface{}) {
+	s.log(TraceLevel, "", args, nil)
+}
+
 // Debug uses fmt.Sprint to construct and log a message.
 func (s *SugaredLogger) Debug(args ...interface{}) {
 	s.log(DebugLevel, "", args, nil)
@@ -128,6 +133,11 @@ func (s *SugaredLogger) Fatal(args ...interface{}) {
 	s.log(FatalLevel, "", args, nil)
 }
 
+// Tracef uses fmt.Sprintf to log a templated message.
+func (s *SugaredLogger) Tracef(template string, args ...interface{}) {
+	s.log(TraceLevel, template, args, nil)
+}
+
 // Debugf uses fmt.Sprintf to log a templated message.
 func (s *SugaredLogger) Debugf(template string, args ...interface{}) {
 	s.log(DebugLevel, template, args, nil)
@@ -162,6 +172,13 @@ func (s *SugaredLogger) Panicf(template string, args ...interface{}) {
 // Fatalf uses fmt.Sprintf to log a templated message, then calls os.Exit.
 func (s *SugaredLogger) Fatalf(template string, args ...interface{}) {
 	s.log(FatalLevel, template, args, nil)
+}
+
+// Tracew logs a message with some additional context. The variadic key-value
+// pairs are treated as they are in With.
+// Trace should only be switched on in certain cases of bug hunting
+func (s *SugaredLogger) Tracew(msg string, keysAndValues ...interface{}) {
+	s.log(TraceLevel, msg, nil, keysAndValues)
 }
 
 // Debugw logs a message with some additional context. The variadic key-value

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -174,15 +174,23 @@ func TestSugarStructuredLogging(t *testing.T) {
 	expectedFields := []Field{String("foo", "bar"), Bool("baz", false)}
 
 	for _, tt := range tests {
-		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+		withSugar(t, TraceLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+			logger.With(context...).Tracew(tt.msg, extra...)
 			logger.With(context...).Debugw(tt.msg, extra...)
 			logger.With(context...).Infow(tt.msg, extra...)
 			logger.With(context...).Warnw(tt.msg, extra...)
 			logger.With(context...).Errorw(tt.msg, extra...)
 			logger.With(context...).DPanicw(tt.msg, extra...)
 
-			expected := make([]observer.LoggedEntry, 5)
-			for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
+			expected := make([]observer.LoggedEntry, 6)
+			for i, lvl := range []zapcore.Level{
+				TraceLevel,
+				DebugLevel,
+				InfoLevel,
+				WarnLevel,
+				ErrorLevel,
+				DPanicLevel,
+			} {
 				expected[i] = observer.LoggedEntry{
 					Entry:   zapcore.Entry{Message: tt.expectMsg, Level: lvl},
 					Context: expectedFields,
@@ -207,6 +215,7 @@ func TestSugarConcatenatingLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+			logger.With(context...).Trace(tt.args...)
 			logger.With(context...).Debug(tt.args...)
 			logger.With(context...).Info(tt.args...)
 			logger.With(context...).Warn(tt.args...)
@@ -243,6 +252,7 @@ func TestSugarTemplatedLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+			logger.With(context...).Tracef(tt.format, tt.args...)
 			logger.With(context...).Debugf(tt.format, tt.args...)
 			logger.With(context...).Infof(tt.format, tt.args...)
 			logger.With(context...).Warnf(tt.format, tt.args...)

--- a/zapcore/level_strings.go
+++ b/zapcore/level_strings.go
@@ -24,6 +24,7 @@ import "go.uber.org/zap/internal/color"
 
 var (
 	_levelToColor = map[Level]color.Color{
+		TraceLevel:  color.White,
 		DebugLevel:  color.Magenta,
 		InfoLevel:   color.Blue,
 		WarnLevel:   color.Yellow,

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -31,6 +31,7 @@ import (
 
 func TestLevelString(t *testing.T) {
 	tests := map[Level]string{
+		TraceLevel:  "trace",
 		DebugLevel:  "debug",
 		InfoLevel:   "info",
 		WarnLevel:   "warn",
@@ -52,7 +53,7 @@ func TestLevelText(t *testing.T) {
 		text  string
 		level Level
 	}{
-		{"debug", DebugLevel},
+		{"trace", TraceLevel},
 		{"info", InfoLevel},
 		{"", InfoLevel}, // make the zero value useful
 		{"warn", WarnLevel},
@@ -81,6 +82,7 @@ func TestCapitalLevelsParse(t *testing.T) {
 		text  string
 		level Level
 	}{
+		{"TRACE", TraceLevel},
 		{"DEBUG", DebugLevel},
 		{"INFO", InfoLevel},
 		{"WARN", WarnLevel},
@@ -103,6 +105,7 @@ func TestWeirdLevelsParse(t *testing.T) {
 		level Level
 	}{
 		// I guess...
+		{"Trace", TraceLevel},
 		{"Debug", DebugLevel},
 		{"Info", InfoLevel},
 		{"Warn", WarnLevel},
@@ -112,6 +115,7 @@ func TestWeirdLevelsParse(t *testing.T) {
 		{"Fatal", FatalLevel},
 
 		// What even is...
+		{"TrAcE", TraceLevel},
 		{"DeBuG", DebugLevel},
 		{"InFo", InfoLevel},
 		{"WaRn", WarnLevel},
@@ -159,7 +163,16 @@ func TestLevelAsFlagValue(t *testing.T) {
 	fs.SetOutput(&buf)
 	fs.Var(&lvl, "level", "log level")
 
-	for _, expected := range []Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel, PanicLevel, FatalLevel} {
+	for _, expected := range []Level{
+		TraceLevel,
+		DebugLevel,
+		InfoLevel,
+		WarnLevel,
+		ErrorLevel,
+		DPanicLevel,
+		PanicLevel,
+		FatalLevel,
+	} {
 		assert.NoError(t, fs.Parse([]string{"-level", expected.String()}))
 		assert.Equal(t, expected, lvl, "Unexpected level after parsing flag.")
 		assert.Equal(t, expected, lvl.Get(), "Unexpected output using flag.Getter API.")

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -259,7 +259,7 @@ func TestSamplerRaces(t *testing.T) {
 func TestSamplerUnknownLevels(t *testing.T) {
 	// Prove that out-of-bounds levels don't panic.
 	unknownLevels := []Level{
-		DebugLevel - 1,
+		TraceLevel - 1,
 		FatalLevel + 1,
 	}
 


### PR DESCRIPTION
This adds a new loglevel (default switched off). The reasoning is:
  - Syslog does it
  - It is useful for i.e. outputting SQL results you would normally not
  give a rats ass about.