### PR TITLE
Optimize zap.Any to use less memory on stack (inline version)

### DIFF
--- a/field.go
+++ b/field.go
@@ -418,15 +418,115 @@ func Inline(val zapcore.ObjectMarshaler) Field {
 // them. To minimize surprises, []byte values are treated as binary blobs, byte
 // values are treated as uint8, and runes are always treated as integers.
 func Any(key string, value interface{}) Field {
-	// To work around go compiler assigning unreasonably large space on stack
-	// (4kb, one `Field` per arm of the switch statement) which can trigger
-	// performance degradation if `Any` is used in a brand new goroutine.
+	// Most of the code below is to work around go compiler assigning unreasonably
+	// large space on stack (5kb, one `Field` per arm of the switch statement)
+	// which can trigger perf degradation if `Any` is used in a brand new goroutine.
+	f := Field{Key: key, Type: zapcore.ReflectType}
+	switch val := value.(type) {
+	case *bool:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *complex128:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *complex64:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *float64:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *float32:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *int:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *int64:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *int32:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *int16:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *int8:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *string:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *uint:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *uint64:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *uint32:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *uint16:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *uint8:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *uintptr:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *time.Time:
+		if val == nil {
+			return f
+		}
+		value = *val
+	case *time.Duration:
+		if val == nil {
+			return f
+		}
+		value = *val
+	}
+
 	var (
 		t     zapcore.FieldType
 		i     int64
 		s     string
 		iface any
 	)
+
 	switch val := value.(type) {
 	case zapcore.ObjectMarshaler:
 		t = zapcore.ObjectMarshalerType
@@ -441,225 +541,102 @@ func Any(key string, value interface{}) Field {
 		}
 		t = zapcore.BoolType
 		i = ival
-	case *bool:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		var ival int64
-		if *val {
-			ival = 1
-		}
-		t = zapcore.BoolType
-		i = ival
 	case []bool:
 		t = zapcore.ArrayMarshalerType
 		iface = bools(val)
 	case complex128:
 		t = zapcore.Complex128Type
 		iface = val
-	case *complex128:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Complex128Type
-		iface = *val
 	case []complex128:
 		t = zapcore.ArrayMarshalerType
 		iface = complex128s(val)
 	case complex64:
 		t = zapcore.Complex64Type
 		iface = val
-	case *complex64:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Complex64Type
-		iface = *val
 	case []complex64:
 		t = zapcore.ArrayMarshalerType
 		iface = complex64s(val)
 	case float64:
 		t = zapcore.Float64Type
 		i = int64(math.Float64bits(val))
-	case *float64:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Float64Type
-		i = int64(math.Float64bits(*val))
 	case []float64:
 		t = zapcore.ArrayMarshalerType
 		iface = float64s(val)
 	case float32:
 		t = zapcore.Float32Type
 		i = int64(math.Float32bits(val))
-	case *float32:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Float32Type
-		i = int64(math.Float32bits(*val))
 	case []float32:
 		t = zapcore.ArrayMarshalerType
 		iface = float32s(val)
 	case int:
 		t = zapcore.Int64Type
 		i = int64(val)
-	case *int:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Int64Type
-		i = int64(*val)
 	case []int:
 		t = zapcore.ArrayMarshalerType
 		iface = ints(val)
 	case int64:
 		t = zapcore.Int64Type
 		i = val
-	case *int64:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Int64Type
-		i = *val
 	case []int64:
 		t = zapcore.ArrayMarshalerType
 		iface = int64s(val)
 	case int32:
 		t = zapcore.Int32Type
 		i = int64(val)
-	case *int32:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Int32Type
-		i = int64(*val)
 	case []int32:
 		t = zapcore.ArrayMarshalerType
 		iface = int32s(val)
 	case int16:
 		t = zapcore.Int16Type
 		i = int64(val)
-	case *int16:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Int16Type
-		i = int64(*val)
 	case []int16:
 		t = zapcore.ArrayMarshalerType
 		iface = int16s(val)
 	case int8:
 		t = zapcore.Int8Type
 		i = int64(val)
-	case *int8:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Int8Type
-		i = int64(*val)
 	case []int8:
 		t = zapcore.ArrayMarshalerType
 		iface = int8s(val)
 	case string:
 		t = zapcore.StringType
 		s = val
-	case *string:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.StringType
-		s = *val
 	case []string:
 		t = zapcore.ArrayMarshalerType
 		iface = stringArray(val)
 	case uint:
 		t = zapcore.Uint64Type
 		i = int64(val)
-	case *uint:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Uint64Type
-		i = int64(*val)
 	case []uint:
 		t = zapcore.ArrayMarshalerType
 		iface = uints(val)
 	case uint64:
 		t = zapcore.Uint64Type
 		i = int64(val)
-	case *uint64:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Uint64Type
-		i = int64(*val)
 	case []uint64:
 		t = zapcore.ArrayMarshalerType
 		iface = uint64s(val)
 	case uint32:
 		t = zapcore.Uint32Type
 		i = int64(val)
-	case *uint32:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Uint32Type
-		i = int64(*val)
 	case []uint32:
 		t = zapcore.ArrayMarshalerType
 		iface = uint32s(val)
 	case uint16:
 		t = zapcore.Uint16Type
 		i = int64(val)
-	case *uint16:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Uint16Type
-		i = int64(*val)
 	case []uint16:
 		t = zapcore.ArrayMarshalerType
 		iface = uint16s(val)
 	case uint8:
 		t = zapcore.Uint8Type
 		i = int64(val)
-	case *uint8:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.Uint8Type
-		i = int64(*val)
 	case []byte:
 		t = zapcore.BinaryType
 		iface = val
 	case uintptr:
 		t = zapcore.UintptrType
 		i = int64(val)
-	case *uintptr:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.UintptrType
-		i = int64(*val)
 	case []uintptr:
 		t = zapcore.ArrayMarshalerType
 		iface = uintptrs(val)
@@ -672,32 +649,12 @@ func Any(key string, value interface{}) Field {
 		t = zapcore.TimeType
 		i = val.UnixNano()
 		iface = val.Location()
-	case *time.Time:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		if val.Before(_minTimeInt64) || val.After(_maxTimeInt64) {
-			t = zapcore.TimeFullType
-			iface = *val
-			break
-		}
-		t = zapcore.TimeType
-		i = val.UnixNano()
-		iface = val.Location()
 	case []time.Time:
 		t = zapcore.ArrayMarshalerType
 		iface = times(val)
 	case time.Duration:
 		t = zapcore.DurationType
 		i = int64(val)
-	case *time.Duration:
-		if val == nil {
-			t = zapcore.ReflectType
-			break
-		}
-		t = zapcore.DurationType
-		i = int64(*val)
 	case []time.Duration:
 		t = zapcore.ArrayMarshalerType
 		iface = durations(val)


### PR DESCRIPTION
This is an alternative to:
- #1301 and #1302, and #1304 - a series of PRs that are faster than this one. However, they rely on unsafe.
- #1303 - my own PR that uses closures to reduce the stack size by 60%.

This PR reduces the stack size from:
```
 field.go:420          0xd16c3                 4881ecf8120000          SUBQ $0x12f8, SP   // 4856
```
to
```
  field.go:420          0xcb603                 4881ecb8000000          SUBQ $0xb8, SP // 184
```
so by ~96%. More crucially, `zap.Any` is now as fast as correctly typed methods, like `zap.String`, etc.

The downside is the (slight) increase in the code maintenance - we inline and rely on the compiler correctly re-using small variable sizes. While this is not pretty, it feels safe - the changes were purely mechanical. Future changes and extensions should be easy to review.

Additionally, the new code is (slightly) faster in all cases since we remove 1-2 function calls from all paths. The "in new goroutine" path is most affected, as shown in the benchmarks below.

This was largely inspired by conversations with @cdvr1993. We started looking at this in parallel, but I would have given up if it wasn't for our conversations.
This particular version was inspired by an earlier version of #1304 - where I realized that @cdvr1993 is doing a similar dispatching mechanism that Zap already does via `zapcore` - a possible optimization.

Longer version:

We have identified an issue where zap.Any can cause performance degradation due to stack size.

This is apparently caused by the compiler assigning 4.8kb (a zap.Field per arm of the switch statement) for zap.Any on stack. This can result in an unnecessary runtime.newstack+runtime.copystack. A GitHub issue against Go language is pending.

This can be particularly bad if `zap.Any` was to be used in a new goroutine since the default goroutine sizes can be as low as 2kb (it can vary depending on average stack size - see golang/go#18138).

*Most crucially, `zap.Any` is now as fast as a direct dispatch like `zap.String`.*

Results can be compared with #1311 

```
❯  go test -bench BenchmarkAny -benchmem -cpu 1

goos: darwin
goarch: arm64
pkg: go.uber.org/zap
BenchmarkAny/string/field-only/typed    152969097                7.460 ns/op           0 B/op          0 allocs/op
BenchmarkAny/string/field-only/any      90461920                13.21 ns/op            0 B/op          0 allocs/op
BenchmarkAny/string/log/typed            3073038               389.1 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log/any              3030273               393.0 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log-go/typed         1000000              1141 ns/op             112 B/op          3 allocs/op
BenchmarkAny/string/log-go/any           1000000              1143 ns/op             128 B/op          3 allocs/op
BenchmarkAny/stringer/field-only/typed  159827430                7.613 ns/op           0 B/op          0 allocs/op
BenchmarkAny/stringer/field-only/any    52378398                22.89 ns/op            0 B/op          0 allocs/op
BenchmarkAny/stringer/log/typed          3283455               372.7 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log/any            3125164               378.3 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log-go/typed       1000000              1108 ns/op             112 B/op          3 allocs/op
BenchmarkAny/stringer/log-go/any         1000000              1145 ns/op             128 B/op          3 allocs/op
PASS
ok      go.uber.org/zap 19.275s
❯  gotip test -bench BenchmarkAny -benchmem -cpu 1

goos: darwin
goarch: arm64
pkg: go.uber.org/zap
BenchmarkAny/string/field-only/typed    159988640                7.383 ns/op           0 B/op          0 allocs/op
BenchmarkAny/string/field-only/any      88060196                13.90 ns/op            0 B/op          0 allocs/op
BenchmarkAny/string/log/typed            2805666               430.7 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log/any              2714698               438.8 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log-go/typed         1000000              1163 ns/op             112 B/op          3 allocs/op
BenchmarkAny/string/log-go/any           1000000              1178 ns/op             128 B/op          3 allocs/op
BenchmarkAny/stringer/field-only/typed  156450748                7.673 ns/op           0 B/op          0 allocs/op
BenchmarkAny/stringer/field-only/any    51093813                24.31 ns/op            0 B/op          0 allocs/op
BenchmarkAny/stringer/log/typed          2974875               414.9 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log/any            2853394               434.3 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log-go/typed       1000000              1177 ns/op             112 B/op          3 allocs/op
BenchmarkAny/stringer/log-go/any          993225              1188 ns/op             128 B/op          3 allocs/op
PASS
ok      go.uber.org/zap 19.440s
 % go test -bench BenchmarkAny -benchmem -cpu 1
goos: linux
goarch: amd64
pkg: go.uber.org/zap
cpu: AMD EPYC 7B13
BenchmarkAny/string/field-only/typed    47207966                25.48 ns/op            0 B/op          0 allocs/op
BenchmarkAny/string/field-only/any      48939066                24.15 ns/op            0 B/op          0 allocs/op
BenchmarkAny/string/log/typed            1651234               739.9 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log/any              1624704               753.6 ns/op            64 B/op          1 allocs/op
BenchmarkAny/string/log-go/typed          526701              2288 ns/op             112 B/op          3 allocs/op
BenchmarkAny/string/log-go/any            505273              2331 ns/op             128 B/op          3 allocs/op
BenchmarkAny/stringer/field-only/typed  48647834                24.69 ns/op            0 B/op          0 allocs/op
BenchmarkAny/stringer/field-only/any    30350282                38.55 ns/op            0 B/op          0 allocs/op
BenchmarkAny/stringer/log/typed          1801276               673.0 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log/any            1584859               733.6 ns/op            64 B/op          1 allocs/op
BenchmarkAny/stringer/log-go/typed        523908              2307 ns/op             112 B/op          3 allocs/op
BenchmarkAny/stringer/log-go/any          507704              2418 ns/op             128 B/op          3 allocs/op
PASS
ok      go.uber.org/zap 19.012s
```