### PR TITLE
Replace deprecated ioutil usage

### DIFF
--- a/benchmarks/apex_test.go
+++ b/benchmarks/apex_test.go
@@ -21,7 +21,7 @@
 package benchmarks
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/json"
@@ -29,14 +29,14 @@ import (
 
 func newDisabledApexLog() *log.Logger {
 	return &log.Logger{
-		Handler: json.New(ioutil.Discard),
+		Handler: json.New(io.Discard),
 		Level:   log.ErrorLevel,
 	}
 }
 
 func newApexLog() *log.Logger {
 	return &log.Logger{
-		Handler: json.New(ioutil.Discard),
+		Handler: json.New(io.Discard),
 		Level:   log.DebugLevel,
 	}
 }

--- a/benchmarks/kit_test.go
+++ b/benchmarks/kit_test.go
@@ -21,11 +21,11 @@
 package benchmarks
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/go-kit/log"
 )
 
 func newKitLog(fields ...interface{}) log.Logger {
-	return log.With(log.NewJSONLogger(ioutil.Discard), fields...)
+	return log.With(log.NewJSONLogger(io.Discard), fields...)
 }

--- a/benchmarks/log15_test.go
+++ b/benchmarks/log15_test.go
@@ -21,13 +21,13 @@
 package benchmarks
 
 import (
-	"io/ioutil"
+	"io"
 
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
 func newLog15() log15.Logger {
 	logger := log15.New()
-	logger.SetHandler(log15.StreamHandler(ioutil.Discard, log15.JsonFormat()))
+	logger.SetHandler(log15.StreamHandler(io.Discard, log15.JsonFormat()))
 	return logger
 }

--- a/benchmarks/logrus_test.go
+++ b/benchmarks/logrus_test.go
@@ -21,7 +21,7 @@
 package benchmarks
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/sirupsen/logrus"
 )
@@ -34,7 +34,7 @@ func newDisabledLogrus() *logrus.Logger {
 
 func newLogrus() *logrus.Logger {
 	return &logrus.Logger{
-		Out:       ioutil.Discard,
+		Out:       io.Discard,
 		Formatter: new(logrus.JSONFormatter),
 		Hooks:     make(logrus.LevelHooks),
 		Level:     logrus.DebugLevel,

--- a/benchmarks/scenario_bench_test.go
+++ b/benchmarks/scenario_bench_test.go
@@ -21,7 +21,7 @@
 package benchmarks
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"testing"
 
@@ -316,7 +316,7 @@ func BenchmarkWithoutFields(b *testing.B) {
 		})
 	})
 	b.Run("stdlib.Println", func(b *testing.B) {
-		logger := log.New(ioutil.Discard, "", log.LstdFlags)
+		logger := log.New(io.Discard, "", log.LstdFlags)
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
@@ -325,7 +325,7 @@ func BenchmarkWithoutFields(b *testing.B) {
 		})
 	})
 	b.Run("stdlib.Printf", func(b *testing.B) {
-		logger := log.New(ioutil.Discard, "", log.LstdFlags)
+		logger := log.New(io.Discard, "", log.LstdFlags)
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {

--- a/benchmarks/zerolog_test.go
+++ b/benchmarks/zerolog_test.go
@@ -21,13 +21,13 @@
 package benchmarks
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/rs/zerolog"
 )
 
 func newZerolog() zerolog.Logger {
-	return zerolog.New(ioutil.Discard).With().Timestamp().Logger()
+	return zerolog.New(io.Discard).With().Timestamp().Logger()
 }
 
 func newDisabledZerolog() zerolog.Logger {

--- a/config_test.go
+++ b/config_test.go
@@ -21,7 +21,7 @@
 package zap
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -58,7 +58,7 @@ func TestConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			temp, err := ioutil.TempFile("", "zap-prod-config-test")
+			temp, err := os.CreateTemp("", "zap-prod-config-test")
 			require.NoError(t, err, "Failed to create temp file.")
 			defer os.Remove(temp.Name())
 
@@ -74,7 +74,7 @@ func TestConfig(t *testing.T) {
 			logger.Info("info")
 			logger.Warn("warn")
 
-			byteContents, err := ioutil.ReadAll(temp)
+			byteContents, err := io.ReadAll(temp)
 			require.NoError(t, err, "Couldn't read log contents from temp file.")
 			logs := string(byteContents)
 			assert.Regexp(t, tt.expectRe, logs, "Unexpected log output.")
@@ -180,7 +180,7 @@ func TestConfigWithSamplingHook(t *testing.T) {
 	expectDropped := 99  // 200 - 100 initial - 1 thereafter
 	expectSampled := 103 // 2 from initial + 100 + 1 thereafter
 
-	temp, err := ioutil.TempFile("", "zap-prod-config-test")
+	temp, err := os.CreateTemp("", "zap-prod-config-test")
 	require.NoError(t, err, "Failed to create temp file.")
 	defer func() {
 		err := os.Remove(temp.Name())
@@ -200,7 +200,7 @@ func TestConfigWithSamplingHook(t *testing.T) {
 	logger.Info("info")
 	logger.Warn("warn")
 
-	byteContents, err := ioutil.ReadAll(temp)
+	byteContents, err := io.ReadAll(temp)
 	require.NoError(t, err, "Couldn't read log contents from temp file.")
 	logs := string(byteContents)
 	assert.Regexp(t, expectRe, logs, "Unexpected log output.")

--- a/example_test.go
+++ b/example_test.go
@@ -22,7 +22,7 @@ package zap_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -125,8 +125,8 @@ func Example_advancedConfiguration() {
 	// implement io.Writer, we can use zapcore.AddSync to add a no-op Sync
 	// method. If they're not safe for concurrent use, we can add a protecting
 	// mutex with zapcore.Lock.)
-	topicDebugging := zapcore.AddSync(ioutil.Discard)
-	topicErrors := zapcore.AddSync(ioutil.Discard)
+	topicDebugging := zapcore.AddSync(io.Discard)
+	topicErrors := zapcore.AddSync(io.Discard)
 
 	// High-priority output should also go to standard error, and low-priority
 	// output should also go to standard out.

--- a/flag_test.go
+++ b/flag_test.go
@@ -22,7 +22,7 @@ package zap
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"go.uber.org/zap/zapcore"
@@ -39,7 +39,7 @@ type flagTestCase struct {
 func (tc flagTestCase) runImplicitSet(t testing.TB) {
 	origCommandLine := flag.CommandLine
 	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
-	flag.CommandLine.SetOutput(ioutil.Discard)
+	flag.CommandLine.SetOutput(io.Discard)
 	defer func() { flag.CommandLine = origCommandLine }()
 
 	level := LevelFlag("level", InfoLevel, "")
@@ -89,7 +89,7 @@ func TestLevelFlag(t *testing.T) {
 func TestLevelFlagsAreIndependent(t *testing.T) {
 	origCommandLine := flag.CommandLine
 	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
-	flag.CommandLine.SetOutput(ioutil.Discard)
+	flag.CommandLine.SetOutput(io.Discard)
 	defer func() { flag.CommandLine = origCommandLine }()
 
 	// Make sure that these two flags are independent.

--- a/internal/readme/readme.go
+++ b/internal/readme/readme.go
@@ -23,7 +23,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -59,7 +59,7 @@ func do() error {
 	if err != nil {
 		return err
 	}
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}

--- a/internal/ztest/writer.go
+++ b/internal/ztest/writer.go
@@ -23,7 +23,7 @@ package ztest
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"strings"
 )
 
@@ -50,12 +50,12 @@ func (s *Syncer) Called() bool {
 	return s.called
 }
 
-// A Discarder sends all writes to ioutil.Discard.
+// A Discarder sends all writes to io.Discard.
 type Discarder struct{ Syncer }
 
 // Write implements io.Writer.
 func (d *Discarder) Write(b []byte) (int, error) {
-	return ioutil.Discard.Write(b)
+	return io.Discard.Write(b)
 }
 
 // FailWriter is a WriteSyncer that always returns an error on writes.

--- a/logger.go
+++ b/logger.go
@@ -22,7 +22,7 @@ package zap
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -85,7 +85,7 @@ func New(core zapcore.Core, options ...Option) *Logger {
 func NewNop() *Logger {
 	return &Logger{
 		core:        zapcore.NewNopCore(),
-		errorOutput: zapcore.AddSync(ioutil.Discard),
+		errorOutput: zapcore.AddSync(io.Discard),
 		addStack:    zapcore.FatalLevel + 1,
 		clock:       zapcore.DefaultClock,
 	}

--- a/sink_test.go
+++ b/sink_test.go
@@ -22,7 +22,7 @@ package zap
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"strings"
 	"testing"
@@ -49,7 +49,7 @@ func TestRegisterSink(t *testing.T) {
 	nopFactory := func(u *url.URL) (Sink, error) {
 		assert.Equal(t, u.Scheme, nopScheme, "Scheme didn't match registration.")
 		nopCalls++
-		return nopCloserSink{zapcore.AddSync(ioutil.Discard)}, nil
+		return nopCloserSink{zapcore.AddSync(io.Discard)}, nil
 	}
 
 	defer resetSinkRegistry()
@@ -75,7 +75,7 @@ func TestRegisterSink(t *testing.T) {
 
 func TestRegisterSinkErrors(t *testing.T) {
 	nopFactory := func(_ *url.URL) (Sink, error) {
-		return nopCloserSink{zapcore.AddSync(ioutil.Discard)}, nil
+		return nopCloserSink{zapcore.AddSync(io.Discard)}, nil
 	}
 	tests := []struct {
 		scheme string

--- a/stacktrace_ext_test.go
+++ b/stacktrace_ext_test.go
@@ -23,7 +23,6 @@ package zap_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -161,7 +160,7 @@ func verifyNoZap(t *testing.T, logs string) {
 }
 
 func withGoPath(t *testing.T, f func(goPath string)) {
-	goPath, err := ioutil.TempDir("", "gopath")
+	goPath, err := os.MkdirTemp("", "gopath")
 	require.NoError(t, err, "Failed to create temporary directory for GOPATH")
 	//defer os.RemoveAll(goPath)
 

--- a/writer.go
+++ b/writer.go
@@ -23,7 +23,6 @@ package zap
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"go.uber.org/zap/zapcore"
 
@@ -93,7 +92,7 @@ func open(paths []string) ([]zapcore.WriteSyncer, func(), error) {
 // using zapcore.NewMultiWriteSyncer and zapcore.Lock individually.
 func CombineWriteSyncers(writers ...zapcore.WriteSyncer) zapcore.WriteSyncer {
 	if len(writers) == 0 {
-		return zapcore.AddSync(ioutil.Discard)
+		return zapcore.AddSync(io.Discard)
 	}
 	return zapcore.Lock(zapcore.NewMultiWriteSyncer(writers...))
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -23,7 +23,7 @@ package zap
 import (
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/url"
 	"os"
@@ -43,7 +43,7 @@ func TestOpenNoPaths(t *testing.T) {
 	assert.NoError(t, err, "Expected opening no paths to succeed.")
 	assert.Equal(
 		t,
-		zapcore.AddSync(ioutil.Discard),
+		zapcore.AddSync(io.Discard),
 		ws,
 		"Expected opening no paths to return a no-op WriteSyncer.",
 	)

--- a/zapcore/buffered_write_syncer_bench_test.go
+++ b/zapcore/buffered_write_syncer_bench_test.go
@@ -21,7 +21,6 @@
 package zapcore
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -31,7 +30,7 @@ import (
 
 func BenchmarkBufferedWriteSyncer(b *testing.B) {
 	b.Run("write file with buffer", func(b *testing.B) {
-		file, err := ioutil.TempFile("", "log")
+		file, err := os.CreateTemp("", "log")
 		require.NoError(b, err)
 
 		defer func() {

--- a/zapcore/core_test.go
+++ b/zapcore/core_test.go
@@ -22,7 +22,6 @@ package zapcore_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -68,7 +67,7 @@ func TestNopCore(t *testing.T) {
 }
 
 func TestIOCore(t *testing.T) {
-	temp, err := ioutil.TempFile("", "zapcore-test-iocore")
+	temp, err := os.CreateTemp("", "zapcore-test-iocore")
 	require.NoError(t, err, "Failed to create temp file.")
 	defer os.Remove(temp.Name())
 
@@ -94,7 +93,7 @@ func TestIOCore(t *testing.T) {
 		ce.Write(makeInt64Field("k", 4))
 	}
 
-	logged, err := ioutil.ReadFile(temp.Name())
+	logged, err := os.ReadFile(temp.Name())
 	require.NoError(t, err, "Failed to read from temp file.")
 	require.Equal(
 		t,

--- a/zapcore/write_syncer_bench_test.go
+++ b/zapcore/write_syncer_bench_test.go
@@ -21,7 +21,6 @@
 package zapcore
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -77,7 +76,7 @@ func BenchmarkMultiWriteSyncer(b *testing.B) {
 
 func BenchmarkWriteSyncer(b *testing.B) {
 	b.Run("write file with no buffer", func(b *testing.B) {
-		file, err := ioutil.TempFile("", "log")
+		file, err := os.CreateTemp("", "log")
 		assert.NoError(b, err)
 		defer file.Close()
 		defer os.Remove(file.Name())

--- a/zaptest/writer.go
+++ b/zaptest/writer.go
@@ -26,7 +26,7 @@ type (
 	// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
 	Syncer = ztest.Syncer
 
-	// A Discarder sends all writes to ioutil.Discard.
+	// A Discarder sends all writes to io.Discard.
 	Discarder = ztest.Discarder
 
 	// FailWriter is a WriteSyncer that always returns an error on writes.


### PR DESCRIPTION
`ioutil` package has been deprecated after go 1.16 https://tip.golang.org/doc/go1.16#ioutil
This PR removes all `ioutil` usage and updates comments