### PR TITLE
CI: Don't run benchmarks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,6 +47,3 @@ jobs:
 
     - name: Upload coverage to codecov.io
       uses: codecov/codecov-action@v1
-
-    - name: Benchmark
-      run: make bench


### PR DESCRIPTION
We don't need to run benchmarks in CI,
especially because it's difficult to get consistent numbers out of it.

We're experimenting with [Bencher](https://bencher.orijtech.com/) for
continuous benchmarking.
