### PR TITLE
Fix `make cover` to include /exp packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ GOVULNCHECK = $(GOBIN)/govulncheck
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 
 # Directories containing independent Go modules.
-#
-# We track coverage only for the main module.
 MODULE_DIRS = . ./exp ./benchmarks ./zapgrpc/internal/test
+
+# Directories that we want to track coverage for.
+COVER_DIRS = . ./exp
 
 # Many Go tools take file globs or directories as arguments instead of packages.
 GO_FILES := $(shell \
@@ -57,7 +58,7 @@ test:
 
 .PHONY: cover
 cover:
-	@$(foreach dir,$(MODULE_DIRS), ( \
+	@$(foreach dir,$(COVER_DIRS), ( \
 		cd $(dir) && \
 		go test -race -coverprofile=cover.out -coverpkg=./... ./... \
 		&& go tool cover -html=cover.out -o cover.html) &&) true

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,10 @@ test:
 
 .PHONY: cover
 cover:
-	go test -race -coverprofile=cover.out -coverpkg=./... ./...
-	go tool cover -html=cover.out -o cover.html
+	@$(foreach dir,$(MODULE_DIRS), ( \
+		cd $(dir) && \
+		go test -race -coverprofile=cover.out -coverpkg=./... ./... \
+		&& go tool cover -html=cover.out -o cover.html) &&) true
 
 .PHONY: bench
 BENCH ?= .


### PR DESCRIPTION
Currently `make cover` did not include coverage from exp/ packages because it was targeting only the root package.

This fixes the command so that it can include sub modules.

Before:
```
❯ make cover
go test -race -coverprofile=cover.out -coverpkg=./... ./...
?   	go.uber.org/zap/internal	[no test files]
?   	go.uber.org/zap/internal/bufferpool	[no test files]
?   	go.uber.org/zap/internal/readme	[no test files]
ok  	go.uber.org/zap	1.877s	coverage: 99.5% of statements in ./...
ok  	go.uber.org/zap/buffer	0.228s	coverage: 89.7% of statements in ./...
ok  	go.uber.org/zap/internal/color	0.353s	coverage: 100.0% of statements in ./...
ok  	go.uber.org/zap/internal/exit	0.424s	coverage: 100.0% of statements in ./...
ok  	go.uber.org/zap/internal/pool	0.506s	coverage: 100.0% of statements in ./...
ok  	go.uber.org/zap/internal/ztest	0.566s	coverage: 15.4% of statements in ./...
ok  	go.uber.org/zap/zapcore	2.958s	coverage: 6.0% of statements in ./...
ok  	go.uber.org/zap/zapgrpc	0.524s	coverage: 8.2% of statements in ./...
ok  	go.uber.org/zap/zapio	0.560s	coverage: 5.8% of statements in ./...
ok  	go.uber.org/zap/zaptest	0.710s	coverage: 11.7% of statements in ./...
ok  	go.uber.org/zap/zaptest/observer	0.463s	coverage: 7.9% of statements in ./...
go tool cover -html=cover.out -o cover.html
```

After:
```
❯ make cover
?   	go.uber.org/zap/internal	[no test files]
?   	go.uber.org/zap/internal/bufferpool	[no test files]
?   	go.uber.org/zap/internal/readme	[no test files]
ok  	go.uber.org/zap	1.921s	coverage: 99.5% of statements in ./...
ok  	go.uber.org/zap/buffer	0.591s	coverage: 89.7% of statements in ./...
ok  	go.uber.org/zap/internal/color	0.396s	coverage: 100.0% of statements in ./...
ok  	go.uber.org/zap/internal/exit	0.677s	coverage: 100.0% of statements in ./...
ok  	go.uber.org/zap/internal/pool	0.929s	coverage: 100.0% of statements in ./...
ok  	go.uber.org/zap/internal/ztest	0.798s	coverage: 15.4% of statements in ./...
ok  	go.uber.org/zap/zapcore	3.273s	coverage: 6.0% of statements in ./...
ok  	go.uber.org/zap/zapgrpc	0.972s	coverage: 8.2% of statements in ./...
ok  	go.uber.org/zap/zapio	1.071s	coverage: 5.8% of statements in ./...
ok  	go.uber.org/zap/zaptest	1.204s	coverage: 11.7% of statements in ./...
ok  	go.uber.org/zap/zaptest/observer	0.887s	coverage: 7.9% of statements in ./...
ok  	go.uber.org/zap/exp/zapfield	0.206s	coverage: 100.0% of statements in ./...
ok  	go.uber.org/zap/exp/zapslog	0.396s	coverage: 84.4% of statements in ./...
ok  	go.uber.org/zap/benchmarks	0.197s	coverage: [no statements] [no tests to run]
ok  	go.uber.org/zap/zapgrpc/internal/test	0.213s	coverage: [no statements]
```