### PR TITLE
Add issue template for questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: Questions
+about: Need help using Zap
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Please use our [Discussions page](https://github.com/uber-go/zap/discussions) to ask for help on how to use Zap**


### PR DESCRIPTION
We're seeing some issues get filed that are being converted to
Discussions manually. Let's add a template on question so that
we can redirect folks to Discussions page directly.