### PR TITLE
zapcore: Add ParseLevel

### DIFF
--- a/zapcore/level.go
+++ b/zapcore/level.go
@@ -26,10 +26,7 @@ import (
 	"fmt"
 )
 
-var (
-	errUnmarshalNilLevel = errors.New("can't unmarshal a nil *Level")
-	errInvalidLevel      = errors.New("invalid level")
-)
+var errUnmarshalNilLevel = errors.New("can't unmarshal a nil *Level")
 
 // A Level is a logging priority. Higher levels are more important.
 type Level int8
@@ -58,30 +55,19 @@ const (
 	_maxLevel = FatalLevel
 )
 
-// LevelFromString returns a level based on the lower-case or all-caps ASCII
-// representation of the log level.
+// UnmarshalLevel unmarshals a level based on the lower-case or all-caps ASCII
+// representation of the log level. If the provided ASCII representation is
+// invalid an error is returned.
 //
 // This is particularly useful when dealing with text input to configure log
 // levels.
-func LevelFromString(text string) (Level, error) {
-	switch text {
-	case "debug", "DEBUG":
-		return DebugLevel, nil
-	case "info", "INFO", "": // make the zero value useful
-		return InfoLevel, nil
-	case "warn", "WARN":
-		return WarnLevel, nil
-	case "error", "ERROR":
-		return ErrorLevel, nil
-	case "dpanic", "DPANIC":
-		return DPanicLevel, nil
-	case "panic", "PANIC":
-		return PanicLevel, nil
-	case "fatal", "FATAL":
-		return FatalLevel, nil
-	default:
-		return -2, errInvalidLevel
+func UnmarshalLevel(text string) (Level, error) {
+	level := DebugLevel
+	err := level.UnmarshalText([]byte(text))
+	if err != nil {
+		return level, err
 	}
+	return level, nil
 }
 
 // String returns a lower-case ASCII representation of the log level.

--- a/zapcore/level.go
+++ b/zapcore/level.go
@@ -26,7 +26,10 @@ import (
 	"fmt"
 )
 
-var errUnmarshalNilLevel = errors.New("can't unmarshal a nil *Level")
+var (
+	errUnmarshalNilLevel = errors.New("can't unmarshal a nil *Level")
+	errInvalidLevel      = errors.New("invalid level")
+)
 
 // A Level is a logging priority. Higher levels are more important.
 type Level int8
@@ -54,6 +57,32 @@ const (
 	_minLevel = DebugLevel
 	_maxLevel = FatalLevel
 )
+
+// LevelFromString returns a level based on the lower-case or all-caps ASCII
+// representation of the log level.
+//
+// This is particularly useful when dealing with text input to configure log
+// levels.
+func LevelFromString(text string) (Level, error) {
+	switch text {
+	case "debug", "DEBUG":
+		return DebugLevel, nil
+	case "info", "INFO", "": // make the zero value useful
+		return InfoLevel, nil
+	case "warn", "WARN":
+		return WarnLevel, nil
+	case "error", "ERROR":
+		return ErrorLevel, nil
+	case "dpanic", "DPANIC":
+		return DPanicLevel, nil
+	case "panic", "PANIC":
+		return PanicLevel, nil
+	case "fatal", "FATAL":
+		return FatalLevel, nil
+	default:
+		return -2, errInvalidLevel
+	}
+}
 
 // String returns a lower-case ASCII representation of the log level.
 func (l Level) String() string {

--- a/zapcore/level.go
+++ b/zapcore/level.go
@@ -55,19 +55,16 @@ const (
 	_maxLevel = FatalLevel
 )
 
-// UnmarshalLevel unmarshals a level based on the lower-case or all-caps ASCII
+// ParseLevel parses a level based on the lower-case or all-caps ASCII
 // representation of the log level. If the provided ASCII representation is
 // invalid an error is returned.
 //
 // This is particularly useful when dealing with text input to configure log
 // levels.
-func UnmarshalLevel(text string) (Level, error) {
-	level := DebugLevel
+func ParseLevel(text string) (Level, error) {
+	var level Level
 	err := level.UnmarshalText([]byte(text))
-	if err != nil {
-		return level, err
-	}
-	return level, nil
+	return level, err
 }
 
 // String returns a lower-case ASCII representation of the log level.

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -23,6 +23,7 @@ package zapcore
 import (
 	"bytes"
 	"flag"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -73,6 +74,23 @@ func TestLevelText(t *testing.T) {
 		err := unmarshaled.UnmarshalText([]byte(tt.text))
 		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
 		assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		text  string
+		level Level
+		err   error
+	}{
+		{"info", InfoLevel, nil},
+		{"DEBUG", DebugLevel, nil},
+		{"FOO", 0, fmt.Errorf("unrecognized level: \"FOO\"")},
+	}
+	for _, tt := range tests {
+		parsedLevel, err := ParseLevel(tt.text)
+		assert.Equal(t, tt.level, parsedLevel)
+		assert.Equal(t, tt.err, err)
 	}
 }
 

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -23,7 +23,6 @@ package zapcore
 import (
 	"bytes"
 	"flag"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -81,16 +80,21 @@ func TestParseLevel(t *testing.T) {
 	tests := []struct {
 		text  string
 		level Level
-		err   error
+		err   string
 	}{
-		{"info", InfoLevel, nil},
-		{"DEBUG", DebugLevel, nil},
-		{"FOO", 0, fmt.Errorf("unrecognized level: \"FOO\"")},
+		{"info", InfoLevel, ""},
+		{"DEBUG", DebugLevel, ""},
+		{"FOO", 0, `unrecognized level: "FOO"`},
 	}
 	for _, tt := range tests {
 		parsedLevel, err := ParseLevel(tt.text)
-		assert.Equal(t, tt.level, parsedLevel)
-		assert.Equal(t, tt.err, err)
+		if len(tt.err) == 0 {
+			assert.NoError(t, err)
+			assert.Equal(t, tt.level, parsedLevel)
+		} else {
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.err)
+		}
 	}
 }
 


### PR DESCRIPTION
This adds the public ParseLevel function which enables the user to
construct a log level based on ASCII text input.

This re-uses the UnmarshalText method of Level for the heavy-lifting,
but it avoids the user having to declare a local `Level` variable first.


```go
var level zapcore.Level
err := level.UnmarshalText([]byte("debug"))

// versus
level, err := zapcore.ParseLevel("debug")
```

#### Usage

```go
level, err := zapcore.LevelFromString("info") // zapcore.InfoLevel, nil

level, err := zapcore.LevelFromString("DEBUG") // zapcore.DebugLevel, nil

level, err := zapcore.LevelFromString("FOO") // -2, "invalid level"
```

One thing I'm not quite sure is the returned Level value of `-2` when the user provided a invalid log level as text. Usually I would go for `-1` but this is already used by `zapcore.DebugLevel`. Let me know if you know any better solution.