### PR TITLE
ci: Test with Go 1.21

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.19.x", "1.20.x"]
+        go: ["1.20.x", "1.21.x"]
         include:
-        - go: 1.20.x
+        - go: 1.21.x
           latest: true
 
     steps:


### PR DESCRIPTION
With the release of Go 1.21,
CI should run against Go 1.20 and 1.21
as these are the only suported versions now.
