### PR TITLE
chore(changelog): Drop 'v' prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,7 +352,7 @@ to this release.
 [#675]: https://github.com/uber-go/zap/pull/675
 [#704]: https://github.com/uber-go/zap/pull/704
 
-## v1.9.1 (06 Aug 2018)
+## 1.9.1 (06 Aug 2018)
 
 Bugfixes:
 
@@ -360,7 +360,7 @@ Bugfixes:
 
 [#614]: https://github.com/uber-go/zap/pull/614
 
-## v1.9.0 (19 Jul 2018)
+## 1.9.0 (19 Jul 2018)
 
 Enhancements:
 * [#602][]: Reduce number of allocations when logging with reflection.
@@ -373,7 +373,7 @@ Thanks to @nfarah86, @AlekSi, @JeanMertz, @philippgille, @etsangsplk, and
 [#572]: https://github.com/uber-go/zap/pull/572
 [#606]: https://github.com/uber-go/zap/pull/606
 
-## v1.8.0 (13 Apr 2018)
+## 1.8.0 (13 Apr 2018)
 
 Enhancements:
 * [#508][]: Make log level configurable when redirecting the standard
@@ -391,14 +391,14 @@ Thanks to @DiSiqueira and @djui for their contributions to this release.
 [#577]: https://github.com/uber-go/zap/pull/577
 [#574]: https://github.com/uber-go/zap/pull/574
 
-## v1.7.1 (25 Sep 2017)
+## 1.7.1 (25 Sep 2017)
 
 Bugfixes:
 * [#504][]: Store strings when using AddByteString with the map encoder.
 
 [#504]: https://github.com/uber-go/zap/pull/504
 
-## v1.7.0 (21 Sep 2017)
+## 1.7.0 (21 Sep 2017)
 
 Enhancements:
 
@@ -407,7 +407,7 @@ Enhancements:
 
 [#487]: https://github.com/uber-go/zap/pull/487
 
-## v1.6.0 (30 Aug 2017)
+## 1.6.0 (30 Aug 2017)
 
 Enhancements:
 
@@ -418,7 +418,7 @@ Enhancements:
 [#490]: https://github.com/uber-go/zap/pull/490
 [#491]: https://github.com/uber-go/zap/pull/491
 
-## v1.5.0 (22 Jul 2017)
+## 1.5.0 (22 Jul 2017)
 
 Enhancements:
 
@@ -436,7 +436,7 @@ Thanks to @richard-tunein and @pavius for their contributions to this release.
 [#460]: https://github.com/uber-go/zap/pull/460
 [#470]: https://github.com/uber-go/zap/pull/470
 
-## v1.4.1 (08 Jun 2017)
+## 1.4.1 (08 Jun 2017)
 
 This release fixes two bugs.
 
@@ -448,7 +448,7 @@ Bugfixes:
 [#435]: https://github.com/uber-go/zap/pull/435
 [#444]: https://github.com/uber-go/zap/pull/444
 
-## v1.4.0 (12 May 2017)
+## 1.4.0 (12 May 2017)
 
 This release adds a few small features and is fully backward-compatible.
 
@@ -464,7 +464,7 @@ Enhancements:
 [#425]: https://github.com/uber-go/zap/pull/425
 [#431]: https://github.com/uber-go/zap/pull/431
 
-## v1.3.0 (25 Apr 2017)
+## 1.3.0 (25 Apr 2017)
 
 This release adds an enhancement to zap's testing helpers as well as the
 ability to marshal an AtomicLevel. It is fully backward-compatible.
@@ -478,7 +478,7 @@ Enhancements:
 [#415]: https://github.com/uber-go/zap/pull/415
 [#416]: https://github.com/uber-go/zap/pull/416
 
-## v1.2.0 (13 Apr 2017)
+## 1.2.0 (13 Apr 2017)
 
 This release adds a gRPC compatibility wrapper. It is fully backward-compatible.
 
@@ -489,7 +489,7 @@ Enhancements:
 
 [#402]: https://github.com/uber-go/zap/pull/402
 
-## v1.1.0 (31 Mar 2017)
+## 1.1.0 (31 Mar 2017)
 
 This release fixes two bugs and adds some enhancements to zap's testing helpers.
 It is fully backward-compatible.
@@ -510,7 +510,7 @@ Thanks to @moitias for contributing to this release.
 [#396]: https://github.com/uber-go/zap/pull/396
 [#386]: https://github.com/uber-go/zap/pull/386
 
-## v1.0.0 (14 Mar 2017)
+## 1.0.0 (14 Mar 2017)
 
 This is zap's first stable release. All exported APIs are now final, and no
 further breaking changes will be made in the 1.x release series. Anyone using a
@@ -569,7 +569,7 @@ contributions to this release.
 [#365]: https://github.com/uber-go/zap/pull/365
 [#372]: https://github.com/uber-go/zap/pull/372
 
-## v1.0.0-rc.3 (7 Mar 2017)
+## 1.0.0-rc.3 (7 Mar 2017)
 
 This is the third release candidate for zap's stable release. There are no
 breaking changes.
@@ -595,7 +595,7 @@ Thanks to @ansel1 and @suyash for their contributions to this release.
 [#353]: https://github.com/uber-go/zap/pull/353
 [#311]: https://github.com/uber-go/zap/pull/311
 
-## v1.0.0-rc.2 (21 Feb 2017)
+## 1.0.0-rc.2 (21 Feb 2017)
 
 This is the second release candidate for zap's stable release. It includes two
 breaking changes.
@@ -641,7 +641,7 @@ Thanks to @skipor and @chapsuk for their contributions to this release.
 [#326]: https://github.com/uber-go/zap/pull/326
 [#300]: https://github.com/uber-go/zap/pull/300
 
-## v1.0.0-rc.1 (14 Feb 2017)
+## 1.0.0-rc.1 (14 Feb 2017)
 
 This is the first release candidate for zap's stable release. There are multiple
 breaking changes and improvements from the pre-release version. Most notably:
@@ -661,7 +661,7 @@ breaking changes and improvements from the pre-release version. Most notably:
 * Sampling is more accurate, and doesn't depend on the standard library's shared
   timer heap.
 
-## v0.1.0-beta.1 (6 Feb 2017)
+## 0.1.0-beta.1 (6 Feb 2017)
 
 This is a minor version, tagged to allow users to pin to the pre-1.0 APIs and
 upgrade at their leisure. Since this is the first tagged release, there are no


### PR DESCRIPTION
Most recent releases lack the 'v' prefix in the release headings.
This drops the prefix from older releases for consistency.
