### PR TITLE
Release v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 1.20.0 (4 Jan 2021)
+## 1.20.0 (4 Jan 2022)
 
 Enhancements:
 * [#989][]: Add `EncoderConfig.SkipLineEnding` flag to disable adding newline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,32 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 1.20.0 (4 Jan 2021)
 
 Enhancements:
-* [#989][]: `zapcore.EncoderConfig` provides a flag `SkipLineEnding` that can be used to skip adding a newline character to logs. Thanks to @lruggieri.
+* [#989][]: Add `EncoderConfig.SkipLineEnding` flag to disable adding newline
+  characters between log statements.
+* [#1039][]: Add `EncoderConfig.NewReflectedEncoder` field to customize JSON
+  encoding of reflected log fields.
 
 Bugfixes:
-* [#1011][]: JSON: Fix inaccurate precision when encoding complex64.
+* [#1011][]: Fix inaccurate precision when encoding complex64 as JSON.
+* [#554][], [#1017][]: Close JSON namespaces opened in `MarshalLogObject`
+  methods when the methods return.
+* [#1033][]: Avoid panicking in Sampler core if `thereafter` is zero.
 
 Other changes:
 * [#1028][]: Drop support for Go < 1.15.
 
-[#1011]: https://github.com/uber-go/zap/pull/1011
+[#554]: https://github.com/uber-go/zap/pull/554
 [#989]: https://github.com/uber-go/zap/pull/989
+[#1011]: https://github.com/uber-go/zap/pull/1011
+[#1017]: https://github.com/uber-go/zap/pull/1017
 [#1028]: https://github.com/uber-go/zap/pull/1028
+[#1033]: https://github.com/uber-go/zap/pull/1033
+[#1039]: https://github.com/uber-go/zap/pull/1039
+
+Thanks to @psrajat, @lruggieri, @sammyrnycreal for their contributions to this release.
 
 ## 1.19.1 (8 Sep 2021)
 


### PR DESCRIPTION
This release v1.20.0 of Zap with a couple new features for customizing
the JSON encoder. Namely,

- support skipping newlines between log statements (#989)
- support changing the reflection JSON encoder (#1039)

Refs GO-1085
