### PR TITLE
Logging with context values

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -21,13 +21,13 @@
 package zap
 
 import (
+	"context"
 	"fmt"
+	"go.uber.org/zap/internal/bufferpool"
+	"go.uber.org/zap/zapcore"
 	"io/ioutil"
 	"os"
 	"strings"
-
-	"go.uber.org/zap/internal/bufferpool"
-	"go.uber.org/zap/zapcore"
 )
 
 // A Logger provides fast, leveled, structured logging. All methods are safe
@@ -52,6 +52,8 @@ type Logger struct {
 	callerSkip int
 
 	clock zapcore.Clock
+
+	contextFunc func(ctx context.Context) []Field
 }
 
 // New constructs a new Logger from the provided zapcore.Core and Options. If
@@ -242,6 +244,78 @@ func (log *Logger) Fatal(msg string, fields ...Field) {
 	}
 }
 
+// InfoCtx logs a message at InfoLevel. The message includes any request context's fields
+// and any fields passed at the log site, as well as any fields accumulated on the logger.
+func (log *Logger) InfoCtx(ctx context.Context, msg string, fields ...Field) {
+	if ce := log.check(InfoLevel, msg); ce != nil {
+		generatedFields := log.generateFields(ctx, fields...)
+		ce.Write(generatedFields...)
+	}
+}
+
+// WarnCtx logs a message at WarnLevel. The message includes any request context's fields
+// and any fields passed at the log site, as well as any fields accumulated on the logger.
+func (log *Logger) WarnCtx(ctx context.Context, msg string, fields ...Field) {
+	if ce := log.check(WarnLevel, msg); ce != nil {
+		generatedFields := log.generateFields(ctx, fields...)
+		ce.Write(generatedFields...)
+	}
+}
+
+// ErrorCtx logs a message at ErrorLevel. The message includes any request context's fields
+// and any fields passed at the log site, as well as any fields accumulated on the logger.
+func (log *Logger) ErrorCtx(ctx context.Context, msg string, fields ...Field) {
+	if ce := log.check(ErrorLevel, msg); ce != nil {
+		generatedFields := log.generateFields(ctx, fields...)
+		ce.Write(generatedFields...)
+	}
+}
+
+// DPanicCtx logs a message at DPanicLevel. The message includes any request context's fields
+// and any fields passed at the log site, as well as any fields accumulated on the logger.
+//
+// If the logger is in development mode, it then panics (DPanic means
+// "development panic"). This is useful for catching errors that are
+// recoverable, but shouldn't ever happen.
+func (log *Logger) DPanicCtx(ctx context.Context, msg string, fields ...Field) {
+	if ce := log.check(DPanicLevel, msg); ce != nil {
+		generatedFields := log.generateFields(ctx, fields...)
+		ce.Write(generatedFields...)
+	}
+}
+
+// PanicCtx logs a message at PanicLevel. The message includes any request context's fields
+// and any fields passed at the log site, as well as any fields accumulated on the logger.
+//
+// The logger then panics, even if logging at PanicLevel is disabled.
+func (log *Logger) PanicCtx(ctx context.Context, msg string, fields ...Field) {
+	if ce := log.check(PanicLevel, msg); ce != nil {
+		generatedFields := log.generateFields(ctx, fields...)
+		ce.Write(generatedFields...)
+	}
+}
+
+// FatalCtx logs a message at FatalLevel. The message includes any request context's fields
+// and fields passed at the log site, as well as any fields accumulated on the logger.
+//
+// The logger then calls os.Exit(1), even if logging at FatalLevel is
+// disabled.
+func (log *Logger) FatalCtx(ctx context.Context, msg string, fields ...Field) {
+	if ce := log.check(FatalLevel, msg); ce != nil {
+		generatedFields := log.generateFields(ctx, fields...)
+		ce.Write(generatedFields...)
+	}
+}
+
+// DebugCtx logs a message at DebugLevel. The message includes any request context's fields
+// and any fields passed at the log site, as well as any fields accumulated on the logger.
+func (log *Logger) DebugCtx(ctx context.Context, msg string, fields ...Field) {
+	if ce := log.check(DebugLevel, msg); ce != nil {
+		generatedFields := log.generateFields(ctx, fields...)
+		ce.Write(generatedFields...)
+	}
+}
+
 // Sync calls the underlying Core's Sync method, flushing any buffered log
 // entries. Applications should take care to call Sync before exiting.
 func (log *Logger) Sync() error {
@@ -360,4 +434,12 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 	}
 
 	return ce
+}
+
+func (log *Logger) generateFields(ctx context.Context, fields ...Field) []Field {
+	if ctx != nil && log.contextFunc != nil {
+		contextFields := log.contextFunc(ctx)
+		return append(contextFields, fields...)
+	}
+	return nil
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -597,6 +598,86 @@ func TestNopLogger(t *testing.T) {
 		assert.Panics(t, func() {
 			logger.Panic("great sadness")
 		}, "Nop logger should still cause panics.")
+	})
+}
+
+func TestRequestContext(t *testing.T) {
+	type key string
+
+	const (
+		CorrelationID key = "Correlation-ID"
+	)
+
+	t.Run("Context option use while logger create", func(t *testing.T) {
+		t.Run("Context is not nil", func(t *testing.T) {
+			requestContextOption := Context(func(ctx context.Context) []Field {
+				var fields []Field
+
+				if ctxRequestPath, ok := ctx.Value(CorrelationID).(string); ok {
+					fields = append(fields, String(string(CorrelationID), ctxRequestPath))
+				}
+
+				return fields
+			})
+			logger, _ := NewProduction(requestContextOption)
+
+			ctx := context.TODO()
+			ctx = context.WithValue(ctx, CorrelationID, "e9718aab-aa1a-4ad8-b1e6-690f6c43bd15")
+
+			logMessage := "Hello Zap Logger Community !!!"
+
+			logger.InfoCtx(ctx, logMessage)
+			logger.DebugCtx(ctx, logMessage)
+			logger.ErrorCtx(ctx, logMessage)
+			logger.WarnCtx(ctx, logMessage)
+			logger.DPanicCtx(ctx, logMessage)
+
+			assert.Panics(t, func() { logger.PanicCtx(ctx, logMessage) }, logMessage)
+			stub := exit.WithStub(func() { logger.FatalCtx(ctx, logMessage) })
+			assert.True(t, stub.Exited, "Expected calls to logger.Fatal to terminate process.")
+		})
+	})
+
+	t.Run("Context option not use while logger create", func(t *testing.T) {
+		t.Run("Context is not nil", func(t *testing.T) {
+			logger, _ := NewProduction()
+
+			ctx := context.TODO()
+			ctx = context.WithValue(ctx, CorrelationID, "e9718aab-aa1a-4ad8-b1e6-690f6c43bd15")
+
+			logMessage := "Hello Zap Logger Community !!!"
+
+			logger.InfoCtx(ctx, logMessage)
+			logger.DebugCtx(ctx, logMessage)
+			logger.ErrorCtx(ctx, logMessage)
+			logger.WarnCtx(ctx, logMessage)
+			logger.DPanicCtx(ctx, logMessage)
+
+			assert.Panics(t, func() { logger.PanicCtx(ctx, logMessage) }, logMessage)
+			stub := exit.WithStub(func() { logger.FatalCtx(ctx, logMessage) })
+			assert.True(t, stub.Exited, "Expected calls to logger.Fatal to terminate process.")
+		})
+	})
+
+	t.Run("Context option not use while logger create for development", func(t *testing.T) {
+		t.Run("Context is not nil", func(t *testing.T) {
+			logger, _ := NewDevelopment()
+
+			ctx := context.TODO()
+			ctx = context.WithValue(ctx, CorrelationID, "e9718aab-aa1a-4ad8-b1e6-690f6c43bd15")
+
+			logMessage := "Hello Zap Logger Community !!!"
+
+			logger.InfoCtx(ctx, logMessage)
+			logger.DebugCtx(ctx, logMessage)
+			logger.ErrorCtx(ctx, logMessage)
+			logger.WarnCtx(ctx, logMessage)
+
+			assert.Panics(t, func() { logger.PanicCtx(ctx, logMessage) }, logMessage)
+			assert.Panics(t, func() { logger.DPanicCtx(ctx, logMessage) }, logMessage)
+			stub := exit.WithStub(func() { logger.FatalCtx(ctx, logMessage) })
+			assert.True(t, stub.Exited, "Expected calls to logger.Fatal to terminate process.")
+		})
 	})
 }
 

--- a/options.go
+++ b/options.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"context"
 	"fmt"
 
 	"go.uber.org/zap/zapcore"
@@ -83,6 +84,15 @@ func ErrorOutput(w zapcore.WriteSyncer) Option {
 func Development() Option {
 	return optionFunc(func(log *Logger) {
 		log.development = true
+	})
+}
+
+// Context It is used to decide which of the values in the context will
+// be used as the base log field. It takes a function as a parameter and
+// this function does this job.
+func Context(contextFunc func(ctx context.Context) []Field) Option {
+	return optionFunc(func(log *Logger) {
+		log.contextFunc = contextFunc
 	})
 }
 


### PR DESCRIPTION
We want to use the values such as CorrelationId, RequestPath, etc. of each incoming request in web service projects, when we trigger log logEvent anywhere in the application. Because we need these values to observe in what case the log event is thrown. For this, we do not want to use zap.WithField in the middleware and create a new logger to use values such as CorrelationId, RequestPath etc. and move them within the application with the context. This both corrects the cost of creating a new instance and we will need to do reflection in the places we will use for the logger object we carry in the context.

1-) We can add the like following method in the options file.

```go
func Context(contextFunc func(ctx context.Context) []Field) Option {
	return optionFunc(func(log *Logger) {
		log.contextFunc = contextFunc
	})
}
```

2-) We should add contextFunc to logger file. This function will control how the values added to the context in the middleware are transformed.

```go
contextFunc func(ctx context.Context) []Field
```

Finally, we must create methods such as Info, Error, Warn, Panic etc. so that they can take context parameters.

For Example;

```go
func (log *Logger) InfoCtx(ctx context.Context, msg string, fields ...Field) {
	generatedFields := log.generateFields(ctx, fields...)
	log.Info(msg, generatedFields...)
}
```

```go
func (log *Logger) generateFields(ctx context.Context, fields ...Field) []Field {
	if ctx != nil && log.contextFunc != nil {
		contextFields := log.contextFunc(ctx)
		return append(contextFields, fields...)
	}
	return nil
}
```

Use Example;

```go
  ctx := context.TODO()
  ctx = context.WithValue(ctx, "Correlation-ID", "e9718aab-aa1a-4ad8-b1e6-690f6c43bd15")

  logger.InfoCtx(ctx, "Hello Zap Logger Community !!!")
```
Console Result;
```json
{"level":"info","ts":1633699393.396655,"caller":"zap/logger.go:252","msg":"Hello Zap Logger Community !!!","Correlation-ID":"e9718aab-aa1a-4ad8-b1e6-690f6c43bd15"}
```
It works very well. 🚀🚀

I'm waiting for a reply as soon as possible.