### PR TITLE
Replace os.TempDir usage with t.TempDir

### DIFF
--- a/stacktrace_ext_test.go
+++ b/stacktrace_ext_test.go
@@ -160,12 +160,11 @@ func verifyNoZap(t *testing.T, logs string) {
 }
 
 func withGoPath(t *testing.T, f func(goPath string)) {
-	goPath, err := os.MkdirTemp("", "gopath")
-	require.NoError(t, err, "Failed to create temporary directory for GOPATH")
-	//defer os.RemoveAll(goPath)
+	goPath := filepath.Join(t.TempDir(), "gopath")
 
+	origGoPath := os.Getenv("GOPATH")
 	os.Setenv("GOPATH", goPath)
-	defer os.Setenv("GOPATH", os.Getenv("GOPATH"))
+	defer os.Setenv("GOPATH", origGoPath)
 
 	f(goPath)
 }

--- a/stacktrace_ext_test.go
+++ b/stacktrace_ext_test.go
@@ -161,7 +161,7 @@ func verifyNoZap(t *testing.T, logs string) {
 
 func withGoPath(t *testing.T, f func(goPath string)) {
 	goPath := filepath.Join(t.TempDir(), "gopath")
-	t.Setenv(goPath)
+	t.Setenv("GOPATH", goPath)
 
 	f(goPath)
 }

--- a/stacktrace_ext_test.go
+++ b/stacktrace_ext_test.go
@@ -161,10 +161,7 @@ func verifyNoZap(t *testing.T, logs string) {
 
 func withGoPath(t *testing.T, f func(goPath string)) {
 	goPath := filepath.Join(t.TempDir(), "gopath")
-
-	origGoPath := os.Getenv("GOPATH")
-	os.Setenv("GOPATH", goPath)
-	defer os.Setenv("GOPATH", origGoPath)
+	t.Setenv(goPath)
 
 	f(goPath)
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -21,10 +21,8 @@
 package zap
 
 import (
-	"encoding/hex"
 	"errors"
 	"io"
-	"math/rand"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -50,7 +48,7 @@ func TestOpenNoPaths(t *testing.T) {
 }
 
 func TestOpen(t *testing.T) {
-	tempName := tempFileName("", "zap-open-test")
+	tempName := filepath.Join(t.TempDir(), "test.log")
 	assert.False(t, fileExists(tempName))
 	require.True(t, strings.HasPrefix(tempName, "/"), "Expected absolute temp file path.")
 
@@ -169,12 +167,6 @@ func TestCombineWriteSyncers(t *testing.T) {
 	tw := &testWriter{"test", t}
 	w := CombineWriteSyncers(tw)
 	w.Write([]byte("test"))
-}
-
-func tempFileName(prefix, suffix string) string {
-	randBytes := make([]byte, 16)
-	rand.Read(randBytes)
-	return filepath.Join(os.TempDir(), prefix+hex.EncodeToString(randBytes)+suffix)
 }
 
 func fileExists(name string) bool {

--- a/zapcore/buffered_write_syncer_bench_test.go
+++ b/zapcore/buffered_write_syncer_bench_test.go
@@ -30,12 +30,11 @@ import (
 
 func BenchmarkBufferedWriteSyncer(b *testing.B) {
 	b.Run("write file with buffer", func(b *testing.B) {
-		file, err := os.CreateTemp("", "test.log")
+		file, err := os.CreateTemp(b.TempDir(), "test.log")
 		require.NoError(b, err)
 
 		defer func() {
 			assert.NoError(b, file.Close())
-			assert.NoError(b, os.Remove(file.Name()))
 		}()
 
 		w := &BufferedWriteSyncer{

--- a/zapcore/buffered_write_syncer_bench_test.go
+++ b/zapcore/buffered_write_syncer_bench_test.go
@@ -30,7 +30,7 @@ import (
 
 func BenchmarkBufferedWriteSyncer(b *testing.B) {
 	b.Run("write file with buffer", func(b *testing.B) {
-		file, err := os.CreateTemp("", "log")
+		file, err := os.CreateTemp("", "test.log")
 		require.NoError(b, err)
 
 		defer func() {

--- a/zapcore/core_test.go
+++ b/zapcore/core_test.go
@@ -67,9 +67,8 @@ func TestNopCore(t *testing.T) {
 }
 
 func TestIOCore(t *testing.T) {
-	temp, err := os.CreateTemp("", "zapcore-test-iocore")
-	require.NoError(t, err, "Failed to create temp file.")
-	defer os.Remove(temp.Name())
+	temp, err := os.CreateTemp(t.TempDir(), "test.log")
+	require.NoError(t, err)
 
 	// Drop timestamps for simpler assertions (timestamp encoding is tested
 	// elsewhere).

--- a/zapcore/write_syncer_bench_test.go
+++ b/zapcore/write_syncer_bench_test.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/internal/ztest"
 )
 
@@ -76,10 +76,8 @@ func BenchmarkMultiWriteSyncer(b *testing.B) {
 
 func BenchmarkWriteSyncer(b *testing.B) {
 	b.Run("write file with no buffer", func(b *testing.B) {
-		file, err := os.CreateTemp("", "log")
-		assert.NoError(b, err)
-		defer file.Close()
-		defer os.Remove(file.Name())
+		file, err := os.CreateTemp(b.TempDir(), "test.log")
+		require.NoError(b, err)
 
 		w := AddSync(file)
 		b.ResetTimer()


### PR DESCRIPTION
Current tests can leave files around if tests fail, and even though they
use rand, it's not seeded, different runs can share the same output file
which causes other failures (e.g., file exists when it's not expected
to).  Avoid this by using  t.TempDir which automatically removed after
tests have run.