### PR TITLE
Check if EncodeLevel is set to avoid nil pointer dereference

### DIFF
--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -364,7 +364,7 @@ func (enc *jsonEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 	final := enc.clone()
 	final.buf.AppendByte('{')
 
-	if final.LevelKey != "" {
+	if final.LevelKey != "" && final.EncodeLevel != nil {
 		final.addKey(final.LevelKey)
 		cur := final.buf.Len()
 		final.EncodeLevel(ent.Level, final)

--- a/zapcore/json_encoder_test.go
+++ b/zapcore/json_encoder_test.go
@@ -137,7 +137,6 @@ func TestJSONEncodeEntry(t *testing.T) {
 }
 
 func TestNoEncodeLevelSupplied(t *testing.T) {
-
 	enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{
 		MessageKey:     "M",
 		LevelKey:       "L",

--- a/zapcore/json_encoder_test.go
+++ b/zapcore/json_encoder_test.go
@@ -136,6 +136,36 @@ func TestJSONEncodeEntry(t *testing.T) {
 	}
 }
 
+func TestNoEncodeLevelSupplied(t *testing.T) {
+
+	enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+		MessageKey:     "M",
+		LevelKey:       "L",
+		TimeKey:        "T",
+		NameKey:        "N",
+		CallerKey:      "C",
+		FunctionKey:    "F",
+		StacktraceKey:  "S",
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.SecondsDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	})
+
+	ent := zapcore.Entry{
+		Level:      zapcore.InfoLevel,
+		Time:       time.Date(2018, 6, 19, 16, 33, 42, 99, time.UTC),
+		LoggerName: "bob",
+		Message:    "lob law",
+	}
+
+	fields := []zapcore.Field{
+		zap.Int("answer", 42),
+	}
+
+	_, err := enc.EncodeEntry(ent, fields)
+	assert.NoError(t, err, "Unexpected JSON encoding error.")
+}
+
 func TestJSONEmptyConfig(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Hello,

Apologies in advance, this is my first go PR.

This PR checks if `EncodeLevel` is set before calling it on `final` encoder clone. This prevents panic on nil pointer dereference in case it hasn't been supplied by the user. For an untrained eye, the stacktrace wasn't making it super clear that `EncodeLevel` _must_ be provided along with `LevelKey`, so hopefully an explicit check hints at it for someone reading the source code. 

I wasn't sure if maybe providing a sensible default here would've been better, but looking at the [console logger](https://github.com/uber-go/zap/blob/a9218159e1d1842b4df993bfa840e3a0c18a0c34/zapcore/console_encoder.go#L83), a similar check is made.

Thanks.