### PR TITLE
lint: Remove redundant embedded field accesses

### DIFF
--- a/clock_test.go
+++ b/clock_test.go
@@ -42,6 +42,6 @@ func TestWithClock(t *testing.T) {
 	withLogger(t, DebugLevel, []Option{WithClock(clock)}, func(log *Logger, logs *observer.ObservedLogs) {
 		log.Info("")
 		require.Equal(t, 1, logs.Len(), "Expected only one log entry to be written.")
-		assert.Equal(t, date, logs.All()[0].Entry.Time, "Unexpected entry time.")
+		assert.Equal(t, date, logs.All()[0].Time, "Unexpected entry time.")
 	})
 }

--- a/global_test.go
+++ b/global_test.go
@@ -171,7 +171,7 @@ func TestRedirectStdLogCaller(t *testing.T) {
 		log.Print("redirected")
 		entries := logs.All()
 		require.Len(t, entries, 1, "Unexpected number of logs.")
-		assert.Contains(t, entries[0].Entry.Caller.File, "global_test.go", "Unexpected caller annotation.")
+		assert.Contains(t, entries[0].Caller.File, "global_test.go", "Unexpected caller annotation.")
 	})
 }
 
@@ -210,7 +210,7 @@ func TestRedirectStdLogAtCaller(t *testing.T) {
 			log.Print("redirected")
 			entries := logs.All()
 			require.Len(t, entries, 1, "Unexpected number of logs.")
-			assert.Contains(t, entries[0].Entry.Caller.File, "global_test.go", "Unexpected caller annotation.")
+			assert.Contains(t, entries[0].Caller.File, "global_test.go", "Unexpected caller annotation.")
 		})
 	}
 }
@@ -270,11 +270,11 @@ func checkStdLogMessage(t *testing.T, msg string, logs *observer.ObservedLogs) {
 	require.Equal(t, 1, logs.Len(), "Expected exactly one entry to be logged")
 	entry := logs.AllUntimed()[0]
 	assert.Equal(t, []Field{}, entry.Context, "Unexpected entry context.")
-	assert.Equal(t, "redirected", entry.Entry.Message, "Unexpected entry message.")
+	assert.Equal(t, "redirected", entry.Message, "Unexpected entry message.")
 	assert.Regexp(
 		t,
 		`/global_test.go:\d+$`,
-		entry.Entry.Caller.String(),
+		entry.Caller.String(),
 		"Unexpected caller annotation.",
 	)
 }

--- a/logger.go
+++ b/logger.go
@@ -314,7 +314,7 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 			log.errorOutput.Sync()
 		}
 
-		ce.Entry.Caller = zapcore.EntryCaller{
+		ce.Caller = zapcore.EntryCaller{
 			Defined:  defined,
 			PC:       frame.PC,
 			File:     frame.File,
@@ -322,8 +322,8 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 			Function: frame.Function,
 		}
 	}
-	if log.addStack.Enabled(ce.Entry.Level) {
-		ce.Entry.Stack = StackSkip("", log.callerSkip+callerSkipOffset).String
+	if log.addStack.Enabled(ce.Level) {
+		ce.Stack = StackSkip("", log.callerSkip+callerSkipOffset).String
 	}
 
 	return ce

--- a/logger_test.go
+++ b/logger_test.go
@@ -284,7 +284,7 @@ func TestLoggerNames(t *testing.T) {
 			}
 			log.Info("")
 			require.Equal(t, 1, logs.Len(), "Expected only one log entry to be written.")
-			assert.Equal(t, tt.expected, logs.AllUntimed()[0].Entry.LoggerName, "Unexpected logger name.")
+			assert.Equal(t, tt.expected, logs.AllUntimed()[0].LoggerName, "Unexpected logger name.")
 		})
 		withSugar(t, DebugLevel, nil, func(log *SugaredLogger, logs *observer.ObservedLogs) {
 			for _, n := range tt.names {
@@ -292,7 +292,7 @@ func TestLoggerNames(t *testing.T) {
 			}
 			log.Infow("")
 			require.Equal(t, 1, logs.Len(), "Expected only one log entry to be written.")
-			assert.Equal(t, tt.expected, logs.AllUntimed()[0].Entry.LoggerName, "Unexpected logger name.")
+			assert.Equal(t, tt.expected, logs.AllUntimed()[0].LoggerName, "Unexpected logger name.")
 		})
 	}
 }
@@ -359,7 +359,7 @@ func TestLoggerAddCaller(t *testing.T) {
 			assert.Regexp(
 				t,
 				tt.pat,
-				output[0].Entry.Caller,
+				output[0].Caller,
 				"Expected to find package name and file name in output.",
 			)
 		})
@@ -432,14 +432,14 @@ func TestLoggerAddCallerFunction(t *testing.T) {
 				assert.Regexp(
 					t,
 					tt.loggerFunction,
-					entry.Entry.Caller.Function,
+					entry.Caller.Function,
 					"Expected to find function name in output.",
 				)
 			}
 			assert.Regexp(
 				t,
 				tt.sugaredFunction,
-				entries[1].Entry.Caller.Function,
+				entries[1].Caller.Function,
 				"Expected to find function name in output.",
 			)
 		})
@@ -458,12 +458,12 @@ func TestLoggerAddCallerFail(t *testing.T) {
 		)
 		assert.Equal(
 			t,
-			logs.AllUntimed()[0].Entry.Message,
+			logs.AllUntimed()[0].Message,
 			"Failure.",
 			"Expected original message to survive failures in runtime.Caller.")
 		assert.Equal(
 			t,
-			logs.AllUntimed()[0].Entry.Caller.Function,
+			logs.AllUntimed()[0].Caller.Function,
 			"",
 			"Expected function name to be empty string.")
 	})
@@ -489,7 +489,7 @@ func TestLoggerIncreaseLevel(t *testing.T) {
 		require.Equal(t, 2, logs.Len(), "expected only warn + error logs due to IncreaseLevel.")
 		assert.Equal(
 			t,
-			logs.AllUntimed()[0].Entry.Message,
+			logs.AllUntimed()[0].Message,
 			"logger.Warn",
 			"Expected first logged message to be warn level message",
 		)

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -344,7 +344,7 @@ func TestSugarAddCaller(t *testing.T) {
 			assert.Regexp(
 				t,
 				tt.pat,
-				output[0].Entry.Caller,
+				output[0].Caller,
 				"Expected to find package name and file name in output.",
 			)
 		})
@@ -363,7 +363,7 @@ func TestSugarAddCallerFail(t *testing.T) {
 		)
 		assert.Equal(
 			t,
-			logs.AllUntimed()[0].Entry.Message,
+			logs.AllUntimed()[0].Message,
 			"Failure.",
 			"Expected original message to survive failures in runtime.Caller.")
 	})


### PR DESCRIPTION
Because the corresponded type is embedded, we can access these fields
directly.
