### PR TITLE
Github Actions Tools Cache

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,7 +36,9 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Download Dependencies
-      run: go mod download
+      run: |
+        go mod download
+        cd tools && go mod download
 
     - name: Lint
       if: matrix.latest


### PR DESCRIPTION
It looks like the second module isn't caching.
If we download the tools mod it should work.