### PR TITLE
zapslog: Handler should ignore an empty Attr

### DIFF
--- a/exp/zapslog/handler.go
+++ b/exp/zapslog/handler.go
@@ -159,6 +159,10 @@ func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
 
 	fields := make([]zapcore.Field, 0, record.NumAttrs())
 	record.Attrs(func(attr slog.Attr) bool {
+		if attr.Equal(slog.Attr{}) {
+			return true // ignore empty attributes
+		}
+
 		fields = append(fields, convertAttrToField(attr))
 		return true
 	})
@@ -169,9 +173,12 @@ func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
 // WithAttrs returns a new Handler whose attributes consist of
 // both the receiver's attributes and the arguments.
 func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	fields := make([]zapcore.Field, len(attrs))
-	for i, attr := range attrs {
-		fields[i] = convertAttrToField(attr)
+	fields := make([]zapcore.Field, 0, len(attrs))
+	for _, attr := range attrs {
+		if attr.Equal(slog.Attr{}) {
+			continue // ignore empty attributes
+		}
+		fields = append(fields, convertAttrToField(attr))
 	}
 	return h.withFields(fields...)
 }


### PR DESCRIPTION
Per the slog.Handler contract,
handlers should not log attributes that are equal to the zero value.
This is equivalent to Zap's `zap.Skip()`.

Discovered by #1335
Refs #1334
