### PR TITLE
zapslog: Handle empty attrs centrally

### DIFF
--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -113,6 +113,18 @@ func TestEmptyAttr(t *testing.T) {
 			"foo": "bar",
 		}, logs[0].ContextMap(), "Unexpected context")
 	})
+
+	t.Run("Group", func(t *testing.T) {
+		sl.With("k", slog.GroupValue(slog.String("foo", "bar"), slog.Attr{})).Info("msg")
+
+		logs := observedLogs.TakeAll()
+		require.Len(t, logs, 1, "Expected exactly one entry to be logged")
+		assert.Equal(t, map[string]any{
+			"k": map[string]any{
+				"foo": "bar",
+			},
+		}, logs[0].ContextMap(), "Unexpected context")
+	})
 }
 
 func TestWithName(t *testing.T) {


### PR DESCRIPTION
Follow-up to #1344 to handle empty attributes using a skip field in a single place, so each caller of `convertAttrToField` doesn't have to check for empty attributes explicitly.