### PR TITLE
ci: Set up dependabot for GH actions and tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Since Zap is a library, we don't want to update its dependency requirements
+  # regularly--not until we need a newer version of a dependency for a feature
+  # or specific fix.
+  # This way, users of Zap aren't forced to upgrade all their transitive
+  # dependencies every time they upgrade Zap.
+  #
+  # However, we do want to regularly update dependencies used inside the tools
+  # submodule because that holds linters and other development tools.
+  - package-ecosystem: "gomod"
+    directory: "/tools"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Sets up dependabot to update GitHub Actions
so that we're not running severely outdated actions (#1235)
and catching up in one go.

Similarly, sets up dependabot for go.mod updates
of the tools submodule so we get the latest staticcheck.

Note that this does NOT add dependabot for Zap itself.
The reasoning for this is that Zap is a library.
If we keep require latest versions of all of Zap's dependencies,
then users of Zap will be forced to upgrade to latest versions
of all transitive dependencies, even if they don't want to/can't.
