### PR TITLE
Add WithOptions to SugaredLogger

### DIFF
--- a/sugar.go
+++ b/sugar.go
@@ -61,8 +61,8 @@ func (s *SugaredLogger) Named(name string) *SugaredLogger {
 	return &SugaredLogger{base: s.base.Named(name)}
 }
 
-// WithOptions clones the base Logger, applies the supplied Options, wraps
-// the resulting Logger, and returns it. It's safe to use concurrently.
+// WithOptions clones the current SugaredLogger, applies the supplied Options,
+// and returns the result. It's safe to use concurrently.
 func (s *SugaredLogger) WithOptions(opts ...Option) *SugaredLogger {
 	base := s.base.clone()
 	for _, opt := range opts {

--- a/sugar.go
+++ b/sugar.go
@@ -61,6 +61,16 @@ func (s *SugaredLogger) Named(name string) *SugaredLogger {
 	return &SugaredLogger{base: s.base.Named(name)}
 }
 
+// WithOptions clones the base Logger, applies the supplied Options, wraps
+// the resulting Logger, and returns it. It's safe to use concurrently.
+func (s *SugaredLogger) WithOptions(opts ...Option) *SugaredLogger {
+	base := s.base.clone()
+	for _, opt := range opts {
+		opt.apply(base)
+	}
+	return &SugaredLogger{base: base}
+}
+
 // With adds a variadic number of fields to the logging context. It accepts a
 // mix of strongly-typed Field objects and loosely-typed key-value pairs. When
 // processing pairs, the first element of the pair is used as the field key

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -369,6 +369,22 @@ func TestSugarAddCallerFail(t *testing.T) {
 	})
 }
 
+func TestSugarWithOptionsIncreaseLevel(t *testing.T) {
+	withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+		logger = logger.WithOptions(IncreaseLevel(WarnLevel))
+		logger.Info("logger.Info")
+		logger.Warn("logger.Warn")
+		logger.Error("logger.Error")
+		require.Equal(t, 2, logs.Len(), "expected only warn + error logs due to IncreaseLevel.")
+		assert.Equal(
+			t,
+			logs.AllUntimed()[0].Message,
+			"logger.Warn",
+			"Expected first logged message to be warn level message",
+		)
+	})
+}
+
 func BenchmarkSugarSingleStrArg(b *testing.B) {
 	withSugar(b, InfoLevel, nil /* opts* */, func(log *SugaredLogger, logs *observer.ObservedLogs) {
 		for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Closes #1072.

I added a simple test for this feature. One thought to add more comprehensive tests would be to replace the following line in the [`withSugar`](https://github.com/uber-go/zap/blob/212dcb966b47f20c741c821bf5f89f127a8ca7b9/common_test.go#L43) function in `common_test.go`:
```
withLogger(t, e, opts, func(logger *Logger, logs *observer.ObservedLogs) { f(logger.Sugar(), logs) })
```
with
```
withLogger(t, e, nil, func(logger *Logger, logs *observer.ObservedLogs) { f(logger.Sugar().WithOptions(opts...), logs) })
```
but maybe that is too much. WDYT?

Thank you!
