### PR TITLE
chore(CHANGELOG): Move reference links to sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 1.25.0 (1 Aug 2023)
 
@@ -47,7 +47,6 @@ Enhancements:
 
 [#1147]: https://github.com/uber-go/zap/pull/1147
 [#1155]: https://github.com/uber-go/zap/pull/1155
-
 
 ## 1.22.0 (8 Aug 2022)
 
@@ -197,6 +196,16 @@ Enhancements:
 
 Thanks to @ash2k, @FMLS, @jimmystewpot, @Oncilla, @tsoslow, @tylitianrui, @withshubh, and @wziww for their contributions to this release.
 
+[#865]: https://github.com/uber-go/zap/pull/865
+[#867]: https://github.com/uber-go/zap/pull/867
+[#881]: https://github.com/uber-go/zap/pull/881
+[#903]: https://github.com/uber-go/zap/pull/903
+[#912]: https://github.com/uber-go/zap/pull/912
+[#913]: https://github.com/uber-go/zap/pull/913
+[#928]: https://github.com/uber-go/zap/pull/928
+[#931]: https://github.com/uber-go/zap/pull/931
+[#936]: https://github.com/uber-go/zap/pull/936
+
 ## 1.16.0 (1 Sep 2020)
 
 Bugfixes:
@@ -218,6 +227,17 @@ Enhancements:
 
 Thanks to @SteelPhase, @tmshn, @lixingwang, @wyxloading, @moul, @segevfiner, @andy-retailnext and @jcorbin for their contributions to this release.
 
+[#629]: https://github.com/uber-go/zap/pull/629
+[#697]: https://github.com/uber-go/zap/pull/697
+[#828]: https://github.com/uber-go/zap/pull/828
+[#835]: https://github.com/uber-go/zap/pull/835
+[#843]: https://github.com/uber-go/zap/pull/843
+[#844]: https://github.com/uber-go/zap/pull/844
+[#852]: https://github.com/uber-go/zap/pull/852
+[#854]: https://github.com/uber-go/zap/pull/854
+[#861]: https://github.com/uber-go/zap/pull/861
+[#862]: https://github.com/uber-go/zap/pull/862
+
 ## 1.15.0 (23 Apr 2020)
 
 Bugfixes:
@@ -234,6 +254,11 @@ Enhancements:
 
 Thanks to @danielbprice for their contributions to this release.
 
+[#804]: https://github.com/uber-go/zap/pull/804
+[#812]: https://github.com/uber-go/zap/pull/812
+[#806]: https://github.com/uber-go/zap/pull/806
+[#813]: https://github.com/uber-go/zap/pull/813
+
 ## 1.14.1 (14 Mar 2020)
 
 Bugfixes:
@@ -246,6 +271,10 @@ Bugfixes:
 
 Thanks to @YashishDua for their contributions to this release.
 
+[#791]: https://github.com/uber-go/zap/pull/791
+[#795]: https://github.com/uber-go/zap/pull/795
+[#799]: https://github.com/uber-go/zap/pull/799
+
 ## 1.14.0 (20 Feb 2020)
 
 Enhancements:
@@ -256,6 +285,11 @@ Enhancements:
 
 Thanks to @caibirdme for their contributions to this release.
 
+[#771]: https://github.com/uber-go/zap/pull/771
+[#773]: https://github.com/uber-go/zap/pull/773
+[#775]: https://github.com/uber-go/zap/pull/775
+[#786]: https://github.com/uber-go/zap/pull/786
+
 ## 1.13.0 (13 Nov 2019)
 
 Enhancements:
@@ -264,10 +298,14 @@ Enhancements:
 
 Thanks to @jbizzle for their contributions to this release.
 
+[#758]: https://github.com/uber-go/zap/pull/758
+
 ## 1.12.0 (29 Oct 2019)
 
 Enhancements:
 * [#751][]: Migrate to Go modules.
+
+[#751]: https://github.com/uber-go/zap/pull/751
 
 ## 1.11.0 (21 Oct 2019)
 
@@ -276,6 +314,9 @@ Enhancements:
 * [#736][]: Add `RFC3339` and `RFC3339Nano` time encoders.
 
 Thanks to @juicemia, @uhthomas for their contributions to this release.
+
+[#725]: https://github.com/uber-go/zap/pull/725
+[#736]: https://github.com/uber-go/zap/pull/736
 
 ## 1.10.0 (29 Apr 2019)
 
@@ -294,11 +335,19 @@ Enhancements:
 Thanks to @iaroslav-ciupin, @lelenanam, @joa, @NWilson for their contributions
 to this release.
 
+[#657]: https://github.com/uber-go/zap/pull/657
+[#706]: https://github.com/uber-go/zap/pull/706
+[#610]: https://github.com/uber-go/zap/pull/610
+[#675]: https://github.com/uber-go/zap/pull/675
+[#704]: https://github.com/uber-go/zap/pull/704
+
 ## v1.9.1 (06 Aug 2018)
 
 Bugfixes:
 
 * [#614][]: MapObjectEncoder should not ignore empty slices.
+
+[#614]: https://github.com/uber-go/zap/pull/614
 
 ## v1.9.0 (19 Jul 2018)
 
@@ -308,6 +357,10 @@ Enhancements:
 
 Thanks to @nfarah86, @AlekSi, @JeanMertz, @philippgille, @etsangsplk, and
 @dimroc for their contributions to this release.
+
+[#602]: https://github.com/uber-go/zap/pull/602
+[#572]: https://github.com/uber-go/zap/pull/572
+[#606]: https://github.com/uber-go/zap/pull/606
 
 ## v1.8.0 (13 Apr 2018)
 
@@ -322,10 +375,17 @@ Bugfixes:
 
 Thanks to @DiSiqueira and @djui for their contributions to this release.
 
+[#508]: https://github.com/uber-go/zap/pull/508
+[#518]: https://github.com/uber-go/zap/pull/518
+[#577]: https://github.com/uber-go/zap/pull/577
+[#574]: https://github.com/uber-go/zap/pull/574
+
 ## v1.7.1 (25 Sep 2017)
 
 Bugfixes:
 * [#504][]: Store strings when using AddByteString with the map encoder.
+
+[#504]: https://github.com/uber-go/zap/pull/504
 
 ## v1.7.0 (21 Sep 2017)
 
@@ -334,6 +394,8 @@ Enhancements:
 * [#487][]: Add `NewStdLogAt`, which extends `NewStdLog` by allowing the user
   to specify the level of the logged messages.
 
+[#487]: https://github.com/uber-go/zap/pull/487
+
 ## v1.6.0 (30 Aug 2017)
 
 Enhancements:
@@ -341,6 +403,9 @@ Enhancements:
 * [#491][]: Omit zap stack frames from stacktraces.
 * [#490][]: Add a `ContextMap` method to observer logs for simpler
   field validation in tests.
+
+[#490]: https://github.com/uber-go/zap/pull/490
+[#491]: https://github.com/uber-go/zap/pull/491
 
 ## v1.5.0 (22 Jul 2017)
 
@@ -355,6 +420,11 @@ Bugfixes:
 
 Thanks to @richard-tunein and @pavius for their contributions to this release.
 
+[#477]: https://github.com/uber-go/zap/pull/477
+[#465]: https://github.com/uber-go/zap/pull/465
+[#460]: https://github.com/uber-go/zap/pull/460
+[#470]: https://github.com/uber-go/zap/pull/470
+
 ## v1.4.1 (08 Jun 2017)
 
 This release fixes two bugs.
@@ -363,6 +433,9 @@ Bugfixes:
 
 * [#435][]: Support a variety of case conventions when unmarshaling levels.
 * [#444][]: Fix a panic in the observer.
+
+[#435]: https://github.com/uber-go/zap/pull/435
+[#444]: https://github.com/uber-go/zap/pull/444
 
 ## v1.4.0 (12 May 2017)
 
@@ -376,6 +449,10 @@ Enhancements:
 * [#431][]: Make `zap.AtomicLevel` implement `fmt.Stringer`, which makes a
   variety of operations a bit simpler.
 
+[#424]: https://github.com/uber-go/zap/pull/424
+[#425]: https://github.com/uber-go/zap/pull/425
+[#431]: https://github.com/uber-go/zap/pull/431
+
 ## v1.3.0 (25 Apr 2017)
 
 This release adds an enhancement to zap's testing helpers as well as the
@@ -387,6 +464,9 @@ Enhancements:
   particularly useful when testing the `SugaredLogger`.
 * [#416][]: Make `AtomicLevel` implement `encoding.TextMarshaler`.
 
+[#415]: https://github.com/uber-go/zap/pull/415
+[#416]: https://github.com/uber-go/zap/pull/416
+
 ## v1.2.0 (13 Apr 2017)
 
 This release adds a gRPC compatibility wrapper. It is fully backward-compatible.
@@ -395,6 +475,8 @@ Enhancements:
 
 * [#402][]: Add a `zapgrpc` package that wraps zap's Logger and implements
   `grpclog.Logger`.
+
+[#402]: https://github.com/uber-go/zap/pull/402
 
 ## v1.1.0 (31 Mar 2017)
 
@@ -412,6 +494,10 @@ Enhancements:
 * [#386][]: Add filtering helpers to zaptest's observing logger.
 
 Thanks to @moitias for contributing to this release.
+
+[#385]: https://github.com/uber-go/zap/pull/385
+[#396]: https://github.com/uber-go/zap/pull/396
+[#386]: https://github.com/uber-go/zap/pull/386
 
 ## v1.0.0 (14 Mar 2017)
 
@@ -458,6 +544,20 @@ Enhancements:
 Thanks to @suyash, @htrendev, @flisky, @Ulexus, and @skipor for their
 contributions to this release.
 
+[#366]: https://github.com/uber-go/zap/pull/366
+[#364]: https://github.com/uber-go/zap/pull/364
+[#371]: https://github.com/uber-go/zap/pull/371
+[#362]: https://github.com/uber-go/zap/pull/362
+[#369]: https://github.com/uber-go/zap/pull/369
+[#347]: https://github.com/uber-go/zap/pull/347
+[#373]: https://github.com/uber-go/zap/pull/373
+[#348]: https://github.com/uber-go/zap/pull/348
+[#327]: https://github.com/uber-go/zap/pull/327
+[#376]: https://github.com/uber-go/zap/pull/376
+[#346]: https://github.com/uber-go/zap/pull/346
+[#365]: https://github.com/uber-go/zap/pull/365
+[#372]: https://github.com/uber-go/zap/pull/372
+
 ## v1.0.0-rc.3 (7 Mar 2017)
 
 This is the third release candidate for zap's stable release. There are no
@@ -478,6 +578,11 @@ Enhancements:
   machinery are now omitted from stacktraces.
 
 Thanks to @ansel1 and @suyash for their contributions to this release.
+
+[#339]: https://github.com/uber-go/zap/pull/339
+[#307]: https://github.com/uber-go/zap/pull/307
+[#353]: https://github.com/uber-go/zap/pull/353
+[#311]: https://github.com/uber-go/zap/pull/311
 
 ## v1.0.0-rc.2 (21 Feb 2017)
 
@@ -516,6 +621,15 @@ Enhancements:
 
 Thanks to @skipor and @chapsuk for their contributions to this release.
 
+[#316]: https://github.com/uber-go/zap/pull/316
+[#309]: https://github.com/uber-go/zap/pull/309
+[#317]: https://github.com/uber-go/zap/pull/317
+[#321]: https://github.com/uber-go/zap/pull/321
+[#325]: https://github.com/uber-go/zap/pull/325
+[#333]: https://github.com/uber-go/zap/pull/333
+[#326]: https://github.com/uber-go/zap/pull/326
+[#300]: https://github.com/uber-go/zap/pull/300
+
 ## v1.0.0-rc.1 (14 Feb 2017)
 
 This is the first release candidate for zap's stable release. There are multiple
@@ -544,95 +658,3 @@ backward compatibility concerns and all functionality is new.
 
 Early zap adopters should pin to the 0.1.x minor version until they're ready to
 upgrade to the upcoming stable release.
-
-[#316]: https://github.com/uber-go/zap/pull/316
-[#309]: https://github.com/uber-go/zap/pull/309
-[#317]: https://github.com/uber-go/zap/pull/317
-[#321]: https://github.com/uber-go/zap/pull/321
-[#325]: https://github.com/uber-go/zap/pull/325
-[#333]: https://github.com/uber-go/zap/pull/333
-[#326]: https://github.com/uber-go/zap/pull/326
-[#300]: https://github.com/uber-go/zap/pull/300
-[#339]: https://github.com/uber-go/zap/pull/339
-[#307]: https://github.com/uber-go/zap/pull/307
-[#353]: https://github.com/uber-go/zap/pull/353
-[#311]: https://github.com/uber-go/zap/pull/311
-[#366]: https://github.com/uber-go/zap/pull/366
-[#364]: https://github.com/uber-go/zap/pull/364
-[#371]: https://github.com/uber-go/zap/pull/371
-[#362]: https://github.com/uber-go/zap/pull/362
-[#369]: https://github.com/uber-go/zap/pull/369
-[#347]: https://github.com/uber-go/zap/pull/347
-[#373]: https://github.com/uber-go/zap/pull/373
-[#348]: https://github.com/uber-go/zap/pull/348
-[#327]: https://github.com/uber-go/zap/pull/327
-[#376]: https://github.com/uber-go/zap/pull/376
-[#346]: https://github.com/uber-go/zap/pull/346
-[#365]: https://github.com/uber-go/zap/pull/365
-[#372]: https://github.com/uber-go/zap/pull/372
-[#385]: https://github.com/uber-go/zap/pull/385
-[#396]: https://github.com/uber-go/zap/pull/396
-[#386]: https://github.com/uber-go/zap/pull/386
-[#402]: https://github.com/uber-go/zap/pull/402
-[#415]: https://github.com/uber-go/zap/pull/415
-[#416]: https://github.com/uber-go/zap/pull/416
-[#424]: https://github.com/uber-go/zap/pull/424
-[#425]: https://github.com/uber-go/zap/pull/425
-[#431]: https://github.com/uber-go/zap/pull/431
-[#435]: https://github.com/uber-go/zap/pull/435
-[#444]: https://github.com/uber-go/zap/pull/444
-[#477]: https://github.com/uber-go/zap/pull/477
-[#465]: https://github.com/uber-go/zap/pull/465
-[#460]: https://github.com/uber-go/zap/pull/460
-[#470]: https://github.com/uber-go/zap/pull/470
-[#487]: https://github.com/uber-go/zap/pull/487
-[#490]: https://github.com/uber-go/zap/pull/490
-[#491]: https://github.com/uber-go/zap/pull/491
-[#504]: https://github.com/uber-go/zap/pull/504
-[#508]: https://github.com/uber-go/zap/pull/508
-[#518]: https://github.com/uber-go/zap/pull/518
-[#577]: https://github.com/uber-go/zap/pull/577
-[#574]: https://github.com/uber-go/zap/pull/574
-[#602]: https://github.com/uber-go/zap/pull/602
-[#572]: https://github.com/uber-go/zap/pull/572
-[#606]: https://github.com/uber-go/zap/pull/606
-[#614]: https://github.com/uber-go/zap/pull/614
-[#657]: https://github.com/uber-go/zap/pull/657
-[#706]: https://github.com/uber-go/zap/pull/706
-[#610]: https://github.com/uber-go/zap/pull/610
-[#675]: https://github.com/uber-go/zap/pull/675
-[#704]: https://github.com/uber-go/zap/pull/704
-[#725]: https://github.com/uber-go/zap/pull/725
-[#736]: https://github.com/uber-go/zap/pull/736
-[#751]: https://github.com/uber-go/zap/pull/751
-[#758]: https://github.com/uber-go/zap/pull/758
-[#771]: https://github.com/uber-go/zap/pull/771
-[#773]: https://github.com/uber-go/zap/pull/773
-[#775]: https://github.com/uber-go/zap/pull/775
-[#786]: https://github.com/uber-go/zap/pull/786
-[#791]: https://github.com/uber-go/zap/pull/791
-[#795]: https://github.com/uber-go/zap/pull/795
-[#799]: https://github.com/uber-go/zap/pull/799
-[#804]: https://github.com/uber-go/zap/pull/804
-[#812]: https://github.com/uber-go/zap/pull/812
-[#806]: https://github.com/uber-go/zap/pull/806
-[#813]: https://github.com/uber-go/zap/pull/813
-[#629]: https://github.com/uber-go/zap/pull/629
-[#697]: https://github.com/uber-go/zap/pull/697
-[#828]: https://github.com/uber-go/zap/pull/828
-[#835]: https://github.com/uber-go/zap/pull/835
-[#843]: https://github.com/uber-go/zap/pull/843
-[#844]: https://github.com/uber-go/zap/pull/844
-[#852]: https://github.com/uber-go/zap/pull/852
-[#854]: https://github.com/uber-go/zap/pull/854
-[#861]: https://github.com/uber-go/zap/pull/861
-[#862]: https://github.com/uber-go/zap/pull/862
-[#865]: https://github.com/uber-go/zap/pull/865
-[#867]: https://github.com/uber-go/zap/pull/867
-[#881]: https://github.com/uber-go/zap/pull/881
-[#903]: https://github.com/uber-go/zap/pull/903
-[#912]: https://github.com/uber-go/zap/pull/912
-[#913]: https://github.com/uber-go/zap/pull/913
-[#928]: https://github.com/uber-go/zap/pull/928
-[#931]: https://github.com/uber-go/zap/pull/931
-[#936]: https://github.com/uber-go/zap/pull/936


### PR DESCRIPTION
Some of the links in the changelog entries
are at the bottom of the changelog file
while others are in the section where they're used.

Adding these to the bottom of the file is unmanageable.
They should be added to the section where they're used.

This moves all remaining links from the bottom of the file
to the sections where they're used.
