### PR TITLE
TestLevelFlag: Don't print to stderr

### DIFF
--- a/flag_test.go
+++ b/flag_test.go
@@ -49,6 +49,7 @@ func (tc flagTestCase) runImplicitSet(t testing.TB) {
 func (tc flagTestCase) runExplicitSet(t testing.TB) {
 	var lvl zapcore.Level
 	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.SetOutput(io.Discard)
 	set.Var(&lvl, "level", "minimum enabled logging level")
 	tc.run(t, set, &lvl)
 }


### PR DESCRIPTION
If you run `go test` in the root of Zap right now,
the output includes:

    invalid value "unknown" for flag -level: unrecognized level: "unknown"
    Usage of test:
      -level value
            minimum enabled logging level

This comes from TestLevelFlag which instantiates a flag.FlagSet.
By default, flag.FlagSet will print messages to stderr,
which is why we see this output.

Switch it to discard its output like other FlagSets
instantiated in other similar tests in the same file.
