### PR TITLE
With no longer clones. Add Clone and CloneWith.

### DIFF
--- a/global_test.go
+++ b/global_test.go
@@ -82,7 +82,7 @@ func TestGlobalsConcurrentUse(t *testing.T) {
 		}()
 		go func() {
 			for !stop.Load() {
-				L().With(Int("foo", 42)).Named("main").WithOptions(Development()).Info("")
+				L().CloneWith(Int("foo", 42)).Named("main").WithOptions(Development()).Info("")
 				S().Info("")
 			}
 			wg.Done()

--- a/increase_level_test.go
+++ b/increase_level_test.go
@@ -78,10 +78,10 @@ func TestIncreaseLevel(t *testing.T) {
 		errorLogger.Warn("ignored warn log")
 		errorLogger.Error("increase level error log")
 
-		withFields := errorLogger.With(String("k", "v"))
-		withFields.Debug("ignored debug log with fields")
-		withFields.Warn("ignored warn log with fields")
-		withFields.Error("increase level error log with fields")
+		errorLogger.With(String("k", "v"))
+		errorLogger.Debug("ignored debug log with fields")
+		errorLogger.Warn("ignored warn log with fields")
+		errorLogger.Error("increase level error log with fields")
 
 		assert.Equal(t, []observer.LoggedEntry{
 			newLoggedEntry(WarnLevel, "original warn log"),

--- a/logger.go
+++ b/logger.go
@@ -129,7 +129,7 @@ func NewExample(options ...Option) *Logger {
 // single application to use both Loggers and SugaredLoggers, converting
 // between them on the boundaries of performance-sensitive code.
 func (log *Logger) Sugar() *SugaredLogger {
-	core := log.clone()
+	core := log.Clone()
 	core.callerSkip += 2
 	return &SugaredLogger{core}
 }
@@ -140,7 +140,7 @@ func (log *Logger) Named(s string) *Logger {
 	if s == "" {
 		return log
 	}
-	l := log.clone()
+	l := log.Clone()
 	if log.name == "" {
 		l.name = s
 	} else {
@@ -152,22 +152,27 @@ func (log *Logger) Named(s string) *Logger {
 // WithOptions clones the current Logger, applies the supplied Options, and
 // returns the resulting Logger. It's safe to use concurrently.
 func (log *Logger) WithOptions(opts ...Option) *Logger {
-	c := log.clone()
+	c := log.Clone()
 	for _, opt := range opts {
 		opt.apply(c)
 	}
 	return c
 }
 
-// With creates a child logger and adds structured context to it. Fields added
-// to the child don't affect the parent, and vice versa.
+// With adds structured context to the Logger.
 func (log *Logger) With(fields ...Field) *Logger {
 	if len(fields) == 0 {
 		return log
 	}
-	l := log.clone()
-	l.core = l.core.With(fields)
-	return l
+	log.core = log.core.With(fields)
+	return log
+}
+
+// CloneWith is a convenience function for Clone() followed by With(). It
+// creates a child logger and adds structured context to it. Fields added
+// to the child don't affect the parent, and vice versa.
+func (log *Logger) CloneWith(fields ...Field) *Logger {
+	return log.Clone().With(fields...)
 }
 
 // Check returns a CheckedEntry if logging a message at the specified level
@@ -253,7 +258,8 @@ func (log *Logger) Core() zapcore.Core {
 	return log.core
 }
 
-func (log *Logger) clone() *Logger {
+// Clone creates and returns a clone of the Logger.
+func (log *Logger) Clone() *Logger {
 	copy := *log
 	return &copy
 }

--- a/sugar.go
+++ b/sugar.go
@@ -60,7 +60,7 @@ type SugaredLogger struct {
 // both Loggers and SugaredLoggers, converting between them on the boundaries
 // of performance-sensitive code.
 func (s *SugaredLogger) Desugar() *Logger {
-	base := s.base.clone()
+	base := s.base.Clone()
 	base.callerSkip -= 2
 	return base
 }
@@ -73,7 +73,7 @@ func (s *SugaredLogger) Named(name string) *SugaredLogger {
 // WithOptions clones the current SugaredLogger, applies the supplied Options,
 // and returns the result. It's safe to use concurrently.
 func (s *SugaredLogger) WithOptions(opts ...Option) *SugaredLogger {
-	base := s.base.clone()
+	base := s.base.Clone()
 	for _, opt := range opts {
 		opt.apply(base)
 	}
@@ -108,7 +108,15 @@ func (s *SugaredLogger) WithOptions(opts ...Option) *SugaredLogger {
 // and execution continues. Passing an orphaned key triggers similar behavior:
 // panics in development and errors in production.
 func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
-	return &SugaredLogger{base: s.base.With(s.sweetenFields(args)...)}
+	s.base.With(s.sweetenFields(args)...)
+	return s
+}
+
+// CloneWith is a convenience function for Clone() followed by With(). It
+// creates and returns a child SugaredLogger with the added fields. Fields
+// added to the child don't affect the parent, and vice versa.
+func (s *SugaredLogger) CloneWith(args ...interface{}) *SugaredLogger {
+	return s.Clone().With(args...)
 }
 
 // Debug uses fmt.Sprint to construct and log a message.
@@ -268,6 +276,11 @@ func (s *SugaredLogger) Fatalln(args ...interface{}) {
 // Sync flushes any buffered log entries.
 func (s *SugaredLogger) Sync() error {
 	return s.base.Sync()
+}
+
+// Clone creates and returns a clone of the SugaredLogger.
+func (s *SugaredLogger) Clone() *SugaredLogger {
+	return &SugaredLogger{base: s.base.Clone()}
 }
 
 // log message with Sprint, Sprintf, or neither.

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -175,11 +175,11 @@ func TestSugarStructuredLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
-			logger.With(context...).Debugw(tt.msg, extra...)
-			logger.With(context...).Infow(tt.msg, extra...)
-			logger.With(context...).Warnw(tt.msg, extra...)
-			logger.With(context...).Errorw(tt.msg, extra...)
-			logger.With(context...).DPanicw(tt.msg, extra...)
+			logger.CloneWith(context...).Debugw(tt.msg, extra...)
+			logger.CloneWith(context...).Infow(tt.msg, extra...)
+			logger.CloneWith(context...).Warnw(tt.msg, extra...)
+			logger.CloneWith(context...).Errorw(tt.msg, extra...)
+			logger.CloneWith(context...).DPanicw(tt.msg, extra...)
 
 			expected := make([]observer.LoggedEntry, 5)
 			for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
@@ -207,11 +207,11 @@ func TestSugarConcatenatingLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
-			logger.With(context...).Debug(tt.args...)
-			logger.With(context...).Info(tt.args...)
-			logger.With(context...).Warn(tt.args...)
-			logger.With(context...).Error(tt.args...)
-			logger.With(context...).DPanic(tt.args...)
+			logger.CloneWith(context...).Debug(tt.args...)
+			logger.CloneWith(context...).Info(tt.args...)
+			logger.CloneWith(context...).Warn(tt.args...)
+			logger.CloneWith(context...).Error(tt.args...)
+			logger.CloneWith(context...).DPanic(tt.args...)
 
 			expected := make([]observer.LoggedEntry, 5)
 			for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
@@ -243,11 +243,11 @@ func TestSugarTemplatedLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
-			logger.With(context...).Debugf(tt.format, tt.args...)
-			logger.With(context...).Infof(tt.format, tt.args...)
-			logger.With(context...).Warnf(tt.format, tt.args...)
-			logger.With(context...).Errorf(tt.format, tt.args...)
-			logger.With(context...).DPanicf(tt.format, tt.args...)
+			logger.CloneWith(context...).Debugf(tt.format, tt.args...)
+			logger.CloneWith(context...).Infof(tt.format, tt.args...)
+			logger.CloneWith(context...).Warnf(tt.format, tt.args...)
+			logger.CloneWith(context...).Errorf(tt.format, tt.args...)
+			logger.CloneWith(context...).DPanicf(tt.format, tt.args...)
 
 			expected := make([]observer.LoggedEntry, 5)
 			for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
@@ -279,11 +279,11 @@ func TestSugarLnLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
-			logger.With(context...).Debugln(tt.args...)
-			logger.With(context...).Infoln(tt.args...)
-			logger.With(context...).Warnln(tt.args...)
-			logger.With(context...).Errorln(tt.args...)
-			logger.With(context...).DPanicln(tt.args...)
+			logger.CloneWith(context...).Debugln(tt.args...)
+			logger.CloneWith(context...).Infoln(tt.args...)
+			logger.CloneWith(context...).Warnln(tt.args...)
+			logger.CloneWith(context...).Errorln(tt.args...)
+			logger.CloneWith(context...).DPanicln(tt.args...)
 
 			expected := make([]observer.LoggedEntry, 5)
 			for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {


### PR DESCRIPTION
Resolves #832.

Please let me know if this is something you would consider? If so perhaps the behaviour of `WithOptions` should also be changed not to clone and a `CloneWithOptions` method added.