### PR TITLE
doc(SugaredLogger): Document print, printf, and println methods

### DIFF
--- a/sugar.go
+++ b/sugar.go
@@ -122,74 +122,88 @@ func (s *SugaredLogger) Level() zapcore.Level {
 	return zapcore.LevelOf(s.base.core)
 }
 
-// Debug uses fmt.Sprint to construct and log a message.
+// Debug logs the provided arguments at [DebugLevel].
+// Spaces are added between arguments when neither is a string.
 func (s *SugaredLogger) Debug(args ...interface{}) {
 	s.log(DebugLevel, "", args, nil)
 }
 
-// Info uses fmt.Sprint to construct and log a message.
+// Info logs the provided arguments at [InfoLevel].
+// Spaces are added between arguments when neither is a string.
 func (s *SugaredLogger) Info(args ...interface{}) {
 	s.log(InfoLevel, "", args, nil)
 }
 
-// Warn uses fmt.Sprint to construct and log a message.
+// Warn logs the provided arguments at [WarnLevel].
+// Spaces are added between arguments when neither is a string.
 func (s *SugaredLogger) Warn(args ...interface{}) {
 	s.log(WarnLevel, "", args, nil)
 }
 
-// Error uses fmt.Sprint to construct and log a message.
+// Error logs the provided arguments at [ErrorLevel].
+// Spaces are added between arguments when neither is a string.
 func (s *SugaredLogger) Error(args ...interface{}) {
 	s.log(ErrorLevel, "", args, nil)
 }
 
-// DPanic uses fmt.Sprint to construct and log a message. In development, the
-// logger then panics. (See DPanicLevel for details.)
+// DPanic logs the provided arguments at [DPanicLevel].
+// In development, the logger then panics. (See [DPanicLevel] for details.)
+// Spaces are added between arguments when neither is a string.
 func (s *SugaredLogger) DPanic(args ...interface{}) {
 	s.log(DPanicLevel, "", args, nil)
 }
 
-// Panic uses fmt.Sprint to construct and log a message, then panics.
+// Panic constructs a message with the provided arguments and panics.
+// Spaces are added between arguments when neither is a string.
 func (s *SugaredLogger) Panic(args ...interface{}) {
 	s.log(PanicLevel, "", args, nil)
 }
 
-// Fatal uses fmt.Sprint to construct and log a message, then calls os.Exit.
+// Fatal constructs a message with the provided arguments and calls os.Exit.
+// Spaces are added between arguments when neither is a string.
 func (s *SugaredLogger) Fatal(args ...interface{}) {
 	s.log(FatalLevel, "", args, nil)
 }
 
-// Debugf uses fmt.Sprintf to log a templated message.
+// Debugf formats the message according to the format specifier
+// and logs it at [DebugLevel].
 func (s *SugaredLogger) Debugf(template string, args ...interface{}) {
 	s.log(DebugLevel, template, args, nil)
 }
 
-// Infof uses fmt.Sprintf to log a templated message.
+// Infof formats the message according to the format specifier
+// and logs it at [InfoLevel].
 func (s *SugaredLogger) Infof(template string, args ...interface{}) {
 	s.log(InfoLevel, template, args, nil)
 }
 
-// Warnf uses fmt.Sprintf to log a templated message.
+// Warnf formats the message according to the format specifier
+// and logs it at [WarnLevel].
 func (s *SugaredLogger) Warnf(template string, args ...interface{}) {
 	s.log(WarnLevel, template, args, nil)
 }
 
-// Errorf uses fmt.Sprintf to log a templated message.
+// Errorf formats the message according to the format specifier
+// and logs it at [ErrorLevel].
 func (s *SugaredLogger) Errorf(template string, args ...interface{}) {
 	s.log(ErrorLevel, template, args, nil)
 }
 
-// DPanicf uses fmt.Sprintf to log a templated message. In development, the
-// logger then panics. (See DPanicLevel for details.)
+// DPanicf formats the message according to the format specifier
+// and logs it at [DPanicLevel].
+// In development, the logger then panics. (See [DPanicLevel] for details.)
 func (s *SugaredLogger) DPanicf(template string, args ...interface{}) {
 	s.log(DPanicLevel, template, args, nil)
 }
 
-// Panicf uses fmt.Sprintf to log a templated message, then panics.
+// Panicf formats the message according to the format specifier
+// and panics.
 func (s *SugaredLogger) Panicf(template string, args ...interface{}) {
 	s.log(PanicLevel, template, args, nil)
 }
 
-// Fatalf uses fmt.Sprintf to log a templated message, then calls os.Exit.
+// Fatalf formats the message according to the format specifier
+// and calls os.Exit.
 func (s *SugaredLogger) Fatalf(template string, args ...interface{}) {
 	s.log(FatalLevel, template, args, nil)
 }
@@ -241,38 +255,45 @@ func (s *SugaredLogger) Fatalw(msg string, keysAndValues ...interface{}) {
 	s.log(FatalLevel, msg, nil, keysAndValues)
 }
 
-// Debugln uses fmt.Sprintln to construct and log a message.
+// Debugln logs a message at [DebugLevel].
+// Spaces are always added between arguments.
 func (s *SugaredLogger) Debugln(args ...interface{}) {
 	s.logln(DebugLevel, args, nil)
 }
 
-// Infoln uses fmt.Sprintln to construct and log a message.
+// Infoln logs a message at [InfoLevel].
+// Spaces are always added between arguments.
 func (s *SugaredLogger) Infoln(args ...interface{}) {
 	s.logln(InfoLevel, args, nil)
 }
 
-// Warnln uses fmt.Sprintln to construct and log a message.
+// Warnln logs a message at [WarnLevel].
+// Spaces are always added between arguments.
 func (s *SugaredLogger) Warnln(args ...interface{}) {
 	s.logln(WarnLevel, args, nil)
 }
 
-// Errorln uses fmt.Sprintln to construct and log a message.
+// Errorln logs a message at [ErrorLevel].
+// Spaces are always added between arguments.
 func (s *SugaredLogger) Errorln(args ...interface{}) {
 	s.logln(ErrorLevel, args, nil)
 }
 
-// DPanicln uses fmt.Sprintln to construct and log a message. In development, the
-// logger then panics. (See DPanicLevel for details.)
+// DPanicln logs a message at [DPanicLevel].
+// In development, the logger then panics. (See [DPanicLevel] for details.)
+// Spaces are always added between arguments.
 func (s *SugaredLogger) DPanicln(args ...interface{}) {
 	s.logln(DPanicLevel, args, nil)
 }
 
-// Panicln uses fmt.Sprintln to construct and log a message, then panics.
+// Panicln logs a message at [PanicLevel] and panics.
+// Spaces are always added between arguments.
 func (s *SugaredLogger) Panicln(args ...interface{}) {
 	s.logln(PanicLevel, args, nil)
 }
 
-// Fatalln uses fmt.Sprintln to construct and log a message, then calls os.Exit.
+// Fatalln logs a message at [FatalLevel] and calls os.Exit.
+// Spaces are always added between arguments.
 func (s *SugaredLogger) Fatalln(args ...interface{}) {
 	s.logln(FatalLevel, args, nil)
 }


### PR DESCRIPTION
Documentation for `SugaredLogger.{Debug,Info,Warn,..}{,f,ln}`
mostly just points peoplt to fmt.Sprint, fmt.Sprintf, and fmt.Println.
This isn't a great experience from a documentation accessibility
point of view.

Document each of these methods independently.
This leads to some duplicated documentation,
but in exchange it makes the documentation more accessible.

A user in an IDE will see meaningful documentation for these methods
rather than "look up how fmt.Sprint" works.

Relates to #1231
