### PR TITLE
test(slog): Use testify's assert, require directly

### DIFF
--- a/exp/zapslog/slog_go121_test.go
+++ b/exp/zapslog/slog_go121_test.go
@@ -26,23 +26,23 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestAddSource(t *testing.T) {
-	r := require.New(t)
 	fac, logs := observer.New(zapcore.DebugLevel)
 	sl := slog.New(NewHandler(fac, &HandlerOptions{
 		AddSource: true,
 	}))
 	sl.Info("msg")
 
-	r.Len(logs.AllUntimed(), 1, "Expected exactly one entry to be logged")
+	require.Len(t, logs.AllUntimed(), 1, "Expected exactly one entry to be logged")
 	entry := logs.AllUntimed()[0]
-	r.Equal("msg", entry.Message, "Unexpected message")
-	r.Regexp(
+	assert.Equal(t, "msg", entry.Message, "Unexpected message")
+	assert.Regexp(t,
 		`/slog_go121_test.go:\d+$`,
 		entry.Caller.String(),
 		"Unexpected caller annotation.",

--- a/exp/zapslog/slog_pre_go121_test.go
+++ b/exp/zapslog/slog_pre_go121_test.go
@@ -25,6 +25,7 @@ package zapslog
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -32,17 +33,16 @@ import (
 )
 
 func TestAddSource(t *testing.T) {
-	r := require.New(t)
 	fac, logs := observer.New(zapcore.DebugLevel)
 	sl := slog.New(NewHandler(fac, &HandlerOptions{
 		AddSource: true,
 	}))
 	sl.Info("msg")
 
-	r.Len(logs.AllUntimed(), 1, "Expected exactly one entry to be logged")
+	require.Len(t, logs.AllUntimed(), 1, "Expected exactly one entry to be logged")
 	entry := logs.AllUntimed()[0]
-	r.Equal("msg", entry.Message, "Unexpected message")
-	r.Regexp(
+	assert.Equal(t, "msg", entry.Message, "Unexpected message")
+	assert.Regexp(t,
 		`/slog_pre_go121_test.go:\d+$`,
 		entry.Caller.String(),
 		"Unexpected caller annotation.",


### PR DESCRIPTION
We don't instantiate `require.New` or `assert.New` in our tests,
preferring to use the package-level functions of require and assert
directly.

Change zapslog tests to match that convention.
