### PR TITLE
Make DPanic fatal in zaptest

### DIFF
--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -138,6 +138,18 @@ func TestTestLoggerErrorOutput(t *testing.T) {
 	}
 }
 
+func TestDPanic(t *testing.T) {
+	log := NewLogger(t)
+	assert.Panics(t, func() {
+		log.DPanic("foo")
+	})
+
+	log = NewLogger(t, Development(false))
+	assert.NotPanics(t, func() {
+		log.DPanic("foo")
+	})
+}
+
 // testLogSpy is a testing.TB that captures logged messages.
 type testLogSpy struct {
 	testing.TB


### PR DESCRIPTION
The intention of `DPanic` is to catch errors that should never happen. Unless you added `zaptest.WrapOptions(zap.Development())`, they were previously silently ignored.

This is a breaking change. But you can opt out of this using `zaptest.Development(false)` option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to disable development mode for the logger.
- **Documentation**
  - Updated logger documentation to reflect the new default behavior and the option to opt out of development mode.
- **Tests**
  - Added tests to verify logger behavior when development mode is enabled or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->