### PR TITLE
Add Name() function to Logger struct

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -281,6 +281,12 @@ func (log *Logger) Core() zapcore.Core {
 	return log.core
 }
 
+// Name returns the Logger's underlying name.
+// Return empty string for unnamed Logger.
+func (log *Logger) Name() string {
+	return log.name
+}
+
 func (log *Logger) clone() *Logger {
 	copy := *log
 	return &copy

--- a/logger.go
+++ b/logger.go
@@ -281,8 +281,8 @@ func (log *Logger) Core() zapcore.Core {
 	return log.core
 }
 
-// Name returns the Logger's underlying name.
-// Return empty string for unnamed Logger.
+// Name returns the Logger's underlying name,
+// or an empty string if the logger is unnamed.
 func (log *Logger) Name() string {
 	return log.name
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -340,7 +340,8 @@ func TestLoggerNames(t *testing.T) {
 			}
 			log.Info("")
 			require.Equal(t, 1, logs.Len(), "Expected only one log entry to be written.")
-			assert.Equal(t, tt.expected, logs.AllUntimed()[0].LoggerName, "Unexpected logger name.")
+			assert.Equal(t, tt.expected, logs.AllUntimed()[0].LoggerName, "Unexpected logger name from entry.")
+			assert.Equal(t, tt.expected, log.Name(), "Unexpected logger name.")
 		})
 		withSugar(t, DebugLevel, nil, func(log *SugaredLogger, logs *observer.ObservedLogs) {
 			for _, n := range tt.names {
@@ -348,7 +349,8 @@ func TestLoggerNames(t *testing.T) {
 			}
 			log.Infow("")
 			require.Equal(t, 1, logs.Len(), "Expected only one log entry to be written.")
-			assert.Equal(t, tt.expected, logs.AllUntimed()[0].LoggerName, "Unexpected logger name.")
+			assert.Equal(t, tt.expected, logs.AllUntimed()[0].LoggerName, "Unexpected logger name from entry.")
+			assert.Equal(t, tt.expected, log.base.Name(), "Unexpected logger name.")
 		})
 	}
 }


### PR DESCRIPTION
Related to https://github.com/uber-go/zap/issues/1200

This PR add `Name()` function to Logger struct which will return the Logger's Name.
By default, Logger's name is empty if not set so for Unnamed Logger it will return empty string.

Please let me know which file test that I should include for testing this function and I will include the unit test.
Thank you.