### PR TITLE
ci: Don't fire double job on branch + PR

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: ['*']
+    branches: [master]
     tags: ['v*']
   pull_request:
     branches: ['*']


### PR DESCRIPTION
CI setup currently triggers build-test-lint jobs
for pull requests and pushes to any and all branches.
This has the negative effect of spinning up double jobs
for pull requests made from branches in the uber-go/zap repository.

This changes CI to only fire on pushes to master and for PRs.

Caveat:
This means that if someone pushes a test branch to uber-go/zap,
it won't run CI until they create a PR (draft or otherwise).
