### PR TITLE
Add *ln variants of methods to the SugaredLogger

### DIFF
--- a/sugar.go
+++ b/sugar.go
@@ -38,10 +38,19 @@ const (
 // method.
 //
 // Unlike the Logger, the SugaredLogger doesn't insist on structured logging.
-// For each log level, it exposes three methods: one for loosely-typed
-// structured logging, one for println-style formatting, and one for
-// printf-style formatting. For example, SugaredLoggers can produce InfoLevel
-// output with Infow ("info with" structured context), Info, or Infof.
+// For each log level, it exposes four methods:
+//
+//  - methods named after the log level for log.Print-style logging
+//  - methods ending in "w" for loosely-typed structured logging
+//  - methods ending in "f" for log.Printf-style logging
+//  - methods ending in "ln" for log.Println-style logging
+//
+// For example, the methods for InfoLevel are:
+//
+//  Info(...any)           Print-style logging
+//  Infow(...any)          Structured logging (read as "info with")
+//  Infof(string, ...any)  Printf-style logging
+//  Infoln(...any)         Println-style logging
 type SugaredLogger struct {
 	base *Logger
 }

--- a/sugar.go
+++ b/sugar.go
@@ -220,11 +220,48 @@ func (s *SugaredLogger) Fatalw(msg string, keysAndValues ...interface{}) {
 	s.log(FatalLevel, msg, nil, keysAndValues)
 }
 
+// Debugln uses fmt.Sprintln to construct and log a message.
+func (s *SugaredLogger) Debugln(args ...interface{}) {
+	s.logln(DebugLevel, "", args, nil)
+}
+
+// Infoln uses fmt.Sprintln to construct and log a message.
+func (s *SugaredLogger) Infoln(args ...interface{}) {
+	s.logln(InfoLevel, "", args, nil)
+}
+
+// Warnln uses fmt.Sprintln to construct and log a message.
+func (s *SugaredLogger) Warnln(args ...interface{}) {
+	s.logln(WarnLevel, "", args, nil)
+}
+
+// Errorln uses fmt.Sprintln to construct and log a message.
+func (s *SugaredLogger) Errorln(args ...interface{}) {
+	s.logln(ErrorLevel, "", args, nil)
+}
+
+// DPanicln uses fmt.Sprintln to construct and log a message. In development, the
+// logger then panics. (See DPanicLevel for details.)
+func (s *SugaredLogger) DPanicln(args ...interface{}) {
+	s.logln(DPanicLevel, "", args, nil)
+}
+
+// Panicln uses fmt.Sprintln to construct and log a message, then panics.
+func (s *SugaredLogger) Panicln(args ...interface{}) {
+	s.logln(PanicLevel, "", args, nil)
+}
+
+// Fatalln uses fmt.Sprintln to construct and log a message, then calls os.Exit.
+func (s *SugaredLogger) Fatalln(args ...interface{}) {
+	s.logln(FatalLevel, "", args, nil)
+}
+
 // Sync flushes any buffered log entries.
 func (s *SugaredLogger) Sync() error {
 	return s.base.Sync()
 }
 
+// log message with Sprint, Sprintf, or neither.
 func (s *SugaredLogger) log(lvl zapcore.Level, template string, fmtArgs []interface{}, context []interface{}) {
 	// If logging at this level is completely disabled, skip the overhead of
 	// string formatting.
@@ -233,6 +270,18 @@ func (s *SugaredLogger) log(lvl zapcore.Level, template string, fmtArgs []interf
 	}
 
 	msg := getMessage(template, fmtArgs)
+	if ce := s.base.Check(lvl, msg); ce != nil {
+		ce.Write(s.sweetenFields(context)...)
+	}
+}
+
+// logln message with Sprintln
+func (s *SugaredLogger) logln(lvl zapcore.Level, template string, fmtArgs []interface{}, context []interface{}) {
+	if lvl < DPanicLevel && !s.base.Core().Enabled(lvl) {
+		return
+	}
+
+	msg := getMessageln(fmtArgs)
 	if ce := s.base.Check(lvl, msg); ce != nil {
 		ce.Write(s.sweetenFields(context)...)
 	}
@@ -254,6 +303,12 @@ func getMessage(template string, fmtArgs []interface{}) string {
 		}
 	}
 	return fmt.Sprint(fmtArgs...)
+}
+
+// getMessageln format with Sprintln.
+func getMessageln(fmtArgs []interface{}) string {
+	msg := fmt.Sprintln(fmtArgs...)
+	return msg[:len(msg)-1]
 }
 
 func (s *SugaredLogger) sweetenFields(args []interface{}) []Field {

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -297,6 +297,13 @@ func TestSugarLnLogging(t *testing.T) {
 	}
 }
 
+func TestSugarLnLoggingIgnored(t *testing.T) {
+	withSugar(t, WarnLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+		logger.Infoln("hello")
+		assert.Zero(t, logs.Len(), "Expected zero log statements.")
+	})
+}
+
 func TestSugarPanicLogging(t *testing.T) {
 	tests := []struct {
 		loggerLevel zapcore.Level


### PR DESCRIPTION

Currently zap sugared logger dose not have method like `fmt.Println`, this PR adding `*ln` variants of methods to SugaredLogger. 

```go
zap.S().Info("a", "b")
zap.S().Infoln("a", "b")
fmt.Println("a", "b")
```
zap Info output: `ab`
zap Infoln output: `a b`
fmt output: `a b`

Related issue: https://github.com/uber-go/zap/issues/889