### PR TITLE
Optimize zap.Any to allocate less memory on stack

### DIFF
--- a/field.go
+++ b/field.go
@@ -418,132 +418,263 @@ func Inline(val zapcore.ObjectMarshaler) Field {
 // them. To minimize surprises, []byte values are treated as binary blobs, byte
 // values are treated as uint8, and runes are always treated as integers.
 func Any(key string, value interface{}) Field {
+	// To work around go compiler assigning unreasonably large space on stack
+	// (4kb, one `Field` per arm of the switch statement) which can trigger
+	// performance degradation if `Any` is used in a brand new goroutine.
+	var f func(key string) Field
 	switch val := value.(type) {
 	case zapcore.ObjectMarshaler:
-		return Object(key, val)
+		f = func(key string) Field {
+			return Object(key, val)
+		}
 	case zapcore.ArrayMarshaler:
-		return Array(key, val)
+		f = func(key string) Field {
+			return Array(key, val)
+		}
 	case bool:
-		return Bool(key, val)
+		f = func(key string) Field {
+			return Bool(key, val)
+		}
 	case *bool:
-		return Boolp(key, val)
+		f = func(key string) Field {
+			return Boolp(key, val)
+		}
 	case []bool:
-		return Bools(key, val)
+		f = func(key string) Field {
+			return Bools(key, val)
+		}
 	case complex128:
-		return Complex128(key, val)
+		f = func(key string) Field {
+			return Complex128(key, val)
+		}
 	case *complex128:
-		return Complex128p(key, val)
+		f = func(key string) Field {
+			return Complex128p(key, val)
+		}
 	case []complex128:
-		return Complex128s(key, val)
+		f = func(key string) Field {
+			return Complex128s(key, val)
+		}
 	case complex64:
-		return Complex64(key, val)
+		f = func(key string) Field {
+			return Complex64(key, val)
+		}
 	case *complex64:
-		return Complex64p(key, val)
+		f = func(key string) Field {
+			return Complex64p(key, val)
+		}
 	case []complex64:
-		return Complex64s(key, val)
+		f = func(key string) Field {
+			return Complex64s(key, val)
+		}
 	case float64:
-		return Float64(key, val)
+		f = func(key string) Field {
+			return Float64(key, val)
+		}
 	case *float64:
-		return Float64p(key, val)
+		f = func(key string) Field {
+			return Float64p(key, val)
+		}
 	case []float64:
-		return Float64s(key, val)
+		f = func(key string) Field {
+			return Float64s(key, val)
+		}
 	case float32:
-		return Float32(key, val)
+		f = func(key string) Field {
+			return Float32(key, val)
+		}
 	case *float32:
-		return Float32p(key, val)
+		f = func(key string) Field {
+			return Float32p(key, val)
+		}
 	case []float32:
-		return Float32s(key, val)
+		f = func(key string) Field {
+			return Float32s(key, val)
+		}
 	case int:
-		return Int(key, val)
+		f = func(key string) Field {
+			return Int(key, val)
+		}
 	case *int:
-		return Intp(key, val)
+		f = func(key string) Field {
+			return Intp(key, val)
+		}
 	case []int:
-		return Ints(key, val)
+		f = func(key string) Field {
+			return Ints(key, val)
+		}
 	case int64:
-		return Int64(key, val)
+		f = func(key string) Field {
+			return Int64(key, val)
+		}
 	case *int64:
-		return Int64p(key, val)
+		f = func(key string) Field {
+			return Int64p(key, val)
+		}
 	case []int64:
-		return Int64s(key, val)
+		f = func(key string) Field {
+			return Int64s(key, val)
+		}
 	case int32:
-		return Int32(key, val)
+		f = func(key string) Field {
+			return Int32(key, val)
+		}
 	case *int32:
-		return Int32p(key, val)
+		f = func(key string) Field {
+			return Int32p(key, val)
+		}
 	case []int32:
-		return Int32s(key, val)
+		f = func(key string) Field {
+			return Int32s(key, val)
+		}
 	case int16:
-		return Int16(key, val)
+		f = func(key string) Field {
+			return Int16(key, val)
+		}
 	case *int16:
-		return Int16p(key, val)
+		f = func(key string) Field {
+			return Int16p(key, val)
+		}
 	case []int16:
-		return Int16s(key, val)
+		f = func(key string) Field {
+			return Int16s(key, val)
+		}
 	case int8:
-		return Int8(key, val)
+		f = func(key string) Field {
+			return Int8(key, val)
+		}
 	case *int8:
-		return Int8p(key, val)
+		f = func(key string) Field {
+			return Int8p(key, val)
+		}
 	case []int8:
-		return Int8s(key, val)
+		f = func(key string) Field {
+			return Int8s(key, val)
+		}
 	case string:
-		return String(key, val)
+		f = func(key string) Field {
+			return String(key, val)
+		}
 	case *string:
-		return Stringp(key, val)
+		f = func(key string) Field {
+			return Stringp(key, val)
+		}
 	case []string:
-		return Strings(key, val)
+		f = func(key string) Field {
+			return Strings(key, val)
+		}
 	case uint:
-		return Uint(key, val)
+		f = func(key string) Field {
+			return Uint(key, val)
+		}
 	case *uint:
-		return Uintp(key, val)
+		f = func(key string) Field {
+			return Uintp(key, val)
+		}
 	case []uint:
-		return Uints(key, val)
+		f = func(key string) Field {
+			return Uints(key, val)
+		}
 	case uint64:
-		return Uint64(key, val)
+		f = func(key string) Field {
+			return Uint64(key, val)
+		}
 	case *uint64:
-		return Uint64p(key, val)
+		f = func(key string) Field {
+			return Uint64p(key, val)
+		}
 	case []uint64:
-		return Uint64s(key, val)
+		f = func(key string) Field {
+			return Uint64s(key, val)
+		}
 	case uint32:
-		return Uint32(key, val)
+		f = func(key string) Field {
+			return Uint32(key, val)
+		}
 	case *uint32:
-		return Uint32p(key, val)
+		f = func(key string) Field {
+			return Uint32p(key, val)
+		}
 	case []uint32:
-		return Uint32s(key, val)
+		f = func(key string) Field {
+			return Uint32s(key, val)
+		}
 	case uint16:
-		return Uint16(key, val)
+		f = func(key string) Field {
+			return Uint16(key, val)
+		}
 	case *uint16:
-		return Uint16p(key, val)
+		f = func(key string) Field {
+			return Uint16p(key, val)
+		}
 	case []uint16:
-		return Uint16s(key, val)
+		f = func(key string) Field {
+			return Uint16s(key, val)
+		}
 	case uint8:
-		return Uint8(key, val)
+		f = func(key string) Field {
+			return Uint8(key, val)
+		}
 	case *uint8:
-		return Uint8p(key, val)
+		f = func(key string) Field {
+			return Uint8p(key, val)
+		}
 	case []byte:
-		return Binary(key, val)
+		f = func(key string) Field {
+			return Binary(key, val)
+		}
 	case uintptr:
-		return Uintptr(key, val)
+		f = func(key string) Field {
+			return Uintptr(key, val)
+		}
 	case *uintptr:
-		return Uintptrp(key, val)
+		f = func(key string) Field {
+			return Uintptrp(key, val)
+		}
 	case []uintptr:
-		return Uintptrs(key, val)
+		f = func(key string) Field {
+			return Uintptrs(key, val)
+		}
 	case time.Time:
-		return Time(key, val)
+		f = func(key string) Field {
+			return Time(key, val)
+		}
 	case *time.Time:
-		return Timep(key, val)
+		f = func(key string) Field {
+			return Timep(key, val)
+		}
 	case []time.Time:
-		return Times(key, val)
+		f = func(key string) Field {
+			return Times(key, val)
+		}
 	case time.Duration:
-		return Duration(key, val)
+		f = func(key string) Field {
+			return Duration(key, val)
+		}
 	case *time.Duration:
-		return Durationp(key, val)
+		f = func(key string) Field {
+			return Durationp(key, val)
+		}
 	case []time.Duration:
-		return Durations(key, val)
+		f = func(key string) Field {
+			return Durations(key, val)
+		}
 	case error:
-		return NamedError(key, val)
+		f = func(key string) Field {
+			return NamedError(key, val)
+		}
 	case []error:
-		return Errors(key, val)
+		f = func(key string) Field {
+			return Errors(key, val)
+		}
 	case fmt.Stringer:
-		return Stringer(key, val)
+		f = func(key string) Field {
+			return Stringer(key, val)
+		}
 	default:
-		return Reflect(key, val)
+		f = func(key string) Field {
+			return Reflect(key, val)
+		}
 	}
+	return f(key)
 }


### PR DESCRIPTION
This is an alternative to #1301 and #1302. It's not as fast as these two options, but it still gives us half the stack reduction without the `unsafe` usage.

This halves the stack usage of `Any`:
```
 field.go:420          0xd16c3                 4881ecf8120000          SUBQ $0x12f8, SP   // 4856
```
to
```
  field.go:420          0xefb80                 4881ec40060000                  SUBQ $0x640, SP   // 1600
```

Interestingly it seems that on both arm64 and amd64 the new code, with the closure, is faster than the plain old switch.
We do see a ~5-10ns delay on `Any` creation if it's used without `logger`, but that's minimal and not realistic.

Bunch of credit for this goes to @cdvr1993, we started independently, I was about to give up but the conversations pushed me forward. In the end he ended up going into a more advanced land where I dare not to enter.

Longer version:

We have identified an issue where zap.Any can cause performance degradation due to stack size.

This is apparently cased by the compiler assigning 4.8kb (a zap.Field per arm of the switch statement) for zap.Any on stack. This can result in an unnecessary runtime.newstack+runtime.copystack. A github issue against Go language is pending.

This can be particularly bad if `zap.Any` was to be used in a new goroutine, since the default goroutine sizes can be as low as 2kb (it can vary depending on average stack size - see golang/go#18138).

This is an alternative to #1301, @cdvr and me were talking about this, and he inspired this idea with the closure.

By using a function and a closure we're able to reduce the size and remove the degradation.
At least on my laptop, this change result in a new performance gain, as all benchmarks show reduced time.

Results can be compared against #1311 

```
❯  go test -bench BenchmarkAny -benchmem -cpu 1

goos: darwin
goarch: arm64
pkg: go.uber.org/zap
BenchmarkAny/string/field-only/typed    158039978                7.462 ns/op           0 B/op          0 allocs/op
BenchmarkAny/string/field-only/any      58012468                20.14 ns/op            0 B/op          0 allocs/op
BenchmarkAny/string/log/typed            2925488               416.3 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log/any              2830414               431.0 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log-go/typed         1000000              1171 ns/op             112 B/op          3 allocs/op
BenchmarkAny/string/log-go/any           1239298               983.8 ns/op           128 B/op          3 allocs/op
BenchmarkAny/stringer/field-only/typed  160920868                7.869 ns/op           0 B/op          0 allocs/op
BenchmarkAny/stringer/field-only/any    39223164                28.51 ns/op            0 B/op          0 allocs/op
BenchmarkAny/stringer/log/typed          3149241               399.9 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log/any            2867043               417.4 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log-go/typed        986689              1154 ns/op             112 B/op          3 allocs/op
BenchmarkAny/stringer/log-go/any         1245523               955.0 ns/op           128 B/op          3 allocs/op
PASS
ok      go.uber.org/zap 21.593s
```

```
gotip test -bench BenchmarkAny -benchmem -cpu 1
goos: darwin
goarch: arm64
pkg: go.uber.org/zap
BenchmarkAny/string/field-only/typed    151253394                7.833 ns/op           0 B/op          0 allocs/op
BenchmarkAny/string/field-only/any      60105433                19.90 ns/op            0 B/op          0 allocs/op
BenchmarkAny/string/log/typed            2770897               452.2 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log/any              2647278               460.8 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log-go/typed         1000000              1215 ns/op             112 B/op          3 allocs/op
BenchmarkAny/string/log-go/any           1000000              1009 ns/op             128 B/op          3 allocs/op
BenchmarkAny/stringer/field-only/typed  153199767                7.809 ns/op           0 B/op          0 allocs/op
BenchmarkAny/stringer/field-only/any    41683854                28.83 ns/op            0 B/op          0 allocs/op
BenchmarkAny/stringer/log/typed          3031976               417.3 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log/any            2607433               455.7 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log-go/typed        992754              1188 ns/op             112 B/op          3 allocs/op
BenchmarkAny/stringer/log-go/any         1217839              1021 ns/op             128 B/op          3 allocs/op
PASS
ok      go.uber.org/zap 20.383s
```

```
 % go test -bench BenchmarkAny -benchmem -cpu 1
goos: linux
goarch: amd64
pkg: go.uber.org/zap
cpu: AMD EPYC 7B13
BenchmarkAny/string/field-only/typed    46764958                25.16 ns/op            0 B/op          0 allocs/op
BenchmarkAny/string/field-only/any      26826728                45.05 ns/op            0 B/op          0 allocs/op
BenchmarkAny/string/log/typed            1622241               733.7 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log/any              1478452               786.3 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log-go/typed          523507              2346 ns/op             112 B/op          3 allocs/op
BenchmarkAny/string/log-go/any            535293              2012 ns/op             128 B/op          3 allocs/op
BenchmarkAny/stringer/field-only/typed  48373972                24.67 ns/op            0 B/op          0 allocs/op
BenchmarkAny/stringer/field-only/any    20464256                58.78 ns/op            0 B/op          0 allocs/op
BenchmarkAny/stringer/log/typed          1793055               686.2 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log/any            1621790               985.2 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log-go/typed        531596              2301 ns/op             112 B/op          3 allocs/op
BenchmarkAny/stringer/log-go/any          581392              2010 ns/op             128 B/op          3 allocs/op
PASS
ok      go.uber.org/zap 20.424s
```
