### PR TITLE
buffer: Fix AppendBytes doc string

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -42,7 +42,7 @@ func (b *Buffer) AppendByte(v byte) {
 	b.bs = append(b.bs, v)
 }
 
-// AppendBytes writes a single byte to the Buffer.
+// AppendBytes writes the given slice of bytes to the Buffer.
 func (b *Buffer) AppendBytes(v []byte) {
 	b.bs = append(b.bs, v...)
 }


### PR DESCRIPTION
Bad copy-paste; AppendBytes appends all the given bytes,
not just one byte.

Thanks to @makkes for catching this.
