### PR TITLE
Logger, SugaredLogger: Add Level method

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -183,6 +183,13 @@ func (log *Logger) With(fields ...Field) *Logger {
 	return l
 }
 
+// Level reports the minimum enabled level for this logger.
+//
+// For NopLoggers, this is [zapcore.InvalidLevel].
+func (log *Logger) Level() zapcore.Level {
+	return zapcore.LevelOf(log.core)
+}
+
 // Check returns a CheckedEntry if logging a message at the specified level
 // is enabled. It's a completely optional optimization; in high-performance
 // applications, Check can help avoid allocating a slice to hold fields.

--- a/logger_test.go
+++ b/logger_test.go
@@ -83,6 +83,33 @@ func TestLoggerAtomicLevel(t *testing.T) {
 	})
 }
 
+func TestLoggerLevel(t *testing.T) {
+	levels := []zapcore.Level{
+		DebugLevel,
+		InfoLevel,
+		WarnLevel,
+		ErrorLevel,
+		DPanicLevel,
+		PanicLevel,
+		FatalLevel,
+	}
+
+	for _, lvl := range levels {
+		lvl := lvl
+		t.Run(lvl.String(), func(t *testing.T) {
+			t.Parallel()
+
+			core, _ := observer.New(lvl)
+			log := New(core)
+			assert.Equal(t, lvl, log.Level())
+		})
+	}
+
+	t.Run("Nop", func(t *testing.T) {
+		assert.Equal(t, zapcore.InvalidLevel, NewNop().Level())
+	})
+}
+
 func TestLoggerInitialFields(t *testing.T) {
 	fieldOpts := opts(Fields(Int("foo", 42), String("bar", "baz")))
 	withLogger(t, DebugLevel, fieldOpts, func(logger *Logger, logs *observer.ObservedLogs) {

--- a/sugar.go
+++ b/sugar.go
@@ -114,6 +114,13 @@ func (s *SugaredLogger) With(args ...interface{}) *SugaredLogger {
 	return &SugaredLogger{base: s.base.With(s.sweetenFields(args)...)}
 }
 
+// Level reports the minimum enabled level for this logger.
+//
+// For NopLoggers, this is [zapcore.InvalidLevel].
+func (s *SugaredLogger) Level() zapcore.Level {
+	return zapcore.LevelOf(s.base.core)
+}
+
 // Debug uses fmt.Sprint to construct and log a message.
 func (s *SugaredLogger) Debug(args ...interface{}) {
 	s.log(DebugLevel, "", args, nil)

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -139,6 +139,35 @@ func TestSugarWith(t *testing.T) {
 	}
 }
 
+func TestSugaredLoggerLevel(t *testing.T) {
+	levels := []zapcore.Level{
+		DebugLevel,
+		InfoLevel,
+		WarnLevel,
+		ErrorLevel,
+		DPanicLevel,
+		PanicLevel,
+		FatalLevel,
+	}
+
+	for _, lvl := range levels {
+		lvl := lvl
+		t.Run(lvl.String(), func(t *testing.T) {
+			t.Parallel()
+
+			core, _ := observer.New(lvl)
+			log := New(core).Sugar()
+			assert.Equal(t, lvl, log.Level())
+		})
+	}
+
+	t.Run("Nop", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, zapcore.InvalidLevel, NewNop().Sugar().Level())
+	})
+}
+
 func TestSugarFieldsInvalidPairs(t *testing.T) {
 	withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
 		logger.With(42, "foo", []string{"bar"}, "baz").Info("")


### PR DESCRIPTION
Add a `Level() Level` method on Logger and SugaredLogger
that reports the current minimum enabled log level for the logger.

This relies on the zapcore.LevelOf function added in #1147.

Resolves #1144
Depends on #1147
