### PR TITLE
Avoid CallersFrames from escaping

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -332,7 +332,7 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 		return ce
 	}
 
-	frame, more := stack.Next()
+	frame := stack.First()
 
 	if log.addCaller {
 		ce.Caller = zapcore.EntryCaller{
@@ -349,13 +349,7 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 		defer buffer.Free()
 
 		stackfmt := newStackFormatter(buffer)
-
-		// We've already extracted the first frame, so format that
-		// separately and defer to stackfmt for the rest.
-		stackfmt.FormatFrame(frame)
-		if more {
-			stackfmt.FormatStack(stack)
-		}
+		stackfmt.FormatStack(stack)
 		ce.Stack = buffer.String()
 	}
 


### PR DESCRIPTION
The `runtime.CallersFrames` method doesn't do much other than returning a struct pointer wrapping the passed in `pcs`. Calling this method twice ends up simplifying some of the logic (not having to format the first stack separately from the remaining), and ends up brining the performance of `TakeStacktrace` similar to `master`.

```
# benchstat comparing 3 runs of master vs this branch, each run using benchtime=10s
name            old time/op    new time/op    delta
TakeStacktrace    1.47µs ± 2%    1.48µs ± 2%   ~     (p=1.000 n=3+3)

name            old alloc/op   new alloc/op   delta
TakeStacktrace      496B ± 0%      496B ± 0%   ~     (all equal)

name            old allocs/op  new allocs/op  delta
TakeStacktrace      2.00 ± 0%      2.00 ± 0%   ~     (all equal)
```