### PR TITLE
Improve string encoding by following json approach

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -43,7 +43,7 @@ func (b *Buffer) AppendByte(v byte) {
 }
 
 // AppendByteV writes a single byte to the Buffer.
-func (b *Buffer) AppendByteV(v ...byte) {
+func (b *Buffer) AppendBytes(v []byte) {
 	b.bs = append(b.bs, v...)
 }
 

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -42,7 +42,7 @@ func (b *Buffer) AppendByte(v byte) {
 	b.bs = append(b.bs, v)
 }
 
-// AppendByteV writes a single byte to the Buffer.
+// AppendBytes writes a single byte to the Buffer.
 func (b *Buffer) AppendBytes(v []byte) {
 	b.bs = append(b.bs, v...)
 }

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -42,6 +42,11 @@ func (b *Buffer) AppendByte(v byte) {
 	b.bs = append(b.bs, v)
 }
 
+// AppendByteV writes a single byte to the Buffer.
+func (b *Buffer) AppendByteV(v ...byte) {
+	b.bs = append(b.bs, v...)
+}
+
 // AppendString writes a string to the Buffer.
 func (b *Buffer) AppendString(s string) {
 	b.bs = append(b.bs, s...)

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -563,18 +563,20 @@ func safeAppendStringLike[S []byte | string](
 			continue
 		}
 
-		appendTo(buf, s[last:i])
-
 		r, size := decodeRune(s[i:])
 		if r == utf8.RuneError && size == 1 {
+			// Invalid UTF-8 sequence.
+			// Replace it with the Unicode replacement character.
+			appendTo(buf, s[last:i])
 			buf.AppendString(`\ufffd`)
 			i++
 			last = i
 			continue
 		}
-		appendTo(buf, s[i:i+size])
+
+		// No special handling required.
+		// Skip over this rune and continue.
 		i += size
-		last = i
 	}
 
 	// add remaining

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -553,7 +553,8 @@ func safeAppendStringLike[S []byte | string](
 		appendTo(buf, s[start:i])
 
 		r, size := decodeRune(s[i:])
-		if tryAddRuneError(buf, r, size) {
+		if r == utf8.RuneError && size == 1 {
+			buf.AppendString(`\ufffd`)
 			i++
 			start = i
 			continue
@@ -565,12 +566,4 @@ func safeAppendStringLike[S []byte | string](
 
 	// add remaining
 	appendTo(buf, s[start:])
-}
-
-func tryAddRuneError(buf *buffer.Buffer, r rune, size int) bool {
-	if r == utf8.RuneError && size == 1 {
-		buf.AppendString(`\ufffd`)
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
Recently we found an application were using zap.Reflect was faster than using zapcore.ObjectMarshaler. After profiling we found that string encoding is really expensive. I replicated what encoding/json does and was able to get greater performance than Reflect.

I had to modify the benchmark to have a greater number of strings.

### Benchmark results

```
goos: linux
goarch: amd64
pkg: go.uber.org/zap/zapcore
cpu: AMD EPYC 7B13
               │ /tmp/old.txt │            /tmp/new.txt             │
               │    sec/op    │   sec/op     vs base                │
ZapJSON-8         89.10µ ± 1%   33.38µ ± 3%  -62.54% (p=0.000 n=10)
StandardJSON-8    40.74µ ± 1%   42.46µ ± 1%   +4.22% (p=0.000 n=10)
geomean           60.25µ        37.65µ       -37.52%
```