### PR TITLE
added missing modules download

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,9 @@ jobs:
     - name: Download Dependencies
       run: |
         go mod download
-        cd tools && go mod download
+        cd tools && go mod download && cd -
+        cd benchmarks && go mod download && cd -
+        cd zapgrpc/internal/test && go mod download && cd -
 
     - name: Lint
       if: matrix.latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,9 +38,9 @@ jobs:
     - name: Download Dependencies
       run: |
         go mod download
-        cd tools && go mod download && cd -
-        cd benchmarks && go mod download && cd -
-        cd zapgrpc/internal/test && go mod download && cd -
+        (cd tools && go mod download)
+        (cd benchmarks && go mod download)
+        (cd zapgrpc/internal/test && go mod download)
 
     - name: Lint
       if: matrix.latest


### PR DESCRIPTION
I missed two more modules in [PR-1043](https://github.com/uber-go/zap/pull/1043)
Now the action builds skipping the all downloads from those modules.