### PR TITLE
fmt: Prefer gofumpt over gofmt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     - unused
 
     # Our own extras:
-    - gofmt
+    - gofumpt
     - nolintlint # lints nolint directives
     - revive
 

--- a/exp/zapfield/zapfield_test.go
+++ b/exp/zapfield/zapfield_test.go
@@ -60,7 +60,6 @@ func TestFieldConstructors(t *testing.T) {
 		}
 		assertCanBeReused(t, tt.field)
 	}
-
 }
 
 func assertCanBeReused(t testing.TB, field zap.Field) {

--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -166,7 +166,7 @@ func TestAttrKinds(t *testing.T) {
 		slog.Duration("duration", time.Hour),
 		slog.Float64("float64", 42.0),
 		slog.Int64("int64", -1234),
-		slog.Time("time", time.Date(2015, 10, 21, 7, 28, 00, 0, time.UTC)),
+		slog.Time("time", time.Date(2015, 10, 21, 7, 28, 0o0, 0, time.UTC)),
 		slog.Uint64("uint64", 2),
 		slog.Group("group", slog.String("inner", "inner-group")),
 		"logvaluer", testToken,

--- a/logger_test.go
+++ b/logger_test.go
@@ -126,7 +126,6 @@ func TestLoggerInitialFields(t *testing.T) {
 }
 
 func TestLoggerWith(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		initialFields []Field

--- a/zapcore/console_encoder_test.go
+++ b/zapcore/console_encoder_test.go
@@ -26,16 +26,14 @@ import (
 	. "go.uber.org/zap/zapcore"
 )
 
-var (
-	testEntry = Entry{
-		LoggerName: "main",
-		Level:      InfoLevel,
-		Message:    `hello`,
-		Time:       _epoch,
-		Stack:      "fake-stack",
-		Caller:     EntryCaller{Defined: true, File: "foo.go", Line: 42, Function: "foo.Foo"},
-	}
-)
+var testEntry = Entry{
+	LoggerName: "main",
+	Level:      InfoLevel,
+	Message:    `hello`,
+	Time:       _epoch,
+	Stack:      "fake-stack",
+	Caller:     EntryCaller{Defined: true, File: "foo.go", Line: 42, Function: "foo.Foo"},
+}
 
 func TestConsoleSeparator(t *testing.T) {
 	tests := []struct {

--- a/zapcore/lazy_with_test.go
+++ b/zapcore/lazy_with_test.go
@@ -76,9 +76,11 @@ func TestLazyCore(t *testing.T) {
 				{Level: zapcore.WarnLevel, Message: "log-at-warn"},
 			},
 			wantLogs: []observer.LoggedEntry{
-				{Entry: zapcore.Entry{
-					Level:   zapcore.WarnLevel,
-					Message: "log-at-warn"},
+				{
+					Entry: zapcore.Entry{
+						Level:   zapcore.WarnLevel,
+						Message: "log-at-warn",
+					},
 					Context: []zapcore.Field{},
 				},
 			},
@@ -102,9 +104,11 @@ func TestLazyCore(t *testing.T) {
 				{makeInt64Field("c", 33), makeInt64Field("d", 44)},
 			},
 			wantLogs: []observer.LoggedEntry{
-				{Entry: zapcore.Entry{
-					Level:   zapcore.WarnLevel,
-					Message: "log-at-warn"},
+				{
+					Entry: zapcore.Entry{
+						Level:   zapcore.WarnLevel,
+						Message: "log-at-warn",
+					},
 					Context: []zapcore.Field{
 						makeInt64Field("a", 11),
 						makeInt64Field("b", 22),

--- a/zapgrpc/zapgrpc.go
+++ b/zapgrpc/zapgrpc.go
@@ -36,16 +36,14 @@ const (
 	grpcLvlFatal
 )
 
-var (
-	// _grpcToZapLevel maps gRPC log levels to zap log levels.
-	// See https://pkg.go.dev/go.uber.org/zap@v1.16.0/zapcore#Level
-	_grpcToZapLevel = map[int]zapcore.Level{
-		grpcLvlInfo:  zapcore.InfoLevel,
-		grpcLvlWarn:  zapcore.WarnLevel,
-		grpcLvlError: zapcore.ErrorLevel,
-		grpcLvlFatal: zapcore.FatalLevel,
-	}
-)
+// _grpcToZapLevel maps gRPC log levels to zap log levels.
+// See https://pkg.go.dev/go.uber.org/zap@v1.16.0/zapcore#Level
+var _grpcToZapLevel = map[int]zapcore.Level{
+	grpcLvlInfo:  zapcore.InfoLevel,
+	grpcLvlWarn:  zapcore.WarnLevel,
+	grpcLvlError: zapcore.ErrorLevel,
+	grpcLvlFatal: zapcore.FatalLevel,
+}
 
 // An Option overrides a Logger's default configuration.
 type Option interface {


### PR DESCRIPTION
Switches to gofumpt for code formatting instead of gofmt.

This is a slightly stricter formatter and addresses common nits
such as extraneous empty lines at start and end of functions,
missing empty lines between functions,
unnecessary or missing var groups,
etc.
