### PR TITLE
Remove mention to LINTABLE_MINOR_VERSIONS since it is gone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,11 +32,6 @@ make test
 make lint
 ```
 
-If you're not using the minor version of Go specified in the Makefile's
-`LINTABLE_MINOR_VERSIONS` variable, `make lint` doesn't do anything. This is
-fine, but it means that you'll only discover lint failures after you open your
-pull request.
-
 ## Making Changes
 
 Start by creating a new branch for your changes:


### PR DESCRIPTION
This variable got removed at https://github.com/uber-go/zap/commit/4065717ebf23209381b