### PR TITLE
Add benchmarks for chained Withs

### DIFF
--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -23,6 +23,7 @@ package zap
 import (
 	"errors"
 	"runtime"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -196,6 +197,37 @@ func BenchmarkAddCallerAndStacktrace(b *testing.B) {
 		for pb.Next() {
 			logger.Warn("Caller and stacktrace.")
 		}
+	})
+}
+func Benchmark5WithsUsed(b *testing.B) {
+	benchmarkWithUsed(b, 5, true)
+}
+
+// This benchmark will be used in future as a
+// baseline for improving
+func Benchmark5WithsNotUsed(b *testing.B) {
+	benchmarkWithUsed(b, 5, false)
+}
+
+func benchmarkWithUsed(b *testing.B, N int, use bool) {
+	keys := make([]string, N)
+	values := make([]string, N)
+	for i := 0; i < N; i++ {
+		keys[i] = "k" + strconv.Itoa(i)
+		values[i] = "v" + strconv.Itoa(i)
+	}
+
+	b.ResetTimer()
+
+	withBenchedLogger(b, func(log *Logger) {
+		for i := 0; i < N; i++ {
+			log = log.With(String(keys[i], values[i]))
+		}
+		if use {
+			log.Info("used")
+			return
+		}
+		runtime.KeepAlive(log)
 	})
 }
 


### PR DESCRIPTION
Add benchmarks to show the performance of chaining child loggers via 'With' and whether the logger is used or not used.

This is intended to establish a baseline for a proposed optimisation in PR https://github.com/uber-go/zap/pull/1319.