### PR TITLE
Reduce Any stack usage with map + list of lookups

### DIFF
--- a/field.go
+++ b/field.go
@@ -493,7 +493,7 @@ func Any(key string, value interface{}) Field {
 		i = int64(math.Float64bits(*val))
 	case []float64:
 		t = zapcore.ArrayMarshalerType
-		val = float64s(val)
+		iface = float64s(val)
 	case float32:
 		t = zapcore.Float32Type
 		i = int64(math.Float32bits(val))
@@ -606,6 +606,7 @@ func Any(key string, value interface{}) Field {
 			t = zapcore.ReflectType
 			break
 		}
+		t = zapcore.Uint64Type
 		i = int64(*val)
 	case []uint64:
 		t = zapcore.ArrayMarshalerType

--- a/field.go
+++ b/field.go
@@ -411,69 +411,16 @@ func Inline(val zapcore.ObjectMarshaler) Field {
 	}
 }
 
-// anyTypeLookup is a map from concrete types to the field constructors.
-var anyTypeLookup = map[reflect.Type]func(string, any) Field{
-	reflect.TypeOf(bool(true)):            func(k string, v any) Field { return Bool(k, v.(bool)) },
-	reflect.TypeOf((*bool)(nil)):          func(k string, v any) Field { return Boolp(k, v.(*bool)) },
-	reflect.TypeOf([]bool(nil)):           func(k string, v any) Field { return Bools(k, v.([]bool)) },
-	reflect.TypeOf(complex128(1)):         func(k string, v any) Field { return Complex128(k, v.(complex128)) },
-	reflect.TypeOf((*complex128)(nil)):    func(k string, v any) Field { return Complex128p(k, v.(*complex128)) },
-	reflect.TypeOf(([]complex128)(nil)):   func(k string, v any) Field { return Complex128s(k, v.([]complex128)) },
-	reflect.TypeOf(complex64(1)):          func(k string, v any) Field { return Complex64(k, v.(complex64)) },
-	reflect.TypeOf((*complex64)(nil)):     func(k string, v any) Field { return Complex64p(k, v.(*complex64)) },
-	reflect.TypeOf(([]complex64)(nil)):    func(k string, v any) Field { return Complex64s(k, v.([]complex64)) },
-	reflect.TypeOf(float64(1)):            func(k string, v any) Field { return Float64(k, v.(float64)) },
-	reflect.TypeOf((*float64)(nil)):       func(k string, v any) Field { return Float64p(k, v.(*float64)) },
-	reflect.TypeOf(([]float64)(nil)):      func(k string, v any) Field { return Float64s(k, v.([]float64)) },
-	reflect.TypeOf(float32(1)):            func(k string, v any) Field { return Float32(k, v.(float32)) },
-	reflect.TypeOf((*float32)(nil)):       func(k string, v any) Field { return Float32p(k, v.(*float32)) },
-	reflect.TypeOf(([]float32)(nil)):      func(k string, v any) Field { return Float32s(k, v.([]float32)) },
-	reflect.TypeOf(int(0)):                func(k string, v any) Field { return Int(k, v.(int)) },
-	reflect.TypeOf((*int)(nil)):           func(k string, v any) Field { return Intp(k, v.(*int)) },
-	reflect.TypeOf(([]int)(nil)):          func(k string, v any) Field { return Ints(k, v.([]int)) },
-	reflect.TypeOf(int64(0)):              func(k string, v any) Field { return Int64(k, v.(int64)) },
-	reflect.TypeOf((*int64)(nil)):         func(k string, v any) Field { return Int64p(k, v.(*int64)) },
-	reflect.TypeOf(([]int64)(nil)):        func(k string, v any) Field { return Int64s(k, v.([]int64)) },
-	reflect.TypeOf(int32(0)):              func(k string, v any) Field { return Int32(k, v.(int32)) },
-	reflect.TypeOf((*int32)(nil)):         func(k string, v any) Field { return Int32p(k, v.(*int32)) },
-	reflect.TypeOf(([]int32)(nil)):        func(k string, v any) Field { return Int32s(k, v.([]int32)) },
-	reflect.TypeOf(int16(0)):              func(k string, v any) Field { return Int16(k, v.(int16)) },
-	reflect.TypeOf((*int16)(nil)):         func(k string, v any) Field { return Int16p(k, v.(*int16)) },
-	reflect.TypeOf(([]int16)(nil)):        func(k string, v any) Field { return Int16s(k, v.([]int16)) },
-	reflect.TypeOf(int8(0)):               func(k string, v any) Field { return Int8(k, v.(int8)) },
-	reflect.TypeOf((*int8)(nil)):          func(k string, v any) Field { return Int8p(k, v.(*int8)) },
-	reflect.TypeOf(([]int8)(nil)):         func(k string, v any) Field { return Int8s(k, v.([]int8)) },
-	reflect.TypeOf(string("")):            func(k string, v any) Field { return String(k, v.(string)) },
-	reflect.TypeOf((*string)(nil)):        func(k string, v any) Field { return Stringp(k, v.(*string)) },
-	reflect.TypeOf(([]string)(nil)):       func(k string, v any) Field { return Strings(k, v.([]string)) },
-	reflect.TypeOf(uint(0)):               func(k string, v any) Field { return Uint(k, v.(uint)) },
-	reflect.TypeOf((*uint)(nil)):          func(k string, v any) Field { return Uintp(k, v.(*uint)) },
-	reflect.TypeOf(([]uint)(nil)):         func(k string, v any) Field { return Uints(k, v.([]uint)) },
-	reflect.TypeOf(uint64(0)):             func(k string, v any) Field { return Uint64(k, v.(uint64)) },
-	reflect.TypeOf((*uint64)(nil)):        func(k string, v any) Field { return Uint64p(k, v.(*uint64)) },
-	reflect.TypeOf(([]uint64)(nil)):       func(k string, v any) Field { return Uint64s(k, v.([]uint64)) },
-	reflect.TypeOf(uint32(0)):             func(k string, v any) Field { return Uint32(k, v.(uint32)) },
-	reflect.TypeOf((*uint32)(nil)):        func(k string, v any) Field { return Uint32p(k, v.(*uint32)) },
-	reflect.TypeOf(([]uint32)(nil)):       func(k string, v any) Field { return Uint32s(k, v.([]uint32)) },
-	reflect.TypeOf(uint16(0)):             func(k string, v any) Field { return Uint16(k, v.(uint16)) },
-	reflect.TypeOf((*uint16)(nil)):        func(k string, v any) Field { return Uint16p(k, v.(*uint16)) },
-	reflect.TypeOf(([]uint16)(nil)):       func(k string, v any) Field { return Uint16s(k, v.([]uint16)) },
-	reflect.TypeOf(uint8(0)):              func(k string, v any) Field { return Uint8(k, v.(uint8)) },
-	reflect.TypeOf((*uint8)(nil)):         func(k string, v any) Field { return Uint8p(k, v.(*uint8)) },
-	reflect.TypeOf(([]uint8)(nil)):        func(k string, v any) Field { return Uint8s(k, v.([]uint8)) },
-	reflect.TypeOf([]byte(nil)):           func(k string, v any) Field { return Binary(k, v.([]byte)) },
-	reflect.TypeOf(uintptr(0)):            func(k string, v any) Field { return Uintptr(k, v.(uintptr)) },
-	reflect.TypeOf((*uintptr)(nil)):       func(k string, v any) Field { return Uintptrp(k, v.(*uintptr)) },
-	reflect.TypeOf([]uintptr(nil)):        func(k string, v any) Field { return Uintptrs(k, v.([]uintptr)) },
-	reflect.TypeOf(time.Time{}):           func(k string, v any) Field { return Time(k, v.(time.Time)) },
-	reflect.TypeOf((*time.Time)(nil)):     func(k string, v any) Field { return Timep(k, v.(*time.Time)) },
-	reflect.TypeOf([]time.Time(nil)):      func(k string, v any) Field { return Times(k, v.([]time.Time)) },
-	reflect.TypeOf(time.Duration(0)):      func(k string, v any) Field { return Duration(k, v.(time.Duration)) },
-	reflect.TypeOf((*time.Duration)(nil)): func(k string, v any) Field { return Durationp(k, v.(*time.Duration)) },
-	reflect.TypeOf([]time.Duration(nil)):  func(k string, v any) Field { return Durations(k, v.([]time.Duration)) },
-	reflect.TypeOf([]error(nil)):          func(k string, v any) Field { return Errors(k, v.([]error)) },
+type anyFuncType func(string, any) Field
+
+func typedToAnyFunc[T any](f func(string, T) Field) anyFuncType {
+	return func(k string, v any) Field {
+		return f(k, v.(T))
+	}
 }
 
+// anyTypeLookup is a map from concrete types to the field constructors.
+var anyTypeLookup = buildAnyTypeLookup()
 var anyInterfaceLookup = []struct {
 	match func(v any) bool
 	fn    func(k string, v any) Field
@@ -494,6 +441,44 @@ var anyInterfaceLookup = []struct {
 		match: func(v any) bool { _, ok := v.(fmt.Stringer); return ok },
 		fn:    func(k string, v any) Field { return Stringer(k, v.(fmt.Stringer)) },
 	},
+}
+
+func addTypeLookup[T any](
+	m map[reflect.Type]anyFuncType,
+	directTypeFn func(string, T) Field,
+	ptrTypeFn func(string, *T) Field,
+	arrayTypeFn func(string, []T) Field,
+) {
+	var v T
+	m[reflect.TypeOf(v)] = typedToAnyFunc(directTypeFn)
+	m[reflect.TypeOf(&v)] = typedToAnyFunc(ptrTypeFn)
+	m[reflect.TypeOf([]T(nil))] = typedToAnyFunc(arrayTypeFn)
+}
+
+func buildAnyTypeLookup() map[reflect.Type]anyFuncType {
+	m := make(map[reflect.Type]anyFuncType)
+	addTypeLookup[bool](m, Bool, Boolp, Bools)
+	addTypeLookup[complex128](m, Complex128, Complex128p, Complex128s)
+	addTypeLookup[complex64](m, Complex64, Complex64p, Complex64s)
+	addTypeLookup[float64](m, Float64, Float64p, Float64s)
+	addTypeLookup[float32](m, Float32, Float32p, Float32s)
+	addTypeLookup[int](m, Int, Intp, Ints)
+	addTypeLookup[int64](m, Int64, Int64p, Int64s)
+	addTypeLookup[int32](m, Int32, Int32p, Int32s)
+	addTypeLookup[int16](m, Int16, Int16p, Int16s)
+	addTypeLookup[int8](m, Int8, Int8p, Int8s)
+	addTypeLookup[string](m, String, Stringp, Strings)
+	addTypeLookup[uint](m, Uint, Uintp, Uints)
+	addTypeLookup[uint64](m, Uint64, Uint64p, Uint64s)
+	addTypeLookup[uint32](m, Uint32, Uint32p, Uint32s)
+	addTypeLookup[uint16](m, Uint16, Uint16p, Uint16s)
+	addTypeLookup[uint8](m, Uint8, Uint8p, Uint8s)
+	addTypeLookup[uintptr](m, Uintptr, Uintptrp, Uintptrs)
+	addTypeLookup[time.Time](m, Time, Timep, Times)
+	addTypeLookup[time.Duration](m, Duration, Durationp, Durations)
+	m[reflect.TypeOf([]byte(nil))] = typedToAnyFunc(Binary)
+	m[reflect.TypeOf([]error(nil))] = typedToAnyFunc(Errors)
+	return m
 }
 
 // Any takes a key and an arbitrary value and chooses the best way to represent

--- a/field.go
+++ b/field.go
@@ -418,132 +418,310 @@ func Inline(val zapcore.ObjectMarshaler) Field {
 // them. To minimize surprises, []byte values are treated as binary blobs, byte
 // values are treated as uint8, and runes are always treated as integers.
 func Any(key string, value interface{}) Field {
+	// To work around go compiler assigning unreasonably large space on stack
+	// (4kb, one `Field` per arm of the switch statement) which can trigger
+	// performance degradation if `Any` is used in a brand new goroutine.
+	var (
+		t     zapcore.FieldType
+		i     int64
+		s     string
+		iface any
+	)
 	switch val := value.(type) {
 	case zapcore.ObjectMarshaler:
-		return Object(key, val)
+		t = zapcore.ObjectMarshalerType
+		iface = val
 	case zapcore.ArrayMarshaler:
-		return Array(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = val
 	case bool:
-		return Bool(key, val)
+		var ival int64
+		if val {
+			ival = 1
+		}
+		t = zapcore.BoolType
+		i = ival
 	case *bool:
-		return Boolp(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		var ival int64
+		if *val {
+			ival = 1
+		}
+		t = zapcore.BoolType
+		i = ival
 	case []bool:
-		return Bools(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = bools(val)
 	case complex128:
-		return Complex128(key, val)
+		t = zapcore.Complex128Type
+		iface = val
 	case *complex128:
-		return Complex128p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Complex128Type
+		iface = *val
 	case []complex128:
-		return Complex128s(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = complex128s(val)
 	case complex64:
-		return Complex64(key, val)
+		t = zapcore.Complex64Type
+		iface = val
 	case *complex64:
-		return Complex64p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Complex64Type
+		iface = *val
 	case []complex64:
-		return Complex64s(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = complex64s(val)
 	case float64:
-		return Float64(key, val)
+		t = zapcore.Float64Type
+		i = int64(math.Float64bits(val))
 	case *float64:
-		return Float64p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Float64Type
+		i = int64(math.Float64bits(*val))
 	case []float64:
-		return Float64s(key, val)
+		t = zapcore.ArrayMarshalerType
+		val = float64s(val)
 	case float32:
-		return Float32(key, val)
+		t = zapcore.Float32Type
+		i = int64(math.Float32bits(val))
 	case *float32:
-		return Float32p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Float32Type
+		i = int64(math.Float32bits(*val))
 	case []float32:
-		return Float32s(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = float32s(val)
 	case int:
-		return Int(key, val)
+		t = zapcore.Int64Type
+		i = int64(val)
 	case *int:
-		return Intp(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Int64Type
+		i = int64(*val)
 	case []int:
-		return Ints(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = ints(val)
 	case int64:
-		return Int64(key, val)
+		t = zapcore.Int64Type
+		i = val
 	case *int64:
-		return Int64p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Int64Type
+		i = *val
 	case []int64:
-		return Int64s(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = int64s(val)
 	case int32:
-		return Int32(key, val)
+		t = zapcore.Int32Type
+		i = int64(val)
 	case *int32:
-		return Int32p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Int32Type
+		i = int64(*val)
 	case []int32:
-		return Int32s(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = int32s(val)
 	case int16:
-		return Int16(key, val)
+		t = zapcore.Int16Type
+		i = int64(val)
 	case *int16:
-		return Int16p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Int16Type
+		i = int64(*val)
 	case []int16:
-		return Int16s(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = int16s(val)
 	case int8:
-		return Int8(key, val)
+		t = zapcore.Int8Type
+		i = int64(val)
 	case *int8:
-		return Int8p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Int8Type
+		i = int64(*val)
 	case []int8:
-		return Int8s(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = int8s(val)
 	case string:
-		return String(key, val)
+		t = zapcore.StringType
+		s = val
 	case *string:
-		return Stringp(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.StringType
+		s = *val
 	case []string:
-		return Strings(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = stringArray(val)
 	case uint:
-		return Uint(key, val)
+		t = zapcore.Uint64Type
+		i = int64(val)
 	case *uint:
-		return Uintp(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Uint64Type
+		i = int64(*val)
 	case []uint:
-		return Uints(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = uints(val)
 	case uint64:
-		return Uint64(key, val)
+		t = zapcore.Uint64Type
+		i = int64(val)
 	case *uint64:
-		return Uint64p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		i = int64(*val)
 	case []uint64:
-		return Uint64s(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = uint64s(val)
 	case uint32:
-		return Uint32(key, val)
+		t = zapcore.Uint32Type
+		i = int64(val)
 	case *uint32:
-		return Uint32p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Uint32Type
+		i = int64(*val)
 	case []uint32:
-		return Uint32s(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = uint32s(val)
 	case uint16:
-		return Uint16(key, val)
+		t = zapcore.Uint16Type
+		i = int64(val)
 	case *uint16:
-		return Uint16p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Uint16Type
+		i = int64(*val)
 	case []uint16:
-		return Uint16s(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = uint16s(val)
 	case uint8:
-		return Uint8(key, val)
+		t = zapcore.Uint8Type
+		i = int64(val)
 	case *uint8:
-		return Uint8p(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.Uint8Type
+		i = int64(*val)
 	case []byte:
-		return Binary(key, val)
+		t = zapcore.BinaryType
+		iface = val
 	case uintptr:
-		return Uintptr(key, val)
+		t = zapcore.UintptrType
+		i = int64(val)
 	case *uintptr:
-		return Uintptrp(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.UintptrType
+		i = int64(*val)
 	case []uintptr:
-		return Uintptrs(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = uintptrs(val)
 	case time.Time:
-		return Time(key, val)
+		if val.Before(_minTimeInt64) || val.After(_maxTimeInt64) {
+			t = zapcore.TimeFullType
+			iface = val
+			break
+		}
+		t = zapcore.TimeType
+		i = val.UnixNano()
+		iface = val.Location()
 	case *time.Time:
-		return Timep(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		if val.Before(_minTimeInt64) || val.After(_maxTimeInt64) {
+			t = zapcore.TimeFullType
+			iface = *val
+			break
+		}
+		t = zapcore.TimeType
+		i = val.UnixNano()
+		iface = val.Location()
 	case []time.Time:
-		return Times(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = times(val)
 	case time.Duration:
-		return Duration(key, val)
+		t = zapcore.DurationType
+		i = int64(val)
 	case *time.Duration:
-		return Durationp(key, val)
+		if val == nil {
+			t = zapcore.ReflectType
+			break
+		}
+		t = zapcore.DurationType
+		i = int64(*val)
 	case []time.Duration:
-		return Durations(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = durations(val)
 	case error:
-		return NamedError(key, val)
+		if val == nil {
+			t = zapcore.SkipType
+			break
+		}
+		t = zapcore.ErrorType
+		iface = val
 	case []error:
-		return Errors(key, val)
+		t = zapcore.ArrayMarshalerType
+		iface = errArray(val)
 	case fmt.Stringer:
-		return Stringer(key, val)
+		t = zapcore.StringerType
+		iface = val
 	default:
-		return Reflect(key, val)
+		t = zapcore.ReflectType
+		iface = val
+	}
+	return Field{
+		Key:       key,
+		Type:      t,
+		Integer:   i,
+		String:    s,
+		Interface: iface,
 	}
 }

--- a/field_test.go
+++ b/field_test.go
@@ -86,6 +86,7 @@ func TestFieldConstructors(t *testing.T) {
 		uint16Val     = uint16(1)
 		uint8Val      = uint8(1)
 		uintptrVal    = uintptr(1)
+		nilErr        error
 	)
 
 	tests := []struct {
@@ -166,6 +167,7 @@ func TestFieldConstructors(t *testing.T) {
 		{"Any:Uintptr", Any("k", uintptr(1)), Uintptr("k", 1)},
 		{"Any:Uintptrs", Any("k", []uintptr{1}), Uintptrs("k", []uintptr{1})},
 		{"Any:Time", Any("k", time.Unix(0, 0)), Time("k", time.Unix(0, 0))},
+		{"Any:Time-FullType", Any("k", time.Time{}), Time("k", time.Time{})},
 		{"Any:Times", Any("k", []time.Time{time.Unix(0, 0)}), Times("k", []time.Time{time.Unix(0, 0)})},
 		{"Any:Duration", Any("k", time.Second), Duration("k", time.Second)},
 		{"Any:Durations", Any("k", []time.Duration{time.Second}), Durations("k", []time.Duration{time.Second})},
@@ -222,6 +224,7 @@ func TestFieldConstructors(t *testing.T) {
 		{"Ptr:Time", Timep("k", &timeVal), Time("k", timeVal)},
 		{"Any:PtrTime", Any("k", (*time.Time)(nil)), nilField("k")},
 		{"Any:PtrTime", Any("k", &timeVal), Time("k", timeVal)},
+		{"Any:PtrTime-FullType", Any("k", &time.Time{}), Time("k", time.Time{})},
 		{"Ptr:Uint", Uintp("k", nil), nilField("k")},
 		{"Ptr:Uint", Uintp("k", &uintVal), Uint("k", uintVal)},
 		{"Any:PtrUint", Any("k", (*uint)(nil)), nilField("k")},
@@ -246,6 +249,7 @@ func TestFieldConstructors(t *testing.T) {
 		{"Ptr:Uintptr", Uintptrp("k", &uintptrVal), Uintptr("k", uintptrVal)},
 		{"Any:PtrUintptr", Any("k", (*uintptr)(nil)), nilField("k")},
 		{"Any:PtrUintptr", Any("k", &uintptrVal), Uintptr("k", uintptrVal)},
+		{"Any:Error-nil", Any("k", nilErr), nilField("k")},
 		{"Namespace", Namespace("k"), Field{Key: "k", Type: zapcore.NamespaceType}},
 	}
 


### PR DESCRIPTION
Alternative to the other Any stack optimizations,  building on top of the tests in https://github.com/uber-go/zap/pull/1303.

This is a different approach to the Any function using a prebuilt a map by type to determine which function to call. The map only works for concrete types, so we also need a list for interfaces, ordered in precedence order (since multiple interfaces may match a single type).

I'm using the output of `go build -gcflags -S` to determine the stack frame size, which allows us to compare the approaches.
```
# master
go.uber.org/zap.Any STEXT size=16672 args=0x20 locals=0x1308 funcid=0x0 align=0x0
        0x0000 00000 (/Users/prashant/dev/3p/zap/field.go:420)  TEXT    go.uber.org/zap.Any(SB), ABIInternal, $4880-32
```
In the above, locals is 0x1308 = 4872, which is 8 bytes less than the frame size on the next line ($4880).

Using this, we can compare the different approaches directly,
```
PR #1301:
go.uber.org/zap.Any STEXT size=5072 args=0x20 locals=0x3e8 funcid=0x0 align=0x0
        0x0000 00000 (/Users/prashant/dev/3p/zap/field.go:421)  TEXT    go.uber.org/zap.Any(SB), ABIInternal, $1008-32

PR #1302:
go.uber.org/zap.Any STEXT size=4048 args=0x20 locals=0x148 funcid=0x0 align=0x0
        0x0000 00000 (/Users/prashant/dev/3p/zap/field.go:422)  TEXT    go.uber.org/zap.Any(SB), ABIInternal, $336-32

PR #1303
go.uber.org/zap.Any STEXT size=6320 args=0x20 locals=0x648 funcid=0x0 align=0x0
        0x0000 00000 (/Users/prashant/dev/3p/zap/field.go:420)  TEXT    go.uber.org/zap.Any(SB), ABIInternal, $1616-32

PR #1304:
go.uber.org/zap.Any STEXT size=3664 args=0x20 locals=0x128 funcid=0x0 align=0x0
        0x0000 00000 (/Users/prashant/dev/3p/zap/field.go:428)  TEXT    go.uber.org/zap.Any(SB), ABIInternal, $304-32

PR #1305:
go.uber.org/zap.Any STEXT size=7120 args=0x20 locals=0xb8 funcid=0x0 align=0x0
        0x0000 00000 (/Users/prashant/dev/3p/zap/field.go:420)  TEXT    go.uber.org/zap.Any(SB), ABIInternal, $192-32

Branch pawel/any-int5
go.uber.org/zap.Any STEXT size=7216 args=0x20 locals=0xc8 funcid=0x0 align=0x0
        0x0000 00000 (/Users/prashant/dev/3p/zap/field.go:420)  TEXT    go.uber.org/zap.Any(SB), ABIInternal, $208-32

This PR:
go.uber.org/zap.Any STEXT size=448 args=0x20 locals=0xf8 funcid=0x0 align=0x0
        0x0000 00000 (/Users/prashant/dev/3p/zap/field.go:506)  TEXT    go.uber.org/zap.Any(SB), ABIInternal, $256-32
```

Benchmarks for this version show `Any` and `String` perform similarly:
```
BenchmarkAny/str-in-go            782828              1422 ns/op              89 B/op          2 allocs/op
BenchmarkAny/any-in-go            723226              1446 ns/op              88 B/op          2 allocs/op
BenchmarkAny/str-in-go-with-stack                 887086              1436 ns/op              88 B/op          2 allocs/op
BenchmarkAny/any-in-go-with-stack                 757072              1455 ns/op              88 B/op          2 allocs/op
```



