### PR TITLE
Unflake BenchmarkSampler_CheckWithHook

### DIFF
--- a/zapcore/sampler_bench_test.go
+++ b/zapcore/sampler_bench_test.go
@@ -277,7 +277,6 @@ func BenchmarkSampler_CheckWithHook(b *testing.B) {
 			// We expect to see 1000 dropped messages for every sampled per settings,
 			// with a delta due to less 1000 messages getting dropped after initial one
 			// is sampled.
-			//assert.Less(b, abs(dropped.Load()-sampled.Load()*1000)/1000, int64(1000))
 			assert.Greater(b, dropped.Load()/1000, sampled.Load()-1000)
 			dropped.Store(0)
 			sampled.Store(0)

--- a/zapcore/sampler_bench_test.go
+++ b/zapcore/sampler_bench_test.go
@@ -274,10 +274,13 @@ func BenchmarkSampler_CheckWithHook(b *testing.B) {
 					}
 				}
 			})
+			// We expect to see 1000 dropped messages for every sampled per settings,
+			// with a delta due to less 1000 messages getting dropped after initial one
+			// is sampled.
+			//assert.Less(b, abs(dropped.Load()-sampled.Load()*1000)/1000, int64(1000))
+			assert.Greater(b, dropped.Load()/1000, sampled.Load()-1000)
+			dropped.Store(0)
+			sampled.Store(0)
 		})
 	}
-	// We expect to see 1000 dropped messages for every sampled per settings,
-	// with a delta due to less 1000 messages getting dropped after initial one
-	// is sampled.
-	assert.Greater(b, dropped.Load()/1000, sampled.Load()-1000)
 }


### PR DESCRIPTION
`BenchmarkSampler_CheckWithHook` was randomly failing esp. under load because under load, Zap sampler can end up dropping less than the expected amount (esp. with Hooks). Moreover, we were making a single comparison after all the benchmarks had run, which causes the time dilation effect to aggregate over all the tests, making it more likely to fail.

This changes the benchmark to compare the dropped and sampled ratio in between test runs and test the dropped/sampled ratio. The change was verified by running the benchmark 500 times on a MacBook Pro i7 model as well as devpod (96 core Linux) and confirming no failures happened. 

Fix #996 
Internal Ref: GO-858