### PR TITLE
Create int64 epoch milliseconds timestamp encoder

### DIFF
--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -108,6 +108,13 @@ func EpochMillisTimeEncoder(t time.Time, enc PrimitiveArrayEncoder) {
 	enc.AppendFloat64(millis)
 }
 
+// EpochMillisInt64TimeEncoder serializes a time.Time to an integer number of
+// milliseconds since the Unix epoch.
+func EpochMillisInt64TimeEncoder(t time.Time, enc PrimitiveArrayEncoder) {
+	millis := t.UnixMilli()
+	enc.AppendInt64(millis)
+}
+
 // EpochNanosTimeEncoder serializes a time.Time to an integer number of
 // nanoseconds since the Unix epoch.
 func EpochNanosTimeEncoder(t time.Time, enc PrimitiveArrayEncoder) {

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -474,6 +474,11 @@ func TestJSONEncoderTimeArrays(t *testing.T) {
 			want:    `[1008720000000,1040169600000,1071619200000]`,
 		},
 		{
+			desc:    "epoch millis int64",
+			encoder: EpochMillisInt64TimeEncoder,
+			want:    `[1008720000000,1040169600000,1071619200000]`,
+		},
+		{
 			desc:    "iso8601",
 			encoder: ISO8601TimeEncoder,
 			want:    `["2001-12-19T00:00:00.000Z","2002-12-18T00:00:00.000Z","2003-12-17T00:00:00.000Z"]`,


### PR DESCRIPTION
This is a counterpart to the `MillisDurationEncoder`. Some log consumers cannot handle Unix timestamps with fractional parts, and this encoder, and this encoder can serve as a convenient workaround in such cases.