### PR TITLE
Swap expected and got fields

### DIFF
--- a/exp/zapfield/zapfield_test.go
+++ b/exp/zapfield/zapfield_test.go
@@ -47,8 +47,8 @@ func TestFieldConstructors(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		field  zap.Field
 		expect zap.Field
+		field  zap.Field
 	}{
 		{"Str", zap.Field{Type: zapcore.StringType, Key: "test key", String: "test value"}, Str(key, value)},
 		{"Strs", zap.Array("test key", stringArray[MyValue]{"test value 1", "test value 2"}), Strs(key, values)},


### PR DESCRIPTION
This is just a small nit from #1281 - I think the expected and got fields of the test case structs are flipped.