### PR TITLE
slog: Ignore frames with a zero PC

### DIFF
--- a/exp/zapslog/slog.go
+++ b/exp/zapslog/slog.go
@@ -144,14 +144,16 @@ func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
 		return nil
 	}
 
-	if h.addSource {
+	if h.addSource && record.PC != 0 {
 		frame, _ := runtime.CallersFrames([]uintptr{record.PC}).Next()
-		ce.Caller = zapcore.EntryCaller{
-			Defined:  true,
-			PC:       frame.PC,
-			File:     frame.File,
-			Line:     frame.Line,
-			Function: frame.Function,
+		if frame.PC != 0 {
+			ce.Caller = zapcore.EntryCaller{
+				Defined:  true,
+				PC:       frame.PC,
+				File:     frame.File,
+				Line:     frame.Line,
+				Function: frame.Function,
+			}
 		}
 	}
 


### PR DESCRIPTION
From [the docs](https://pkg.go.dev/golang.org/x/exp/slog#Handler), referring to handling [`slog.Record`](https://pkg.go.dev/golang.org/x/exp/slog#Record):

> If r.PC is zero, ignore it.

This change will not add caller information if either (a) the `slog.Record` in question has a zero value PC, or (b) `runtime.CallersFrames` returns a frame with a zero value PC (defensive, since we did not produce the PC value).