### PR TITLE
feat(zapslog): implement stack trace handling

### DIFF
--- a/exp/go.mod
+++ b/exp/go.mod
@@ -14,4 +14,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace go.uber.org/zap => ../
+// replace to commit: https://github.com/uber-go/zap/commit/98e9c4fe632cc00c99033d8d616f1318b7063eee
+replace go.uber.org/zap => go.uber.org/zap v1.24.1-0.20230825131617-98e9c4fe632c

--- a/exp/go.mod
+++ b/exp/go.mod
@@ -10,7 +10,8 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace go.uber.org/zap => ../

--- a/exp/go.mod
+++ b/exp/go.mod
@@ -14,5 +14,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// replace to commit: https://github.com/uber-go/zap/commit/98e9c4fe632cc00c99033d8d616f1318b7063eee
-replace go.uber.org/zap => go.uber.org/zap v1.24.1-0.20230825131617-98e9c4fe632c
+replace go.uber.org/zap => ../

--- a/exp/go.sum
+++ b/exp/go.sum
@@ -14,8 +14,6 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/zap v1.24.1-0.20230825131617-98e9c4fe632c h1:qCcNiJbqgoZUdgWoa1xo+N7Fv82mJ5upF8x/T/1FK2Y=
-go.uber.org/zap v1.24.1-0.20230825131617-98e9c4fe632c/go.mod h1:JIAUzQIH94IC4fOJQm7gMmBJP5k7wQfdcnYdPoEXJYk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/exp/go.sum
+++ b/exp/go.sum
@@ -1,8 +1,7 @@
-github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -12,13 +11,9 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
-go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
-go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
+go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
-go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
-go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/exp/go.sum
+++ b/exp/go.sum
@@ -14,6 +14,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.24.1-0.20230825131617-98e9c4fe632c h1:qCcNiJbqgoZUdgWoa1xo+N7Fv82mJ5upF8x/T/1FK2Y=
+go.uber.org/zap v1.24.1-0.20230825131617-98e9c4fe632c/go.mod h1:JIAUzQIH94IC4fOJQm7gMmBJP5k7wQfdcnYdPoEXJYk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/exp/zapslog/example_test.go
+++ b/exp/zapslog/example_test.go
@@ -42,7 +42,7 @@ func Example_slog() {
 	logger := zap.NewExample(zap.IncreaseLevel(zap.InfoLevel))
 	defer logger.Sync()
 
-	sl := slog.New(zapslog.NewHandler(logger.Core(), nil /* options */))
+	sl := slog.New(zapslog.NewHandler(logger.Core()))
 	ctx := context.Background()
 
 	sl.Info("user", "name", "Al", "secret", Password("secret"))

--- a/exp/zapslog/handler.go
+++ b/exp/zapslog/handler.go
@@ -120,9 +120,8 @@ func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
 
 // Handle handles the Record.
 func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
-	zapLevel := convertSlogLevel(record.Level)
 	ent := zapcore.Entry{
-		Level:      zapLevel,
+		Level:      convertSlogLevel(record.Level),
 		Time:       record.Time,
 		Message:    record.Message,
 		LoggerName: h.name,

--- a/exp/zapslog/handler.go
+++ b/exp/zapslog/handler.go
@@ -37,7 +37,7 @@ type Handler struct {
 	core       zapcore.Core
 	name       string // logger name
 	addCaller  bool
-	addStack   zapcore.LevelEnabler
+	addStackAt slog.Level
 	callerSkip int
 }
 
@@ -45,8 +45,8 @@ type Handler struct {
 // with options.
 func NewHandler(core zapcore.Core, opts ...Option) *Handler {
 	h := &Handler{
-		core:     core,
-		addStack: zapcore.ErrorLevel,
+		core:       core,
+		addStackAt: slog.LevelError,
 	}
 	for _, v := range opts {
 		v.apply(h)
@@ -145,7 +145,7 @@ func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
 		}
 	}
 
-	if h.addStack.Enabled(zapLevel) {
+	if record.Level >= h.addStackAt {
 		// Skipping 3:
 		// zapslog/handler log/slog.(*Logger).log
 		// slog/logger log/slog.(*Logger).log

--- a/exp/zapslog/handler.go
+++ b/exp/zapslog/handler.go
@@ -28,6 +28,7 @@ import (
 	"runtime"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/internal/stacktrace"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -145,7 +146,11 @@ func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
 	}
 
 	if h.addStack.Enabled(zapLevel) {
-		ce.Stack = zap.TakeStacktrace(4 + h.callerSkip)
+		// Skipping 3:
+		// zapslog/handler log/slog.(*Logger).log
+		// slog/logger log/slog.(*Logger).log
+		// slog/logger log/slog.(*Logger).<level>
+		ce.Stack = stacktrace.Take(3 + h.callerSkip)
 	}
 
 	fields := make([]zapcore.Field, 0, record.NumAttrs())

--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -62,7 +62,7 @@ func TestAddStack(t *testing.T) {
 		"Unexpected stack trace annotation.",
 	)
 	assert.Regexp(t,
-		`/zapslog/slog_go121_test.go:\d+`,
+		`/zapslog/handler_test.go:\d+`,
 		entry.Stack,
 		"Unexpected stack trace annotation.",
 	)

--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestAddCaller(t *testing.T) {
 	fac, logs := observer.New(zapcore.DebugLevel)
-	sl := slog.New(NewHandler(fac, AddCaller()))
+	sl := slog.New(NewHandler(fac, WithCaller(true)))
 	sl.Info("msg")
 
 	require.Len(t, logs.AllUntimed(), 1, "Expected exactly one entry to be logged")

--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -50,7 +50,7 @@ func TestAddCaller(t *testing.T) {
 func TestAddStack(t *testing.T) {
 	r := require.New(t)
 	fac, logs := observer.New(zapcore.DebugLevel)
-	sl := slog.New(NewHandler(fac, AddStacktrace(zapcore.DebugLevel)))
+	sl := slog.New(NewHandler(fac, AddStacktrace(slog.LevelDebug)))
 	sl.Info("msg")
 
 	r.Len(logs.AllUntimed(), 1, "Expected exactly one entry to be logged")

--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -50,7 +50,7 @@ func TestAddCaller(t *testing.T) {
 func TestAddStack(t *testing.T) {
 	r := require.New(t)
 	fac, logs := observer.New(zapcore.DebugLevel)
-	sl := slog.New(NewHandler(fac, AddStacktrace(slog.LevelDebug)))
+	sl := slog.New(NewHandler(fac, AddStacktraceAt(slog.LevelDebug)))
 	sl.Info("msg")
 
 	r.Len(logs.AllUntimed(), 1, "Expected exactly one entry to be logged")

--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -48,14 +48,13 @@ func TestAddCaller(t *testing.T) {
 }
 
 func TestAddStack(t *testing.T) {
-	r := require.New(t)
 	fac, logs := observer.New(zapcore.DebugLevel)
 	sl := slog.New(NewHandler(fac, AddStacktraceAt(slog.LevelDebug)))
 	sl.Info("msg")
 
-	r.Len(logs.AllUntimed(), 1, "Expected exactly one entry to be logged")
+	require.Len(t, logs.AllUntimed(), 1, "Expected exactly one entry to be logged")
 	entry := logs.AllUntimed()[0]
-	r.Equal("msg", entry.Message, "Unexpected message")
+	require.Equal(t, "msg", entry.Message, "Unexpected message")
 	assert.Regexp(t,
 		`^go.uber.org/zap/exp/zapslog.TestAddStack`,
 		entry.Stack,

--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zapslog
+
+import "go.uber.org/zap/zapcore"
+
+type Option interface {
+	apply(*Handler)
+}
+
+// optionFunc wraps a func so it satisfies the Option interface.
+type optionFunc func(*Handler)
+
+func (f optionFunc) apply(handler *Handler) {
+	f(handler)
+}
+
+// WithName configures the Logger to annotate each message with the logger name.
+func WithName(name string) Option {
+	return optionFunc(func(h *Handler) {
+		h.name = name
+	})
+}
+
+// AddCaller configures the Logger to annotate each message with the filename,
+// line number, and function name of zap's caller. See also WithCaller.
+func AddCaller() Option {
+	return WithCaller(true)
+}
+
+// WithCaller configures the Logger to annotate each message with the filename,
+// line number, and function name of zap's caller, or not, depending on the
+// value of enabled. This is a generalized form of AddCaller.
+func WithCaller(enabled bool) Option {
+	return optionFunc(func(handler *Handler) {
+		handler.addCaller = enabled
+	})
+}
+
+// AddCallerSkip increases the number of callers skipped by caller annotation
+// (as enabled by the AddCaller option). When building wrappers around the
+// Logger and SugaredLogger, supplying this Option prevents zap from always
+// reporting the wrapper code as the caller.
+func AddCallerSkip(skip int) Option {
+	return optionFunc(func(log *Handler) {
+		log.callerSkip += skip
+	})
+}
+
+// AddStacktrace configures the Logger to record a stack trace for all messages at
+// or above a given level.
+func AddStacktrace(lvl zapcore.LevelEnabler) Option {
+	return optionFunc(func(log *Handler) {
+		log.addStack = lvl
+	})
+}

--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -43,9 +43,8 @@ func WithName(name string) Option {
 	})
 }
 
-// WithCaller configures the Logger to annotate each message with the filename,
-// line number, and function name of Zap's caller, or not, depending on the
-// value of enabled.
+// WithCaller configures the Logger to include the filename and line number
+// of the caller in log messages--if available.
 func WithCaller(enabled bool) Option {
 	return optionFunc(func(handler *Handler) {
 		handler.addCaller = enabled

--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -40,15 +40,9 @@ func WithName(name string) Option {
 	})
 }
 
-// AddCaller configures the Logger to annotate each message with the filename,
-// line number, and function name of zap's caller. See also WithCaller.
-func AddCaller() Option {
-	return WithCaller(true)
-}
-
 // WithCaller configures the Logger to annotate each message with the filename,
-// line number, and function name of zap's caller, or not, depending on the
-// value of enabled. This is a generalized form of AddCaller.
+// line number, and function name of Zap's caller, or not, depending on the
+// value of enabled.
 func WithCaller(enabled bool) Option {
 	return optionFunc(func(handler *Handler) {
 		handler.addCaller = enabled

--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -52,11 +52,13 @@ func WithCaller(enabled bool) Option {
 	})
 }
 
-// AddCallerSkip increases the number of callers skipped by caller annotation
-// (as enabled by the AddCaller option). When building wrappers around the
-// Logger and SugaredLogger, supplying this Option prevents zap from always
-// reporting the wrapper code as the caller.
-func AddCallerSkip(skip int) Option {
+// WithCallerSkip increases the number of callers skipped by caller annotation
+// (as enabled by the [WithCaller] option).
+//
+// When building wrappers around the Logger,
+// supplying this Option prevents Zap from always reporting
+// the wrapper code as the caller.
+func WithCallerSkip(skip int) Option {
 	return optionFunc(func(log *Handler) {
 		log.callerSkip += skip
 	})

--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -22,7 +22,7 @@
 
 package zapslog
 
-import "go.uber.org/zap/zapcore"
+import "log/slog"
 
 // An Option configures a slog Handler.
 type Option interface {
@@ -64,10 +64,10 @@ func WithCallerSkip(skip int) Option {
 	})
 }
 
-// AddStacktrace configures the Logger to record a stack trace for all messages at
-// or above a given level.
-func AddStacktrace(lvl zapcore.LevelEnabler) Option {
+// AddStacktraceAt configures the Logger to record a stack trace
+// for all messages at or above a given level.
+func AddStacktraceAt(lvl slog.Level) Option {
 	return optionFunc(func(log *Handler) {
-		log.addStack = lvl
+		log.addStackAt = lvl
 	})
 }

--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -24,6 +24,7 @@ package zapslog
 
 import "go.uber.org/zap/zapcore"
 
+// An Option configures a slog Handler.
 type Option interface {
 	apply(*Handler)
 }

--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build go1.21
+
 package zapslog
 
 import "go.uber.org/zap/zapcore"


### PR DESCRIPTION
fix: https://github.com/uber-go/zap/issues/1329

As discussed in the issue, replacing the `HandlersOptions` with functional options, i also renamed `addSource` to `addCaller` to properly match the `zap` semantic.