### PR TITLE
lint: Enable paralleltest, fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,8 @@ linters:
 
     # Our own extras:
     - gofumpt
-    - nolintlint # lints nolint directives
+    - nolintlint   # lints nolint directives
+    - paralleltest # requires t.Parallel on all tests
     - revive
 
 linters-settings:

--- a/array_test.go
+++ b/array_test.go
@@ -53,6 +53,8 @@ func BenchmarkBoolsReflect(b *testing.B) {
 }
 
 func TestArrayWrappers(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc     string
 		field    Field
@@ -101,11 +103,16 @@ func TestArrayWrappers(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		enc := zapcore.NewMapObjectEncoder()
-		tt.field.Key = "k"
-		tt.field.AddTo(enc)
-		assert.Equal(t, tt.expected, enc.Fields["k"], "%s: unexpected map contents.", tt.desc)
-		assert.Equal(t, 1, len(enc.Fields), "%s: found extra keys in map: %v", tt.desc, enc.Fields)
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			enc := zapcore.NewMapObjectEncoder()
+			tt.field.Key = "k"
+			tt.field.AddTo(enc)
+			assert.Equal(t, tt.expected, enc.Fields["k"], "unexpected map contents")
+			assert.Equal(t, 1, len(enc.Fields), "found extra keys in map: %v", enc.Fields)
+		})
 	}
 }
 

--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -30,32 +30,86 @@ import (
 )
 
 func TestBufferWrites(t *testing.T) {
-	buf := NewPool().Get()
+	t.Parallel()
 
 	tests := []struct {
 		desc string
-		f    func()
+		f    func(*Buffer)
 		want string
 	}{
-		{"AppendByte", func() { buf.AppendByte('v') }, "v"},
-		{"AppendString", func() { buf.AppendString("foo") }, "foo"},
-		{"AppendIntPositive", func() { buf.AppendInt(42) }, "42"},
-		{"AppendIntNegative", func() { buf.AppendInt(-42) }, "-42"},
-		{"AppendUint", func() { buf.AppendUint(42) }, "42"},
-		{"AppendBool", func() { buf.AppendBool(true) }, "true"},
-		{"AppendFloat64", func() { buf.AppendFloat(3.14, 64) }, "3.14"},
+		{
+			desc: "AppendByte",
+			f:    func(buf *Buffer) { buf.AppendByte('v') },
+			want: "v",
+		},
+		{
+			desc: "AppendString",
+			f:    func(buf *Buffer) { buf.AppendString("foo") },
+			want: "foo",
+		},
+		{
+			desc: "AppendIntPositive",
+			f:    func(buf *Buffer) { buf.AppendInt(42) },
+			want: "42",
+		},
+		{
+			desc: "AppendIntNegative",
+			f:    func(buf *Buffer) { buf.AppendInt(-42) },
+			want: "-42",
+		},
+		{
+			desc: "AppendUint",
+			f:    func(buf *Buffer) { buf.AppendUint(42) },
+			want: "42",
+		},
+		{
+			desc: "AppendBool",
+			f:    func(buf *Buffer) { buf.AppendBool(true) },
+			want: "true",
+		},
+		{
+			desc: "AppendFloat64",
+			f:    func(buf *Buffer) { buf.AppendFloat(3.14, 64) },
+			want: "3.14",
+		},
 		// Intentionally introduce some floating-point error.
-		{"AppendFloat32", func() { buf.AppendFloat(float64(float32(3.14)), 32) }, "3.14"},
-		{"AppendWrite", func() { buf.Write([]byte("foo")) }, "foo"},
-		{"AppendTime", func() { buf.AppendTime(time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC), time.RFC3339) }, "2000-01-02T03:04:05Z"},
-		{"WriteByte", func() { buf.WriteByte('v') }, "v"},
-		{"WriteString", func() { buf.WriteString("foo") }, "foo"},
+		{
+			desc: "AppendFloat32",
+			f:    func(buf *Buffer) { buf.AppendFloat(float64(float32(3.14)), 32) },
+			want: "3.14",
+		},
+		{
+			desc: "AppendWrite",
+			f:    func(buf *Buffer) { buf.Write([]byte("foo")) },
+			want: "foo",
+		},
+		{
+			desc: "AppendTime",
+			f:    func(buf *Buffer) { buf.AppendTime(time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC), time.RFC3339) },
+			want: "2000-01-02T03:04:05Z",
+		},
+		{
+			desc: "WriteByte",
+			f:    func(buf *Buffer) { buf.WriteByte('v') },
+			want: "v",
+		},
+		{
+			desc: "WriteString",
+			f:    func(buf *Buffer) { buf.WriteString("foo") },
+			want: "foo",
+		},
 	}
 
+	pool := NewPool()
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			buf.Reset()
-			tt.f()
+			t.Parallel()
+
+			buf := pool.Get()
+			defer buf.Free()
+
+			tt.f(buf)
 			assert.Equal(t, tt.want, buf.String(), "Unexpected buffer.String().")
 			assert.Equal(t, tt.want, string(buf.Bytes()), "Unexpected string(buffer.Bytes()).")
 			assert.Equal(t, len(tt.want), buf.Len(), "Unexpected buffer length.")

--- a/buffer/pool_test.go
+++ b/buffer/pool_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestBuffers(t *testing.T) {
+	t.Parallel()
+
 	const dummyData = "dummy data"
 	p := NewPool()
 

--- a/clock_test.go
+++ b/clock_test.go
@@ -37,6 +37,8 @@ func (c constantClock) NewTicker(d time.Duration) *time.Ticker {
 }
 
 func TestWithClock(t *testing.T) {
+	t.Parallel()
+
 	date := time.Date(2077, 1, 23, 10, 15, 13, 441, time.UTC)
 	clock := constantClock(date)
 	withLogger(t, DebugLevel, []Option{WithClock(clock)}, func(log *Logger, logs *observer.ObservedLogs) {

--- a/config_test.go
+++ b/config_test.go
@@ -32,6 +32,8 @@ import (
 )
 
 func TestConfig(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc     string
 		cfg      Config
@@ -57,7 +59,10 @@ func TestConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			logOut := filepath.Join(t.TempDir(), "test.log")
 
 			tt.cfg.OutputPaths = []string{logOut}
@@ -86,6 +91,8 @@ func TestConfig(t *testing.T) {
 }
 
 func TestConfigWithInvalidPaths(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc      string
 		output    string
@@ -97,7 +104,10 @@ func TestConfigWithInvalidPaths(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := NewProductionConfig()
 			cfg.OutputPaths = []string{tt.output}
 			cfg.ErrorOutputPaths = []string{tt.errOutput}
@@ -108,6 +118,8 @@ func TestConfigWithInvalidPaths(t *testing.T) {
 }
 
 func TestConfigWithMissingAttributes(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc      string
 		cfg       Config
@@ -135,7 +147,10 @@ func TestConfigWithMissingAttributes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := tt.cfg
 			_, err := cfg.Build()
 			assert.EqualError(t, err, tt.expectErr)
@@ -159,6 +174,8 @@ func makeSamplerCountingHook() (h func(zapcore.Entry, zapcore.SamplingDecision),
 }
 
 func TestConfigWithSamplingHook(t *testing.T) {
+	t.Parallel()
+
 	shook, dcount, scount := makeSamplerCountingHook()
 	cfg := Config{
 		Level:       NewAtomicLevelAt(InfoLevel),

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -29,9 +29,12 @@ import (
 )
 
 func TestRegisterDefaultEncoders(t *testing.T) {
+	t.Parallel()
+
 	testEncodersRegistered(t, "console", "json")
 }
 
+//nolint:paralleltest // modifies global registry
 func TestRegisterEncoder(t *testing.T) {
 	testEncoders(func() {
 		assert.NoError(t, RegisterEncoder("foo", newNilEncoder), "expected to be able to register the encoder foo")
@@ -39,6 +42,7 @@ func TestRegisterEncoder(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // modifies global registry
 func TestDuplicateRegisterEncoder(t *testing.T) {
 	testEncoders(func() {
 		assert.NoError(t, RegisterEncoder("foo", newNilEncoder), "expected to be able to register the encoder foo")
@@ -47,9 +51,12 @@ func TestDuplicateRegisterEncoder(t *testing.T) {
 }
 
 func TestRegisterEncoderNoName(t *testing.T) {
+	t.Parallel()
+
 	assert.Equal(t, errNoEncoderNameSpecified, RegisterEncoder("", newNilEncoder), "expected an error when registering an encoder with no name")
 }
 
+//nolint:paralleltest // modifies global registry
 func TestNewEncoder(t *testing.T) {
 	testEncoders(func() {
 		assert.NoError(t, RegisterEncoder("foo", newNilEncoder), "expected to be able to register the encoder foo")
@@ -60,11 +67,15 @@ func TestNewEncoder(t *testing.T) {
 }
 
 func TestNewEncoderNotRegistered(t *testing.T) {
+	t.Parallel()
+
 	_, err := newEncoder("foo", zapcore.EncoderConfig{})
 	assert.Error(t, err, "expected an error when trying to create an encoder of an unregistered name")
 }
 
 func TestNewEncoderNoName(t *testing.T) {
+	t.Parallel()
+
 	_, err := newEncoder("", zapcore.EncoderConfig{})
 	assert.Equal(t, errNoEncoderNameSpecified, err, "expected an error when creating an encoder with no name")
 }

--- a/error_test.go
+++ b/error_test.go
@@ -32,6 +32,8 @@ import (
 )
 
 func TestErrorConstructors(t *testing.T) {
+	t.Parallel()
+
 	fail := errors.New("fail")
 
 	tests := []struct {
@@ -48,14 +50,21 @@ func TestErrorConstructors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if !assert.Equal(t, tt.expect, tt.field, "Unexpected output from convenience field constructor %s.", tt.name) {
-			t.Logf("type expected: %T\nGot: %T", tt.expect.Interface, tt.field.Interface)
-		}
-		assertCanBeReused(t, tt.field)
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if !assert.Equal(t, tt.expect, tt.field, "Unexpected output from convenience field constructor %s.", tt.name) {
+				t.Logf("type expected: %T\nGot: %T", tt.expect.Interface, tt.field.Interface)
+			}
+			assertCanBeReused(t, tt.field)
+		})
 	}
 }
 
 func TestErrorArrayConstructor(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc     string
 		field    Field
@@ -70,15 +79,22 @@ func TestErrorArrayConstructor(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		enc := zapcore.NewMapObjectEncoder()
-		tt.field.Key = "k"
-		tt.field.AddTo(enc)
-		assert.Equal(t, tt.expected, enc.Fields["k"], "%s: unexpected map contents.", tt.desc)
-		assert.Equal(t, 1, len(enc.Fields), "%s: found extra keys in map: %v", tt.desc, enc.Fields)
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			enc := zapcore.NewMapObjectEncoder()
+			tt.field.Key = "k"
+			tt.field.AddTo(enc)
+			assert.Equal(t, tt.expected, enc.Fields["k"], "%s: unexpected map contents.", tt.desc)
+			assert.Equal(t, 1, len(enc.Fields), "%s: found extra keys in map: %v", tt.desc, enc.Fields)
+		})
 	}
 }
 
 func TestErrorsArraysHandleRichErrors(t *testing.T) {
+	t.Parallel()
+
 	errs := []error{fmt.Errorf("egad")}
 
 	enc := zapcore.NewMapObjectEncoder()

--- a/exp/zapfield/zapfield_test.go
+++ b/exp/zapfield/zapfield_test.go
@@ -36,6 +36,8 @@ type (
 )
 
 func TestFieldConstructors(t *testing.T) {
+	t.Parallel()
+
 	var (
 		key    = MyKey("test key")
 		value  = MyValue("test value")
@@ -55,10 +57,15 @@ func TestFieldConstructors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if !assert.Equal(t, tt.expect, tt.field, "Unexpected output from convenience field constructor %s.", tt.name) {
-			t.Logf("type expected: %T\nGot: %T", tt.expect.Interface, tt.field.Interface)
-		}
-		assertCanBeReused(t, tt.field)
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if !assert.Equal(t, tt.expect, tt.field, "Unexpected output from convenience field constructor %s.", tt.name) {
+				t.Logf("type expected: %T\nGot: %T", tt.expect.Interface, tt.field.Interface)
+			}
+			assertCanBeReused(t, tt.field)
+		})
 	}
 }
 

--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -51,6 +51,8 @@ func TestAddCaller(t *testing.T) {
 }
 
 func TestAddStack(t *testing.T) {
+	t.Parallel()
+
 	fac, logs := observer.New(zapcore.DebugLevel)
 	sl := slog.New(NewHandler(fac, AddStacktraceAt(slog.LevelDebug)))
 	sl.Info("msg")
@@ -71,6 +73,8 @@ func TestAddStack(t *testing.T) {
 }
 
 func TestAddStackSkip(t *testing.T) {
+	t.Parallel()
+
 	fac, logs := observer.New(zapcore.DebugLevel)
 	sl := slog.New(NewHandler(fac, AddStacktraceAt(slog.LevelDebug), WithCallerSkip(1)))
 	sl.Info("msg")
@@ -87,10 +91,12 @@ func TestAddStackSkip(t *testing.T) {
 func TestEmptyAttr(t *testing.T) {
 	t.Parallel()
 
-	fac, observedLogs := observer.New(zapcore.DebugLevel)
-	sl := slog.New(NewHandler(fac))
-
 	t.Run("Handle", func(t *testing.T) {
+		t.Parallel()
+
+		fac, observedLogs := observer.New(zapcore.DebugLevel)
+		sl := slog.New(NewHandler(fac))
+
 		sl.Info(
 			"msg",
 			slog.String("foo", "bar"),
@@ -105,6 +111,11 @@ func TestEmptyAttr(t *testing.T) {
 	})
 
 	t.Run("WithAttrs", func(t *testing.T) {
+		t.Parallel()
+
+		fac, observedLogs := observer.New(zapcore.DebugLevel)
+		sl := slog.New(NewHandler(fac))
+
 		sl.With(slog.String("foo", "bar"), slog.Attr{}).Info("msg")
 
 		logs := observedLogs.TakeAll()
@@ -115,6 +126,11 @@ func TestEmptyAttr(t *testing.T) {
 	})
 
 	t.Run("Group", func(t *testing.T) {
+		t.Parallel()
+
+		fac, observedLogs := observer.New(zapcore.DebugLevel)
+		sl := slog.New(NewHandler(fac))
+
 		sl.With("k", slog.GroupValue(slog.String("foo", "bar"), slog.Attr{})).Info("msg")
 
 		logs := observedLogs.TakeAll()
@@ -129,8 +145,11 @@ func TestEmptyAttr(t *testing.T) {
 
 func TestWithName(t *testing.T) {
 	t.Parallel()
-	fac, observedLogs := observer.New(zapcore.DebugLevel)
+
 	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+
+		fac, observedLogs := observer.New(zapcore.DebugLevel)
 		sl := slog.New(NewHandler(fac))
 		sl.Info("msg")
 
@@ -139,7 +158,11 @@ func TestWithName(t *testing.T) {
 		entry := logs[0]
 		assert.Equal(t, "", entry.LoggerName, "Unexpected logger name")
 	})
+
 	t.Run("with name", func(t *testing.T) {
+		t.Parallel()
+
+		fac, observedLogs := observer.New(zapcore.DebugLevel)
 		sl := slog.New(NewHandler(fac, WithName("test-name")))
 		sl.Info("msg")
 
@@ -157,6 +180,8 @@ func (Token) LogValue() slog.Value {
 }
 
 func TestAttrKinds(t *testing.T) {
+	t.Parallel()
+
 	fac, logs := observer.New(zapcore.DebugLevel)
 	sl := slog.New(NewHandler(fac))
 	testToken := Token("no")

--- a/field_test.go
+++ b/field_test.go
@@ -61,6 +61,8 @@ func assertCanBeReused(t testing.TB, field Field) {
 }
 
 func TestFieldConstructors(t *testing.T) {
+	t.Parallel()
+
 	// Interface types.
 	addr := net.ParseIP("1.2.3.4")
 	name := username("phil")
@@ -256,7 +258,10 @@ func TestFieldConstructors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			if !assert.Equal(t, tt.expect, tt.field, "Unexpected output from convenience field constructor") {
 				t.Logf("type expected: %T\nGot: %T", tt.expect.Interface, tt.field.Interface)
 			}
@@ -266,6 +271,8 @@ func TestFieldConstructors(t *testing.T) {
 }
 
 func TestStackField(t *testing.T) {
+	t.Parallel()
+
 	f := Stack("stacktrace")
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
@@ -275,6 +282,8 @@ func TestStackField(t *testing.T) {
 }
 
 func TestStackSkipField(t *testing.T) {
+	t.Parallel()
+
 	f := StackSkip("stacktrace", 0)
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
@@ -284,6 +293,8 @@ func TestStackSkipField(t *testing.T) {
 }
 
 func TestStackSkipFieldWithSkip(t *testing.T) {
+	t.Parallel()
+
 	f := StackSkip("stacktrace", 1)
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
@@ -292,6 +303,8 @@ func TestStackSkipFieldWithSkip(t *testing.T) {
 }
 
 func TestDict(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc     string
 		field    Field
@@ -303,7 +316,10 @@ func TestDict(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			enc := zapcore.NewMapObjectEncoder()
 			tt.field.Key = "k"
 			tt.field.AddTo(enc)

--- a/flag_test.go
+++ b/flag_test.go
@@ -65,6 +65,7 @@ func (tc flagTestCase) run(t testing.TB, set *flag.FlagSet, actual *zapcore.Leve
 	}
 }
 
+//nolint:paralleltest // modifies global flag set
 func TestLevelFlag(t *testing.T) {
 	tests := []flagTestCase{
 		{
@@ -87,6 +88,7 @@ func TestLevelFlag(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // modifies global flag set
 func TestLevelFlagsAreIndependent(t *testing.T) {
 	origCommandLine := flag.CommandLine
 	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)

--- a/global_test.go
+++ b/global_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:paralleltest // modifies global logger
 func TestReplaceGlobals(t *testing.T) {
 	initialL := *L()
 	initialS := *S()
@@ -66,6 +67,7 @@ func TestReplaceGlobals(t *testing.T) {
 	assert.Equal(t, initialS, *S(), "Expected func returned from ReplaceGlobals to restore initial S.")
 }
 
+//nolint:paralleltest // modifies global logger
 func TestGlobalsConcurrentUse(t *testing.T) {
 	var (
 		stop atomic.Bool
@@ -98,6 +100,8 @@ func TestGlobalsConcurrentUse(t *testing.T) {
 }
 
 func TestNewStdLog(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
 		std := NewStdLog(l)
 		std.Print("redirected")
@@ -106,6 +110,8 @@ func TestNewStdLog(t *testing.T) {
 }
 
 func TestNewStdLogAt(t *testing.T) {
+	t.Parallel()
+
 	// include DPanicLevel here, but do not include Development in options
 	levels := []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
 	for _, level := range levels {
@@ -119,6 +125,8 @@ func TestNewStdLogAt(t *testing.T) {
 }
 
 func TestNewStdLogAtPanics(t *testing.T) {
+	t.Parallel()
+
 	// include DPanicLevel here and enable Development in options
 	levels := []zapcore.Level{DPanicLevel, PanicLevel}
 	for _, level := range levels {
@@ -132,6 +140,8 @@ func TestNewStdLogAtPanics(t *testing.T) {
 }
 
 func TestNewStdLogAtFatal(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
 		stub := exit.WithStub(func() {
 			std, err := NewStdLogAt(l, FatalLevel)
@@ -145,10 +155,13 @@ func TestNewStdLogAtFatal(t *testing.T) {
 }
 
 func TestNewStdLogAtInvalid(t *testing.T) {
+	t.Parallel()
+
 	_, err := NewStdLogAt(NewNop(), zapcore.Level(99))
 	assert.ErrorContains(t, err, "99", "Expected level code in error message")
 }
 
+//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLog(t *testing.T) {
 	initialFlags := log.Flags()
 	initialPrefix := log.Prefix()
@@ -167,6 +180,7 @@ func TestRedirectStdLog(t *testing.T) {
 	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
 }
 
+//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogCaller(t *testing.T) {
 	withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
 		defer RedirectStdLog(l)()
@@ -177,6 +191,7 @@ func TestRedirectStdLogCaller(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogAt(t *testing.T) {
 	initialFlags := log.Flags()
 	initialPrefix := log.Prefix()
@@ -201,6 +216,7 @@ func TestRedirectStdLogAt(t *testing.T) {
 	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
 }
 
+//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogAtCaller(t *testing.T) {
 	// include DPanicLevel here, but do not include Development in options
 	levels := []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
@@ -217,6 +233,7 @@ func TestRedirectStdLogAtCaller(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogAtPanics(t *testing.T) {
 	initialFlags := log.Flags()
 	initialPrefix := log.Prefix()
@@ -237,6 +254,7 @@ func TestRedirectStdLogAtPanics(t *testing.T) {
 	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
 }
 
+//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogAtFatal(t *testing.T) {
 	initialFlags := log.Flags()
 	initialPrefix := log.Prefix()
@@ -257,6 +275,7 @@ func TestRedirectStdLogAtFatal(t *testing.T) {
 	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
 }
 
+//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogAtInvalid(t *testing.T) {
 	restore, err := RedirectStdLogAt(NewNop(), zapcore.Level(99))
 	defer func() {

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -36,6 +36,8 @@ import (
 )
 
 func TestAtomicLevelServeHTTP(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc          string
 		method        string
@@ -153,7 +155,10 @@ func TestAtomicLevelServeHTTP(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			lvl := zap.NewAtomicLevel()
 			lvl.SetLevel(zapcore.InfoLevel)
 

--- a/increase_level_test.go
+++ b/increase_level_test.go
@@ -40,6 +40,8 @@ func newLoggedEntry(level zapcore.Level, msg string, fields ...zapcore.Field) ob
 }
 
 func TestIncreaseLevelTryDecrease(t *testing.T) {
+	t.Parallel()
+
 	errorOut := &bytes.Buffer{}
 	opts := []Option{
 		ErrorOutput(zapcore.AddSync(errorOut)),
@@ -66,6 +68,8 @@ func TestIncreaseLevelTryDecrease(t *testing.T) {
 }
 
 func TestIncreaseLevel(t *testing.T) {
+	t.Parallel()
+
 	errorOut := &bytes.Buffer{}
 	opts := []Option{
 		ErrorOutput(zapcore.AddSync(errorOut)),

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestColorFormatting(t *testing.T) {
+	t.Parallel()
+
 	assert.Equal(
 		t,
 		"\x1b[31mfoo\x1b[0m",

--- a/internal/exit/exit_test.go
+++ b/internal/exit/exit_test.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap/internal/exit"
 )
 
+//nolint:paralleltest // stubs global exit
 func TestStub(t *testing.T) {
 	type want struct {
 		exit bool

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -33,6 +33,7 @@ type pooledValue[T any] struct {
 	value T
 }
 
+//nolint:paralleltest // disables GC temporarily
 func TestNew(t *testing.T) {
 	// Disable GC to avoid the victim cache during the test.
 	defer debug.SetGCPercent(debug.SetGCPercent(-1))
@@ -76,6 +77,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestNew_Race(t *testing.T) {
+	t.Parallel()
+
 	p := pool.New(func() *pooledValue[int] {
 		return &pooledValue[int]{
 			value: -1,

--- a/internal/stacktrace/stack_test.go
+++ b/internal/stacktrace/stack_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestTake(t *testing.T) {
+	t.Parallel()
+
 	trace := Take(0)
 	lines := strings.Split(trace, "\n")
 	require.NotEmpty(t, lines, "Expected stacktrace to have at least one frame.")
@@ -42,6 +44,8 @@ func TestTake(t *testing.T) {
 }
 
 func TestTakeWithSkip(t *testing.T) {
+	t.Parallel()
+
 	trace := Take(1)
 	lines := strings.Split(trace, "\n")
 	require.NotEmpty(t, lines, "Expected stacktrace to have at least one frame.")
@@ -54,6 +58,8 @@ func TestTakeWithSkip(t *testing.T) {
 }
 
 func TestTakeWithSkipInnerFunc(t *testing.T) {
+	t.Parallel()
+
 	var trace string
 	func() {
 		trace = Take(2)
@@ -69,6 +75,8 @@ func TestTakeWithSkipInnerFunc(t *testing.T) {
 }
 
 func TestTakeDeepStack(t *testing.T) {
+	t.Parallel()
+
 	const (
 		N                  = 500
 		withStackDepthName = "go.uber.org/zap/internal/stacktrace.withStackDepth"

--- a/internal/ztest/clock_test.go
+++ b/internal/ztest/clock_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestMockClock_NewTicker(t *testing.T) {
+	t.Parallel()
+
 	var n atomic.Int32
 	clock := NewMockClock()
 
@@ -57,6 +59,8 @@ func TestMockClock_NewTicker(t *testing.T) {
 }
 
 func TestMockClock_NewTicker_slowConsumer(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 
 	ticker := clock.NewTicker(time.Microsecond)
@@ -75,6 +79,8 @@ func TestMockClock_NewTicker_slowConsumer(t *testing.T) {
 }
 
 func TestMockClock_Add_negative(t *testing.T) {
+	t.Parallel()
+
 	clock := NewMockClock()
 	assert.Panics(t, func() { clock.Add(-1) })
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -47,6 +47,8 @@ func makeCountingHook() (func(zapcore.Entry) error, *atomic.Int64) {
 }
 
 func TestLoggerAtomicLevel(t *testing.T) {
+	t.Parallel()
+
 	// Test that the dynamic level applies to all ancestors and descendants.
 	dl := NewAtomicLevel()
 
@@ -86,6 +88,8 @@ func TestLoggerAtomicLevel(t *testing.T) {
 }
 
 func TestLoggerLevel(t *testing.T) {
+	t.Parallel()
+
 	levels := []zapcore.Level{
 		DebugLevel,
 		InfoLevel,
@@ -113,6 +117,8 @@ func TestLoggerLevel(t *testing.T) {
 }
 
 func TestLoggerInitialFields(t *testing.T) {
+	t.Parallel()
+
 	fieldOpts := opts(Fields(Int("foo", 42), String("bar", "baz")))
 	withLogger(t, DebugLevel, fieldOpts, func(logger *Logger, logs *observer.ObservedLogs) {
 		logger.Info("")
@@ -126,6 +132,8 @@ func TestLoggerInitialFields(t *testing.T) {
 }
 
 func TestLoggerWith(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		initialFields []Field
@@ -153,7 +161,10 @@ func TestLoggerWith(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			withLogger(t, DebugLevel, opts(Fields(tt.initialFields...)), func(logger *Logger, logs *observer.ObservedLogs) {
 				// Child loggers should have copy-on-write semantics, so two children
 				// shouldn't stomp on each other's fields or affect the parent's fields.
@@ -176,6 +187,8 @@ func TestLoggerWith(t *testing.T) {
 }
 
 func TestLoggerWithCaptures(t *testing.T) {
+	t.Parallel()
+
 	type withF func(*Logger, ...Field) *Logger
 	tests := []struct {
 		name        string
@@ -337,7 +350,10 @@ func TestLoggerWithCaptures(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{
 				MessageKey: "m",
 			})
@@ -373,35 +389,53 @@ func TestLoggerWithCaptures(t *testing.T) {
 }
 
 func TestLoggerLogPanic(t *testing.T) {
-	for _, tt := range []struct {
+	t.Parallel()
+
+	tests := []struct {
+		desc     string
 		do       func(*Logger)
-		should   bool
 		expected string
 	}{
-		{func(logger *Logger) { logger.Check(PanicLevel, "foo").Write() }, true, "foo"},
-		{func(logger *Logger) { logger.Log(PanicLevel, "bar") }, true, "bar"},
-		{func(logger *Logger) { logger.Panic("baz") }, true, "baz"},
-	} {
-		withLogger(t, DebugLevel, nil, func(logger *Logger, logs *observer.ObservedLogs) {
-			if tt.should {
-				assert.Panics(t, func() { tt.do(logger) }, "Expected panic")
-			} else {
-				assert.NotPanics(t, func() { tt.do(logger) }, "Expected no panic")
-			}
+		{
+			desc:     "Check",
+			do:       func(logger *Logger) { logger.Check(PanicLevel, "foo").Write() },
+			expected: "foo",
+		},
+		{
+			desc:     "Log",
+			do:       func(logger *Logger) { logger.Log(PanicLevel, "bar") },
+			expected: "bar",
+		},
+		{
+			desc:     "Panic",
+			do:       func(logger *Logger) { logger.Panic("baz") },
+			expected: "baz",
+		},
+	}
 
-			output := logs.AllUntimed()
-			assert.Equal(t, 1, len(output), "Unexpected number of logs.")
-			assert.Equal(t, 0, len(output[0].Context), "Unexpected context on first log.")
-			assert.Equal(
-				t,
-				zapcore.Entry{Message: tt.expected, Level: PanicLevel},
-				output[0].Entry,
-				"Unexpected output from panic-level Log.",
-			)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			withLogger(t, DebugLevel, nil, func(logger *Logger, logs *observer.ObservedLogs) {
+				assert.Panics(t, func() { tt.do(logger) }, "Expected panic")
+
+				output := logs.AllUntimed()
+				assert.Equal(t, 1, len(output), "Unexpected number of logs.")
+				assert.Equal(t, 0, len(output[0].Context), "Unexpected context on first log.")
+				assert.Equal(
+					t,
+					zapcore.Entry{Message: tt.expected, Level: PanicLevel},
+					output[0].Entry,
+					"Unexpected output from panic-level Log.",
+				)
+			})
 		})
 	}
 }
 
+//nolint:paralleltest // stubs out exit funcs
 func TestLoggerLogFatal(t *testing.T) {
 	for _, tt := range []struct {
 		do       func(*Logger)
@@ -430,6 +464,8 @@ func TestLoggerLogFatal(t *testing.T) {
 }
 
 func TestLoggerLeveledMethods(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, DebugLevel, nil, func(logger *Logger, logs *observer.ObservedLogs) {
 		tests := []struct {
 			method        func(string, ...Field)
@@ -456,6 +492,8 @@ func TestLoggerLeveledMethods(t *testing.T) {
 }
 
 func TestLoggerLogLevels(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, DebugLevel, nil, func(logger *Logger, logs *observer.ObservedLogs) {
 		levels := []zapcore.Level{
 			DebugLevel,
@@ -479,6 +517,8 @@ func TestLoggerLogLevels(t *testing.T) {
 }
 
 func TestLoggerAlwaysPanics(t *testing.T) {
+	t.Parallel()
+
 	// Users can disable writing out panic-level logs, but calls to logger.Panic()
 	// should still call panic().
 	withLogger(t, FatalLevel, nil, func(logger *Logger, logs *observer.ObservedLogs) {
@@ -494,6 +534,7 @@ func TestLoggerAlwaysPanics(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // stubs out exit funcs
 func TestLoggerAlwaysFatals(t *testing.T) {
 	// Users can disable writing out fatal-level logs, but calls to logger.Fatal()
 	// should still terminate the process.
@@ -516,6 +557,8 @@ func TestLoggerAlwaysFatals(t *testing.T) {
 }
 
 func TestLoggerDPanic(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, DebugLevel, nil, func(logger *Logger, logs *observer.ObservedLogs) {
 		assert.NotPanics(t, func() { logger.DPanic("") })
 		assert.Equal(
@@ -537,6 +580,8 @@ func TestLoggerDPanic(t *testing.T) {
 }
 
 func TestLoggerNoOpsDisabledLevels(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, WarnLevel, nil, func(logger *Logger, logs *observer.ObservedLogs) {
 		logger.Info("silence!")
 		assert.Equal(
@@ -549,6 +594,8 @@ func TestLoggerNoOpsDisabledLevels(t *testing.T) {
 }
 
 func TestLoggerNames(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		names    []string
 		expected string
@@ -588,6 +635,8 @@ func TestLoggerNames(t *testing.T) {
 }
 
 func TestLoggerWriteFailure(t *testing.T) {
+	t.Parallel()
+
 	errSink := &ztest.Buffer{}
 	logger := New(
 		zapcore.NewCore(
@@ -605,6 +654,8 @@ func TestLoggerWriteFailure(t *testing.T) {
 }
 
 func TestLoggerSync(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, DebugLevel, nil, func(logger *Logger, _ *observer.ObservedLogs) {
 		assert.NoError(t, logger.Sync(), "Expected syncing a test logger to succeed.")
 		assert.NoError(t, logger.Sugar().Sync(), "Expected syncing a sugared logger to succeed.")
@@ -612,6 +663,8 @@ func TestLoggerSync(t *testing.T) {
 }
 
 func TestLoggerSyncFail(t *testing.T) {
+	t.Parallel()
+
 	noSync := &ztest.Buffer{}
 	err := errors.New("fail")
 	noSync.SetError(err)
@@ -625,6 +678,8 @@ func TestLoggerSyncFail(t *testing.T) {
 }
 
 func TestLoggerAddCaller(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		options []Option
 		pat     string
@@ -639,24 +694,31 @@ func TestLoggerAddCaller(t *testing.T) {
 		{opts(AddCaller(), AddCallerSkip(1)), `.+/common_test.go:[\d]+$`},
 		{opts(AddCaller(), AddCallerSkip(1), AddCallerSkip(3)), `.+/src/runtime/.*:[\d]+$`},
 	}
-	for _, tt := range tests {
-		withLogger(t, DebugLevel, tt.options, func(logger *Logger, logs *observer.ObservedLogs) {
-			// Make sure that sugaring and desugaring resets caller skip properly.
-			logger = logger.Sugar().Desugar()
-			logger.Info("")
-			output := logs.AllUntimed()
-			assert.Equal(t, 1, len(output), "Unexpected number of logs written out.")
-			assert.Regexp(
-				t,
-				tt.pat,
-				output[0].Caller,
-				"Expected to find package name and file name in output.",
-			)
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			withLogger(t, DebugLevel, tt.options, func(logger *Logger, logs *observer.ObservedLogs) {
+				// Make sure that sugaring and desugaring resets caller skip properly.
+				logger = logger.Sugar().Desugar()
+				logger.Info("")
+				output := logs.AllUntimed()
+				assert.Equal(t, 1, len(output), "Unexpected number of logs written out.")
+				assert.Regexp(
+					t,
+					tt.pat,
+					output[0].Caller,
+					"Expected to find package name and file name in output.",
+				)
+			})
 		})
 	}
 }
 
 func TestLoggerAddCallerFunction(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		options         []Option
 		loggerFunction  string
@@ -708,35 +770,42 @@ func TestLoggerAddCallerFunction(t *testing.T) {
 			sugaredFunction: "runtime.goexit",
 		},
 	}
-	for _, tt := range tests {
-		withLogger(t, DebugLevel, tt.options, func(logger *Logger, logs *observer.ObservedLogs) {
-			// Make sure that sugaring and desugaring resets caller skip properly.
-			logger = logger.Sugar().Desugar()
-			infoLog(logger, "")
-			infoLogSugared(logger.Sugar(), "")
-			infoLog(logger.Sugar().Desugar(), "")
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 
-			entries := logs.AllUntimed()
-			assert.Equal(t, 3, len(entries), "Unexpected number of logs written out.")
-			for _, entry := range []observer.LoggedEntry{entries[0], entries[2]} {
+			withLogger(t, DebugLevel, tt.options, func(logger *Logger, logs *observer.ObservedLogs) {
+				// Make sure that sugaring and desugaring resets caller skip properly.
+				logger = logger.Sugar().Desugar()
+				infoLog(logger, "")
+				infoLogSugared(logger.Sugar(), "")
+				infoLog(logger.Sugar().Desugar(), "")
+
+				entries := logs.AllUntimed()
+				assert.Equal(t, 3, len(entries), "Unexpected number of logs written out.")
+				for _, entry := range []observer.LoggedEntry{entries[0], entries[2]} {
+					assert.Regexp(
+						t,
+						tt.loggerFunction,
+						entry.Caller.Function,
+						"Expected to find function name in output.",
+					)
+				}
 				assert.Regexp(
 					t,
-					tt.loggerFunction,
-					entry.Caller.Function,
+					tt.sugaredFunction,
+					entries[1].Caller.Function,
 					"Expected to find function name in output.",
 				)
-			}
-			assert.Regexp(
-				t,
-				tt.sugaredFunction,
-				entries[1].Caller.Function,
-				"Expected to find function name in output.",
-			)
+			})
 		})
 	}
 }
 
 func TestLoggerAddCallerFail(t *testing.T) {
+	t.Parallel()
+
 	errBuf := &ztest.Buffer{}
 	withLogger(t, DebugLevel, opts(AddCaller(), AddCallerSkip(1e3), ErrorOutput(errBuf)), func(log *Logger, logs *observer.ObservedLogs) {
 		log.Info("Failure.")
@@ -760,6 +829,8 @@ func TestLoggerAddCallerFail(t *testing.T) {
 }
 
 func TestLoggerReplaceCore(t *testing.T) {
+	t.Parallel()
+
 	replace := WrapCore(func(zapcore.Core) zapcore.Core {
 		return zapcore.NewNopCore()
 	})
@@ -772,6 +843,8 @@ func TestLoggerReplaceCore(t *testing.T) {
 }
 
 func TestLoggerIncreaseLevel(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, DebugLevel, opts(IncreaseLevel(WarnLevel)), func(logger *Logger, logs *observer.ObservedLogs) {
 		logger.Info("logger.Info")
 		logger.Warn("logger.Warn")
@@ -787,6 +860,8 @@ func TestLoggerIncreaseLevel(t *testing.T) {
 }
 
 func TestLoggerHooks(t *testing.T) {
+	t.Parallel()
+
 	hook, seen := makeCountingHook()
 	withLogger(t, DebugLevel, opts(Hooks(hook)), func(logger *Logger, logs *observer.ObservedLogs) {
 		logger.Debug("")
@@ -796,6 +871,8 @@ func TestLoggerHooks(t *testing.T) {
 }
 
 func TestLoggerConcurrent(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, DebugLevel, nil, func(logger *Logger, logs *observer.ObservedLogs) {
 		child := logger.With(String("foo", "bar"))
 
@@ -825,6 +902,7 @@ func TestLoggerConcurrent(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // stubs global exit func
 func TestLoggerFatalOnNoop(t *testing.T) {
 	exitStub := exit.Stub()
 	defer exitStub.Unstub()
@@ -837,6 +915,8 @@ func TestLoggerFatalOnNoop(t *testing.T) {
 }
 
 func TestLoggerCustomOnFatal(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		msg          string
 		onFatal      zapcore.CheckWriteAction
@@ -855,7 +935,10 @@ func TestLoggerCustomOnFatal(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.msg, func(t *testing.T) {
+			t.Parallel()
+
 			withLogger(t, InfoLevel, opts(OnFatal(tt.onFatal)), func(logger *Logger, logs *observer.ObservedLogs) {
 				var finished bool
 				recovered := make(chan interface{})
@@ -889,6 +972,8 @@ func (h *customWriteHook) OnWrite(_ *zapcore.CheckedEntry, _ []Field) {
 }
 
 func TestLoggerWithFatalHook(t *testing.T) {
+	t.Parallel()
+
 	var h customWriteHook
 	withLogger(t, InfoLevel, opts(WithFatalHook(&h)), func(logger *Logger, logs *observer.ObservedLogs) {
 		logger.Fatal("great sadness")
@@ -898,9 +983,13 @@ func TestLoggerWithFatalHook(t *testing.T) {
 }
 
 func TestNopLogger(t *testing.T) {
+	t.Parallel()
+
 	logger := NewNop()
 
 	t.Run("basic levels", func(t *testing.T) {
+		t.Parallel()
+
 		logger.Debug("foo", String("k", "v"))
 		logger.Info("bar", Int("x", 42))
 		logger.Warn("baz", Strings("ks", []string{"a", "b"}))
@@ -908,10 +997,14 @@ func TestNopLogger(t *testing.T) {
 	})
 
 	t.Run("DPanic", func(t *testing.T) {
+		t.Parallel()
+
 		logger.With(String("component", "whatever")).DPanic("stuff")
 	})
 
 	t.Run("Panic", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Panics(t, func() {
 			logger.Panic("great sadness")
 		}, "Nop logger should still cause panics.")
@@ -919,11 +1012,17 @@ func TestNopLogger(t *testing.T) {
 }
 
 func TestMust(t *testing.T) {
+	t.Parallel()
+
 	t.Run("must without an error does not panic", func(t *testing.T) {
+		t.Parallel()
+
 		assert.NotPanics(t, func() { Must(NewNop(), nil) }, "must paniced with no error")
 	})
 
 	t.Run("must with an error panics", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Panics(t, func() { Must(nil, errors.New("an error")) }, "must did not panic with an error")
 	})
 }

--- a/sink_test.go
+++ b/sink_test.go
@@ -44,6 +44,7 @@ func stubSinkRegistry(t testing.TB) *sinkRegistry {
 	return r
 }
 
+//nolint:paralleltest // stubs global registry
 func TestRegisterSink(t *testing.T) {
 	stubSinkRegistry(t)
 
@@ -84,6 +85,8 @@ func TestRegisterSink(t *testing.T) {
 }
 
 func TestRegisterSinkErrors(t *testing.T) {
+	t.Parallel()
+
 	nopFactory := func(_ *url.URL) (Sink, error) {
 		return nopCloserSink{zapcore.AddSync(io.Discard)}, nil
 	}
@@ -98,7 +101,10 @@ func TestRegisterSinkErrors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run("scheme-"+tt.scheme, func(t *testing.T) {
+			t.Parallel()
+
 			r := newSinkRegistry()
 			err := r.RegisterSink(tt.scheme, nopFactory)
 			assert.ErrorContains(t, err, tt.err)

--- a/stacktrace_ext_test.go
+++ b/stacktrace_ext_test.go
@@ -47,6 +47,8 @@ var _zapPackages = []string{
 }
 
 func TestStacktraceFiltersZapLog(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, func(logger *zap.Logger, out *bytes.Buffer) {
 		logger.Error("test log")
 		logger.Sugar().Error("sugar test log")
@@ -57,6 +59,8 @@ func TestStacktraceFiltersZapLog(t *testing.T) {
 }
 
 func TestStacktraceFiltersZapMarshal(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, func(logger *zap.Logger, out *bytes.Buffer) {
 		marshal := func(enc zapcore.ObjectEncoder) error {
 			logger.Warn("marshal caused warn")
@@ -83,6 +87,7 @@ func TestStacktraceFiltersZapMarshal(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest // modifies process global state
 func TestStacktraceFiltersVendorZap(t *testing.T) {
 	// We already have the dependencies downloaded so this should be
 	// instant.
@@ -120,6 +125,8 @@ func TestStacktraceFiltersVendorZap(t *testing.T) {
 }
 
 func TestStacktraceWithoutCallerSkip(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, func(logger *zap.Logger, out *bytes.Buffer) {
 		func() {
 			logger.Error("test log")
@@ -131,6 +138,8 @@ func TestStacktraceWithoutCallerSkip(t *testing.T) {
 }
 
 func TestStacktraceWithCallerSkip(t *testing.T) {
+	t.Parallel()
+
 	withLogger(t, func(logger *zap.Logger, out *bytes.Buffer) {
 		logger = logger.WithOptions(zap.AddCallerSkip(2))
 		func() {

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -22,6 +22,7 @@ package zap
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"go.uber.org/zap/internal/exit"
@@ -34,6 +35,8 @@ import (
 )
 
 func TestSugarWith(t *testing.T) {
+	t.Parallel()
+
 	// Convenience functions to create expected error logs.
 	ignored := func(msg interface{}) observer.LoggedEntry {
 		return observer.LoggedEntry{
@@ -141,16 +144,21 @@ func TestSugarWith(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
-			logger.With(tt.args...).Info("")
-			output := logs.AllUntimed()
-			if len(tt.errLogs) > 0 {
-				for i := range tt.errLogs {
-					assert.Equal(t, tt.errLogs[i], output[i], "Unexpected error log at position %d for scenario %s.", i, tt.desc)
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+				logger.With(tt.args...).Info("")
+				output := logs.AllUntimed()
+				if len(tt.errLogs) > 0 {
+					for i := range tt.errLogs {
+						assert.Equal(t, tt.errLogs[i], output[i], "Unexpected error log at position %d for scenario %s.", i, tt.desc)
+					}
 				}
-			}
-			assert.Equal(t, len(tt.errLogs)+1, len(output), "Expected only one non-error message to be logged in scenario %s.", tt.desc)
-			assert.Equal(t, tt.expected, output[len(tt.errLogs)].Context, "Unexpected message context in scenario %s.", tt.desc)
+				assert.Equal(t, len(tt.errLogs)+1, len(output), "Expected only one non-error message to be logged in scenario %s.", tt.desc)
+				assert.Equal(t, tt.expected, output[len(tt.errLogs)].Context, "Unexpected message context in scenario %s.", tt.desc)
+			})
 		})
 	}
 }
@@ -185,6 +193,8 @@ func TestSugaredLoggerLevel(t *testing.T) {
 }
 
 func TestSugarFieldsInvalidPairs(t *testing.T) {
+	t.Parallel()
+
 	withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
 		logger.With(42, "foo", []string{"bar"}, "baz").Info("")
 		output := logs.AllUntimed()
@@ -205,6 +215,8 @@ func TestSugarFieldsInvalidPairs(t *testing.T) {
 }
 
 func TestSugarStructuredLogging(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		msg       string
 		expectMsg string
@@ -221,27 +233,34 @@ func TestSugarStructuredLogging(t *testing.T) {
 		expectedFields = []Field{String("foo", "bar"), Error(err), Bool("baz", false)}
 	)
 
-	for _, tt := range tests {
-		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
-			logger.With(context...).Debugw(tt.msg, extra...)
-			logger.With(context...).Infow(tt.msg, extra...)
-			logger.With(context...).Warnw(tt.msg, extra...)
-			logger.With(context...).Errorw(tt.msg, extra...)
-			logger.With(context...).DPanicw(tt.msg, extra...)
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 
-			expected := make([]observer.LoggedEntry, 5)
-			for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
-				expected[i] = observer.LoggedEntry{
-					Entry:   zapcore.Entry{Message: tt.expectMsg, Level: lvl},
-					Context: expectedFields,
+			withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+				logger.With(context...).Debugw(tt.msg, extra...)
+				logger.With(context...).Infow(tt.msg, extra...)
+				logger.With(context...).Warnw(tt.msg, extra...)
+				logger.With(context...).Errorw(tt.msg, extra...)
+				logger.With(context...).DPanicw(tt.msg, extra...)
+
+				expected := make([]observer.LoggedEntry, 5)
+				for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
+					expected[i] = observer.LoggedEntry{
+						Entry:   zapcore.Entry{Message: tt.expectMsg, Level: lvl},
+						Context: expectedFields,
+					}
 				}
-			}
-			assert.Equal(t, expected, logs.AllUntimed(), "Unexpected log output.")
+				assert.Equal(t, expected, logs.AllUntimed(), "Unexpected log output.")
+			})
 		})
 	}
 }
 
 func TestSugarConcatenatingLogging(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		args   []interface{}
 		expect string
@@ -253,27 +272,34 @@ func TestSugarConcatenatingLogging(t *testing.T) {
 	context := []interface{}{"foo", "bar"}
 	expectedFields := []Field{String("foo", "bar")}
 
-	for _, tt := range tests {
-		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
-			logger.With(context...).Debug(tt.args...)
-			logger.With(context...).Info(tt.args...)
-			logger.With(context...).Warn(tt.args...)
-			logger.With(context...).Error(tt.args...)
-			logger.With(context...).DPanic(tt.args...)
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 
-			expected := make([]observer.LoggedEntry, 5)
-			for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
-				expected[i] = observer.LoggedEntry{
-					Entry:   zapcore.Entry{Message: tt.expect, Level: lvl},
-					Context: expectedFields,
+			withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+				logger.With(context...).Debug(tt.args...)
+				logger.With(context...).Info(tt.args...)
+				logger.With(context...).Warn(tt.args...)
+				logger.With(context...).Error(tt.args...)
+				logger.With(context...).DPanic(tt.args...)
+
+				expected := make([]observer.LoggedEntry, 5)
+				for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
+					expected[i] = observer.LoggedEntry{
+						Entry:   zapcore.Entry{Message: tt.expect, Level: lvl},
+						Context: expectedFields,
+					}
 				}
-			}
-			assert.Equal(t, expected, logs.AllUntimed(), "Unexpected log output.")
+				assert.Equal(t, expected, logs.AllUntimed(), "Unexpected log output.")
+			})
 		})
 	}
 }
 
 func TestSugarTemplatedLogging(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		format string
 		args   []interface{}
@@ -289,27 +315,34 @@ func TestSugarTemplatedLogging(t *testing.T) {
 	context := []interface{}{"foo", "bar"}
 	expectedFields := []Field{String("foo", "bar")}
 
-	for _, tt := range tests {
-		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
-			logger.With(context...).Debugf(tt.format, tt.args...)
-			logger.With(context...).Infof(tt.format, tt.args...)
-			logger.With(context...).Warnf(tt.format, tt.args...)
-			logger.With(context...).Errorf(tt.format, tt.args...)
-			logger.With(context...).DPanicf(tt.format, tt.args...)
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 
-			expected := make([]observer.LoggedEntry, 5)
-			for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
-				expected[i] = observer.LoggedEntry{
-					Entry:   zapcore.Entry{Message: tt.expect, Level: lvl},
-					Context: expectedFields,
+			withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+				logger.With(context...).Debugf(tt.format, tt.args...)
+				logger.With(context...).Infof(tt.format, tt.args...)
+				logger.With(context...).Warnf(tt.format, tt.args...)
+				logger.With(context...).Errorf(tt.format, tt.args...)
+				logger.With(context...).DPanicf(tt.format, tt.args...)
+
+				expected := make([]observer.LoggedEntry, 5)
+				for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
+					expected[i] = observer.LoggedEntry{
+						Entry:   zapcore.Entry{Message: tt.expect, Level: lvl},
+						Context: expectedFields,
+					}
 				}
-			}
-			assert.Equal(t, expected, logs.AllUntimed(), "Unexpected log output.")
+				assert.Equal(t, expected, logs.AllUntimed(), "Unexpected log output.")
+			})
 		})
 	}
 }
 
 func TestSugarLnLogging(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		args   []interface{}
 		expect string
@@ -325,27 +358,34 @@ func TestSugarLnLogging(t *testing.T) {
 	context := []interface{}{"foo", "bar"}
 	expectedFields := []Field{String("foo", "bar")}
 
-	for _, tt := range tests {
-		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
-			logger.With(context...).Debugln(tt.args...)
-			logger.With(context...).Infoln(tt.args...)
-			logger.With(context...).Warnln(tt.args...)
-			logger.With(context...).Errorln(tt.args...)
-			logger.With(context...).DPanicln(tt.args...)
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 
-			expected := make([]observer.LoggedEntry, 5)
-			for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
-				expected[i] = observer.LoggedEntry{
-					Entry:   zapcore.Entry{Message: tt.expect, Level: lvl},
-					Context: expectedFields,
+			withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+				logger.With(context...).Debugln(tt.args...)
+				logger.With(context...).Infoln(tt.args...)
+				logger.With(context...).Warnln(tt.args...)
+				logger.With(context...).Errorln(tt.args...)
+				logger.With(context...).DPanicln(tt.args...)
+
+				expected := make([]observer.LoggedEntry, 5)
+				for i, lvl := range []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel} {
+					expected[i] = observer.LoggedEntry{
+						Entry:   zapcore.Entry{Message: tt.expect, Level: lvl},
+						Context: expectedFields,
+					}
 				}
-			}
-			assert.Equal(t, expected, logs.AllUntimed(), "Unexpected log output.")
+				assert.Equal(t, expected, logs.AllUntimed(), "Unexpected log output.")
+			})
 		})
 	}
 }
 
 func TestSugarLnLoggingIgnored(t *testing.T) {
+	t.Parallel()
+
 	withSugar(t, WarnLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
 		logger.Infoln("hello")
 		assert.Zero(t, logs.Len(), "Expected zero log statements.")
@@ -353,6 +393,8 @@ func TestSugarLnLoggingIgnored(t *testing.T) {
 }
 
 func TestSugarPanicLogging(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		loggerLevel zapcore.Level
 		f           func(*SugaredLogger)
@@ -372,21 +414,27 @@ func TestSugarPanicLogging(t *testing.T) {
 		{DebugLevel, func(s *SugaredLogger) { s.Panicln("foo") }, "foo"},
 	}
 
-	for _, tt := range tests {
-		withSugar(t, tt.loggerLevel, nil, func(sugar *SugaredLogger, logs *observer.ObservedLogs) {
-			assert.Panics(t, func() { tt.f(sugar) }, "Expected panic-level logger calls to panic.")
-			if tt.expectedMsg != "" {
-				assert.Equal(t, []observer.LoggedEntry{{
-					Context: []Field{},
-					Entry:   zapcore.Entry{Message: tt.expectedMsg, Level: PanicLevel},
-				}}, logs.AllUntimed(), "Unexpected log output.")
-			} else {
-				assert.Equal(t, 0, logs.Len(), "Didn't expect any log output.")
-			}
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			withSugar(t, tt.loggerLevel, nil, func(sugar *SugaredLogger, logs *observer.ObservedLogs) {
+				assert.Panics(t, func() { tt.f(sugar) }, "Expected panic-level logger calls to panic.")
+				if tt.expectedMsg != "" {
+					assert.Equal(t, []observer.LoggedEntry{{
+						Context: []Field{},
+						Entry:   zapcore.Entry{Message: tt.expectedMsg, Level: PanicLevel},
+					}}, logs.AllUntimed(), "Unexpected log output.")
+				} else {
+					assert.Equal(t, 0, logs.Len(), "Didn't expect any log output.")
+				}
+			})
 		})
 	}
 }
 
+//nolint:paralleltest // stubs exit funcs
 func TestSugarFatalLogging(t *testing.T) {
 	tests := []struct {
 		loggerLevel zapcore.Level
@@ -424,6 +472,8 @@ func TestSugarFatalLogging(t *testing.T) {
 }
 
 func TestSugarAddCaller(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		options []Option
 		pat     string
@@ -433,22 +483,29 @@ func TestSugarAddCaller(t *testing.T) {
 		{opts(AddCaller(), AddCallerSkip(1)), `.+/common_test.go:[\d]+$`},
 		{opts(AddCaller(), AddCallerSkip(1), AddCallerSkip(5)), `.+/src/runtime/.*:[\d]+$`},
 	}
-	for _, tt := range tests {
-		withSugar(t, DebugLevel, tt.options, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
-			logger.Info("")
-			output := logs.AllUntimed()
-			assert.Equal(t, 1, len(output), "Unexpected number of logs written out.")
-			assert.Regexp(
-				t,
-				tt.pat,
-				output[0].Caller,
-				"Expected to find package name and file name in output.",
-			)
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			withSugar(t, DebugLevel, tt.options, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
+				logger.Info("")
+				output := logs.AllUntimed()
+				assert.Equal(t, 1, len(output), "Unexpected number of logs written out.")
+				assert.Regexp(
+					t,
+					tt.pat,
+					output[0].Caller,
+					"Expected to find package name and file name in output.",
+				)
+			})
 		})
 	}
 }
 
 func TestSugarAddCallerFail(t *testing.T) {
+	t.Parallel()
+
 	errBuf := &ztest.Buffer{}
 	withSugar(t, DebugLevel, opts(AddCaller(), AddCallerSkip(1e3), ErrorOutput(errBuf)), func(log *SugaredLogger, logs *observer.ObservedLogs) {
 		log.Info("Failure.")
@@ -467,6 +524,8 @@ func TestSugarAddCallerFail(t *testing.T) {
 }
 
 func TestSugarWithOptionsIncreaseLevel(t *testing.T) {
+	t.Parallel()
+
 	withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
 		logger = logger.WithOptions(IncreaseLevel(WarnLevel))
 		logger.Info("logger.Info")
@@ -483,6 +542,8 @@ func TestSugarWithOptionsIncreaseLevel(t *testing.T) {
 }
 
 func TestSugarLnWithOptionsIncreaseLevel(t *testing.T) {
+	t.Parallel()
+
 	withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
 		logger = logger.WithOptions(IncreaseLevel(WarnLevel))
 		logger.Infoln("logger.Infoln")

--- a/time_test.go
+++ b/time_test.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -28,6 +29,8 @@ import (
 )
 
 func TestTimeToMillis(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		t     time.Time
 		stamp int64
@@ -36,7 +39,13 @@ func TestTimeToMillis(t *testing.T) {
 		{t: time.Unix(1, 0), stamp: 1000},
 		{t: time.Unix(1, int64(500*time.Millisecond)), stamp: 1500},
 	}
-	for _, tt := range tests {
-		assert.Equal(t, tt.stamp, timeToMillis(tt.t), "Unexpected timestamp for time %v.", tt.t)
+
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.stamp, timeToMillis(tt.t), "Unexpected timestamp for time %v.", tt.t)
+		})
 	}
 }

--- a/zapcore/buffered_write_syncer_test.go
+++ b/zapcore/buffered_write_syncer_test.go
@@ -31,9 +31,13 @@ import (
 )
 
 func TestBufferWriter(t *testing.T) {
+	t.Parallel()
+
 	// If we pass a plain io.Writer, make sure that we still get a WriteSyncer
 	// with a no-op Sync.
 	t.Run("sync", func(t *testing.T) {
+		t.Parallel()
+
 		buf := &bytes.Buffer{}
 		ws := &BufferedWriteSyncer{WS: AddSync(buf)}
 
@@ -45,6 +49,8 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("stop", func(t *testing.T) {
+		t.Parallel()
+
 		buf := &bytes.Buffer{}
 		ws := &BufferedWriteSyncer{WS: AddSync(buf)}
 		requireWriteWorks(t, ws)
@@ -54,6 +60,8 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("stop twice", func(t *testing.T) {
+		t.Parallel()
+
 		ws := &BufferedWriteSyncer{WS: &ztest.FailWriter{}}
 		_, err := ws.Write([]byte("foo"))
 		require.NoError(t, err, "Unexpected error writing to WriteSyncer.")
@@ -62,6 +70,8 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("wrap twice", func(t *testing.T) {
+		t.Parallel()
+
 		buf := &bytes.Buffer{}
 		bufsync := &BufferedWriteSyncer{WS: AddSync(buf)}
 		ws := &BufferedWriteSyncer{WS: bufsync}
@@ -75,6 +85,8 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("small buffer", func(t *testing.T) {
+		t.Parallel()
+
 		buf := &bytes.Buffer{}
 		ws := &BufferedWriteSyncer{WS: AddSync(buf), Size: 5}
 
@@ -86,6 +98,8 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("with lockedWriteSyncer", func(t *testing.T) {
+		t.Parallel()
+
 		buf := &bytes.Buffer{}
 		ws := &BufferedWriteSyncer{WS: Lock(AddSync(buf)), Size: 5}
 
@@ -97,6 +111,8 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("flush error", func(t *testing.T) {
+		t.Parallel()
+
 		ws := &BufferedWriteSyncer{WS: &ztest.FailWriter{}, Size: 4}
 		n, err := ws.Write([]byte("foo"))
 		require.NoError(t, err, "Unexpected error writing to WriteSyncer.")
@@ -107,6 +123,8 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("flush timer", func(t *testing.T) {
+		t.Parallel()
+
 		buf := &bytes.Buffer{}
 		clock := ztest.NewMockClock()
 		ws := &BufferedWriteSyncer{
@@ -128,12 +146,18 @@ func TestBufferWriter(t *testing.T) {
 }
 
 func TestBufferWriterWithoutStart(t *testing.T) {
+	t.Parallel()
+
 	t.Run("stop", func(t *testing.T) {
+		t.Parallel()
+
 		ws := &BufferedWriteSyncer{WS: AddSync(new(bytes.Buffer))}
 		assert.NoError(t, ws.Stop(), "Stop must not fail")
 	})
 
 	t.Run("Sync", func(t *testing.T) {
+		t.Parallel()
+
 		ws := &BufferedWriteSyncer{WS: AddSync(new(bytes.Buffer))}
 		assert.NoError(t, ws.Sync(), "Sync must not fail")
 	})

--- a/zapcore/clock_test.go
+++ b/zapcore/clock_test.go
@@ -31,6 +31,8 @@ import (
 var _ Clock = (*ztest.MockClock)(nil)
 
 func TestSystemClock_NewTicker(t *testing.T) {
+	t.Parallel()
+
 	want := 3
 
 	var n int

--- a/zapcore/console_encoder_test.go
+++ b/zapcore/console_encoder_test.go
@@ -36,6 +36,8 @@ var testEntry = Entry{
 }
 
 func TestConsoleSeparator(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc        string
 		separator   string
@@ -64,8 +66,11 @@ func TestConsoleSeparator(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		console := NewConsoleEncoder(encoderTestEncoderConfig(tt.separator))
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			console := NewConsoleEncoder(encoderTestEncoderConfig(tt.separator))
 			entry := testEntry
 			consoleOut, err := console.EncodeEntry(entry, nil)
 			if !assert.NoError(t, err) {

--- a/zapcore/core_test.go
+++ b/zapcore/core_test.go
@@ -38,6 +38,8 @@ func makeInt64Field(key string, val int) Field {
 }
 
 func TestNopCore(t *testing.T) {
+	t.Parallel()
+
 	entry := Entry{
 		Message:    "test",
 		Level:      InfoLevel,
@@ -59,14 +61,21 @@ func TestNopCore(t *testing.T) {
 	core := NewNopCore()
 	assert.Equal(t, core, core.With([]Field{makeInt64Field("k", 42)}), "Expected no-op With.")
 	for _, level := range allLevels {
-		assert.False(t, core.Enabled(level), "Expected all levels to be disabled in no-op core.")
-		assert.Equal(t, ce, core.Check(entry, ce), "Expected no-op Check to return checked entry unchanged.")
-		assert.NoError(t, core.Write(entry, nil), "Expected no-op Writes to always succeed.")
-		assert.NoError(t, core.Sync(), "Expected no-op Syncs to always succeed.")
+		level := level
+		t.Run(level.String(), func(t *testing.T) {
+			t.Parallel()
+
+			assert.False(t, core.Enabled(level), "Expected all levels to be disabled in no-op core.")
+			assert.Equal(t, ce, core.Check(entry, ce), "Expected no-op Check to return checked entry unchanged.")
+			assert.NoError(t, core.Write(entry, nil), "Expected no-op Writes to always succeed.")
+			assert.NoError(t, core.Sync(), "Expected no-op Syncs to always succeed.")
+		})
 	}
 }
 
 func TestIOCore(t *testing.T) {
+	t.Parallel()
+
 	temp, err := os.CreateTemp(t.TempDir(), "test.log")
 	require.NoError(t, err)
 
@@ -82,9 +91,7 @@ func TestIOCore(t *testing.T) {
 	).With([]Field{makeInt64Field("k", 1)})
 	defer assert.NoError(t, core.Sync(), "Expected Syncing a temp file to succeed.")
 
-	t.Run("LevelOf", func(t *testing.T) {
-		assert.Equal(t, InfoLevel, LevelOf(core), "Incorrect Core Level")
-	})
+	assert.Equal(t, InfoLevel, LevelOf(core), "Incorrect Core Level")
 
 	if ce := core.Check(Entry{Level: DebugLevel, Message: "debug"}, nil); ce != nil {
 		ce.Write(makeInt64Field("k", 2))
@@ -108,6 +115,8 @@ func TestIOCore(t *testing.T) {
 }
 
 func TestIOCoreSyncFail(t *testing.T) {
+	t.Parallel()
+
 	sink := &ztest.Discarder{}
 	err := errors.New("failed")
 	sink.SetError(err)
@@ -127,33 +136,43 @@ func TestIOCoreSyncFail(t *testing.T) {
 }
 
 func TestIOCoreSyncsOutput(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
+		desc       string
 		entry      Entry
 		shouldSync bool
 	}{
-		{Entry{Level: DebugLevel}, false},
-		{Entry{Level: InfoLevel}, false},
-		{Entry{Level: WarnLevel}, false},
-		{Entry{Level: ErrorLevel}, false},
-		{Entry{Level: DPanicLevel}, true},
-		{Entry{Level: PanicLevel}, true},
-		{Entry{Level: FatalLevel}, true},
+		{"Debug", Entry{Level: DebugLevel}, false},
+		{"Info", Entry{Level: InfoLevel}, false},
+		{"Warn", Entry{Level: WarnLevel}, false},
+		{"Error", Entry{Level: ErrorLevel}, false},
+		{"DPanic", Entry{Level: DPanicLevel}, true},
+		{"Panic", Entry{Level: PanicLevel}, true},
+		{"Fatal", Entry{Level: FatalLevel}, true},
 	}
 
 	for _, tt := range tests {
-		sink := &ztest.Discarder{}
-		core := NewCore(
-			NewJSONEncoder(testEncoderConfig()),
-			sink,
-			DebugLevel,
-		)
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
 
-		assert.NoError(t, core.Write(tt.entry, nil), "Unexpected error writing entry.")
-		assert.Equal(t, tt.shouldSync, sink.Called(), "Incorrect Sync behavior.")
+			sink := &ztest.Discarder{}
+			core := NewCore(
+				NewJSONEncoder(testEncoderConfig()),
+				sink,
+				DebugLevel,
+			)
+
+			assert.NoError(t, core.Write(tt.entry, nil), "Unexpected error writing entry.")
+			assert.Equal(t, tt.shouldSync, sink.Called(), "Incorrect Sync behavior.")
+		})
 	}
 }
 
 func TestIOCoreWriteFailure(t *testing.T) {
+	t.Parallel()
+
 	core := NewCore(
 		NewJSONEncoder(testEncoderConfig()),
 		Lock(&ztest.FailWriter{}),

--- a/zapcore/entry_test.go
+++ b/zapcore/entry_test.go
@@ -46,6 +46,8 @@ func assertGoexit(t *testing.T, f func()) {
 }
 
 func TestPutNilEntry(t *testing.T) {
+	t.Parallel()
+
 	// Pooling nil entries defeats the purpose.
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -74,22 +76,28 @@ func TestPutNilEntry(t *testing.T) {
 }
 
 func TestEntryCaller(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
+		name   string
 		caller EntryCaller
 		full   string
 		short  string
 	}{
 		{
+			name:   "unknown",
 			caller: NewEntryCaller(100, "/path/to/foo.go", 42, false),
 			full:   "undefined",
 			short:  "undefined",
 		},
 		{
+			name:   "absolute",
 			caller: NewEntryCaller(100, "/path/to/foo.go", 42, true),
 			full:   "/path/to/foo.go:42",
 			short:  "to/foo.go:42",
 		},
 		{
+			name:   "relative",
 			caller: NewEntryCaller(100, "to/foo.go", 42, true),
 			full:   "to/foo.go:42",
 			short:  "to/foo.go:42",
@@ -97,25 +105,37 @@ func TestEntryCaller(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.full, tt.caller.String(), "Unexpected string from EntryCaller.")
-		assert.Equal(t, tt.full, tt.caller.FullPath(), "Unexpected FullPath from EntryCaller.")
-		assert.Equal(t, tt.short, tt.caller.TrimmedPath(), "Unexpected TrimmedPath from EntryCaller.")
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.full, tt.caller.String(), "Unexpected string from EntryCaller.")
+			assert.Equal(t, tt.full, tt.caller.FullPath(), "Unexpected FullPath from EntryCaller.")
+			assert.Equal(t, tt.short, tt.caller.TrimmedPath(), "Unexpected TrimmedPath from EntryCaller.")
+		})
 	}
 }
 
+//nolint:paralleltest // stubs exit func
 func TestCheckedEntryWrite(t *testing.T) {
 	t.Run("nil is safe", func(t *testing.T) {
+		t.Parallel()
+
 		var ce *CheckedEntry
 		assert.NotPanics(t, func() { ce.Write() }, "Unexpected panic writing nil CheckedEntry.")
 	})
 
 	t.Run("WriteThenPanic", func(t *testing.T) {
+		t.Parallel()
+
 		var ce *CheckedEntry
 		ce = ce.After(Entry{}, WriteThenPanic)
 		assert.Panics(t, func() { ce.Write() }, "Expected to panic when WriteThenPanic is set.")
 	})
 
 	t.Run("WriteThenGoexit", func(t *testing.T) {
+		t.Parallel()
+
 		var ce *CheckedEntry
 		ce = ce.After(Entry{}, WriteThenGoexit)
 		assertGoexit(t, func() { ce.Write() })
@@ -132,6 +152,8 @@ func TestCheckedEntryWrite(t *testing.T) {
 	})
 
 	t.Run("After", func(t *testing.T) {
+		t.Parallel()
+
 		var ce *CheckedEntry
 		hook := &customHook{}
 		ce = ce.After(Entry{}, hook)

--- a/zapcore/error_test.go
+++ b/zapcore/error_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,6 +66,8 @@ func (e customMultierr) Errors() []error {
 }
 
 func TestErrorEncoding(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		k     string
 		t     FieldType // defaults to ErrorType
@@ -140,19 +143,26 @@ func TestErrorEncoding(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		if tt.t == UnknownType {
-			tt.t = ErrorType
-		}
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 
-		enc := NewMapObjectEncoder()
-		f := Field{Key: tt.k, Type: tt.t, Interface: tt.iface}
-		f.AddTo(enc)
-		assert.Equal(t, tt.want, enc.Fields, "Unexpected output from field %+v.", f)
+			if tt.t == UnknownType {
+				tt.t = ErrorType
+			}
+
+			enc := NewMapObjectEncoder()
+			f := Field{Key: tt.k, Type: tt.t, Interface: tt.iface}
+			f.AddTo(enc)
+			assert.Equal(t, tt.want, enc.Fields, "Unexpected output from field %+v.", f)
+		})
 	}
 }
 
 func TestRichErrorSupport(t *testing.T) {
+	t.Parallel()
+
 	f := Field{
 		Type:      ErrorType,
 		Interface: fmt.Errorf("failed: %w", errors.New("egad")),

--- a/zapcore/field_test.go
+++ b/zapcore/field_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
@@ -94,6 +95,8 @@ func (eobj *errObj) Error() string {
 }
 
 func TestUnknownFieldType(t *testing.T) {
+	t.Parallel()
+
 	unknown := Field{Key: "k", String: "foo"}
 	assert.Equal(t, UnknownType, unknown.Type, "Expected zero value of FieldType to be UnknownType.")
 	assert.Panics(t, func() {
@@ -102,6 +105,8 @@ func TestUnknownFieldType(t *testing.T) {
 }
 
 func TestFieldAddingError(t *testing.T) {
+	t.Parallel()
+
 	var empty interface{}
 	tests := []struct {
 		t     FieldType
@@ -118,16 +123,23 @@ func TestFieldAddingError(t *testing.T) {
 		{t: StringerType, iface: &obj{3}, want: empty, err: "PANIC=<nil>"},
 		{t: ErrorType, iface: &errObj{kind: 1}, want: empty, err: "PANIC=panic in Error() method"},
 	}
-	for _, tt := range tests {
-		f := Field{Key: "k", Interface: tt.iface, Type: tt.t}
-		enc := NewMapObjectEncoder()
-		assert.NotPanics(t, func() { f.AddTo(enc) }, "Unexpected panic when adding fields returns an error.")
-		assert.Equal(t, tt.want, enc.Fields["k"], "On error, expected zero value in field.Key.")
-		assert.Equal(t, tt.err, enc.Fields["kError"], "Expected error message in log context.")
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			f := Field{Key: "k", Interface: tt.iface, Type: tt.t}
+			enc := NewMapObjectEncoder()
+			assert.NotPanics(t, func() { f.AddTo(enc) }, "Unexpected panic when adding fields returns an error.")
+			assert.Equal(t, tt.want, enc.Fields["k"], "On error, expected zero value in field.Key.")
+			assert.Equal(t, tt.err, enc.Fields["kError"], "Expected error message in log context.")
+		})
 	}
 }
 
 func TestFields(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		t     FieldType
 		i     int64
@@ -167,20 +179,27 @@ func TestFields(t *testing.T) {
 		{t: ErrorType, iface: (*errObj)(nil), want: "<nil>"},
 	}
 
-	for _, tt := range tests {
-		enc := NewMapObjectEncoder()
-		f := Field{Key: "k", Type: tt.t, Integer: tt.i, Interface: tt.iface, String: tt.s}
-		f.AddTo(enc)
-		assert.Equal(t, tt.want, enc.Fields["k"], "Unexpected output from field %+v.", f)
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 
-		delete(enc.Fields, "k")
-		assert.Equal(t, 0, len(enc.Fields), "Unexpected extra fields present.")
+			enc := NewMapObjectEncoder()
+			f := Field{Key: "k", Type: tt.t, Integer: tt.i, Interface: tt.iface, String: tt.s}
+			f.AddTo(enc)
+			assert.Equal(t, tt.want, enc.Fields["k"], "Unexpected output from field %+v.", f)
 
-		assert.True(t, f.Equals(f), "Field does not equal itself")
+			delete(enc.Fields, "k")
+			assert.Equal(t, 0, len(enc.Fields), "Unexpected extra fields present.")
+
+			assert.True(t, f.Equals(f), "Field does not equal itself")
+		})
 	}
 }
 
 func TestInlineMarshaler(t *testing.T) {
+	t.Parallel()
+
 	enc := NewMapObjectEncoder()
 
 	topLevelStr := Field{Key: "k", Type: StringType, String: "s"}
@@ -202,6 +221,8 @@ func TestInlineMarshaler(t *testing.T) {
 }
 
 func TestEquals(t *testing.T) {
+	t.Parallel()
+
 	// Values outside the UnixNano range were encoded incorrectly (#737, #803).
 	timeOutOfRangeHigh := time.Unix(0, math.MaxInt64).Add(time.Nanosecond)
 	timeOutOfRangeLow := time.Unix(0, math.MinInt64).Add(-time.Nanosecond)
@@ -321,8 +342,13 @@ func TestEquals(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		assert.Equal(t, tt.want, tt.a.Equals(tt.b), "a.Equals(b) a: %#v b: %#v", tt.a, tt.b)
-		assert.Equal(t, tt.want, tt.b.Equals(tt.a), "b.Equals(a) a: %#v b: %#v", tt.a, tt.b)
+	for i, tt := range tests {
+		i, tt := i, tt
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.a.Equals(tt.b), "a.Equals(b) a: %#v b: %#v", tt.a, tt.b)
+			assert.Equal(t, tt.want, tt.b.Equals(tt.a), "b.Equals(a) a: %#v b: %#v", tt.a, tt.b)
+		})
 	}
 }

--- a/zapcore/increase_level_test.go
+++ b/zapcore/increase_level_test.go
@@ -32,6 +32,8 @@ import (
 )
 
 func TestIncreaseLevel(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		coreLevel     Level
 		increaseLevel Level
@@ -78,8 +80,11 @@ func TestIncreaseLevel(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		msg := fmt.Sprintf("increase %v to %v", tt.coreLevel, tt.increaseLevel)
 		t.Run(msg, func(t *testing.T) {
+			t.Parallel()
+
 			logger, logs := observer.New(tt.coreLevel)
 
 			// sanity check

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -45,6 +45,8 @@ var _defaultEncoderConfig = EncoderConfig{
 }
 
 func TestJSONClone(t *testing.T) {
+	t.Parallel()
+
 	// The parent encoder is created with plenty of excess capacity.
 	parent := &jsonEncoder{buf: bufferpool.Get()}
 	clone := parent.Clone()
@@ -58,6 +60,8 @@ func TestJSONClone(t *testing.T) {
 }
 
 func TestJSONEscaping(t *testing.T) {
+	t.Parallel()
+
 	enc := &jsonEncoder{buf: bufferpool.Get()}
 	// Test all the edge cases of JSON escaping directly.
 	cases := map[string]string{
@@ -92,6 +96,7 @@ func TestJSONEscaping(t *testing.T) {
 		"foo\xed\xa0\x80": `foo\ufffd\ufffd\ufffd`,
 	}
 
+	//nolint:paralleltest // shared state
 	t.Run("String", func(t *testing.T) {
 		for input, output := range cases {
 			enc.truncate()
@@ -100,6 +105,7 @@ func TestJSONEscaping(t *testing.T) {
 		}
 	})
 
+	//nolint:paralleltest // shared state
 	t.Run("ByteString", func(t *testing.T) {
 		for input, output := range cases {
 			enc.truncate()
@@ -110,6 +116,8 @@ func TestJSONEscaping(t *testing.T) {
 }
 
 func TestJSONEncoderObjectFields(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc     string
 		expected string
@@ -282,13 +290,18 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			assertOutput(t, _defaultEncoderConfig, tt.expected, tt.f)
 		})
 	}
 }
 
 func TestJSONEncoderTimeFormats(t *testing.T) {
+	t.Parallel()
+
 	date := time.Date(2000, time.January, 2, 3, 4, 5, 6, time.UTC)
 
 	f := func(e Encoder) {
@@ -331,13 +344,18 @@ func TestJSONEncoderTimeFormats(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			assertOutput(t, tt.cfg, tt.expected, f)
 		})
 	}
 }
 
 func TestJSONEncoderArrays(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc     string
 		expected string // expect f to be called twice
@@ -440,7 +458,10 @@ func TestJSONEncoderArrays(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			f := func(enc Encoder) error {
 				return enc.AddArray("array", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
 					tt.f(arr)
@@ -457,6 +478,8 @@ func TestJSONEncoderArrays(t *testing.T) {
 }
 
 func TestJSONEncoderTimeArrays(t *testing.T) {
+	t.Parallel()
+
 	times := []time.Time{
 		time.Unix(1008720000, 0).UTC(), // 2001-12-19
 		time.Unix(1040169600, 0).UTC(), // 2002-12-18
@@ -491,7 +514,10 @@ func TestJSONEncoderTimeArrays(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			cfg := _defaultEncoderConfig
 			cfg.EncodeTime = tt.encoder
 
@@ -653,6 +679,8 @@ func asciiRoundTripsCorrectlyByteString(s ASCII) bool {
 }
 
 func TestJSONQuick(t *testing.T) {
+	t.Parallel()
+
 	check := func(f interface{}) {
 		err := quick.Check(f, &quick.Config{MaxCountScale: 100.0})
 		assert.NoError(t, err)

--- a/zapcore/json_encoder_test.go
+++ b/zapcore/json_encoder_test.go
@@ -37,6 +37,8 @@ import (
 // zapcore_test package, so that it can import the toplevel zap package for
 // field constructor convenience.
 func TestJSONEncodeEntry(t *testing.T) {
+	t.Parallel()
+
 	type bar struct {
 		Key string  `json:"key"`
 		Val float64 `json:"val"`
@@ -126,7 +128,10 @@ func TestJSONEncodeEntry(t *testing.T) {
 	})
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			buf, err := enc.EncodeEntry(tt.ent, tt.fields)
 			if assert.NoError(t, err, "Unexpected JSON encoding error.") {
 				assert.JSONEq(t, tt.expected, buf.String(), "Incorrect encoded JSON entry.")
@@ -137,6 +142,8 @@ func TestJSONEncodeEntry(t *testing.T) {
 }
 
 func TestNoEncodeLevelSupplied(t *testing.T) {
+	t.Parallel()
+
 	enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{
 		MessageKey:     "M",
 		LevelKey:       "L",
@@ -166,6 +173,8 @@ func TestNoEncodeLevelSupplied(t *testing.T) {
 }
 
 func TestJSONEmptyConfig(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		field    zapcore.Field
@@ -184,7 +193,10 @@ func TestJSONEmptyConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{})
 
 			buf, err := enc.EncodeEntry(zapcore.Entry{
@@ -213,6 +225,8 @@ func (enc *emptyReflectedEncoder) Encode(obj interface{}) error {
 }
 
 func TestJSONCustomReflectedEncoder(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		field    zapcore.Field

--- a/zapcore/lazy_with_test.go
+++ b/zapcore/lazy_with_test.go
@@ -58,6 +58,8 @@ func withLazyCore(f func(zapcore.Core, *proxyCore, *observer.ObservedLogs), init
 }
 
 func TestLazyCore(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		entries       []zapcore.Entry
@@ -120,7 +122,10 @@ func TestLazyCore(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			withLazyCore(func(lazy zapcore.Core, proxy *proxyCore, logs *observer.ObservedLogs) {
 				checkCounts := func(withCount int64, msg string) {
 					assert.Equal(t, withCount, proxy.withCount.Load(), msg)

--- a/zapcore/level_strings_test.go
+++ b/zapcore/level_strings_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestAllLevelsCoveredByLevelString(t *testing.T) {
+	t.Parallel()
+
 	numLevels := int((_maxLevel - _minLevel) + 1)
 
 	isComplete := func(m map[Level]string) bool {

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestLevelString(t *testing.T) {
+	t.Parallel()
+
 	tests := map[Level]string{
 		DebugLevel:   "debug",
 		InfoLevel:    "info",
@@ -43,12 +45,19 @@ func TestLevelString(t *testing.T) {
 	}
 
 	for lvl, stringLevel := range tests {
-		assert.Equal(t, stringLevel, lvl.String(), "Unexpected lowercase level string.")
-		assert.Equal(t, strings.ToUpper(stringLevel), lvl.CapitalString(), "Unexpected all-caps level string.")
+		lvl, stringLevel := lvl, stringLevel
+		t.Run(stringLevel, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, stringLevel, lvl.String(), "Unexpected lowercase level string.")
+			assert.Equal(t, strings.ToUpper(stringLevel), lvl.CapitalString(), "Unexpected all-caps level string.")
+		})
 	}
 }
 
 func TestLevelText(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		text  string
 		level Level
@@ -63,21 +72,28 @@ func TestLevelText(t *testing.T) {
 		{"fatal", FatalLevel},
 	}
 	for _, tt := range tests {
-		if tt.text != "" {
-			lvl := tt.level
-			marshaled, err := lvl.MarshalText()
-			assert.NoError(t, err, "Unexpected error marshaling level %v to text.", &lvl)
-			assert.Equal(t, tt.text, string(marshaled), "Marshaling level %v to text yielded unexpected result.", &lvl)
-		}
+		tt := tt
+		t.Run(tt.text, func(t *testing.T) {
+			t.Parallel()
 
-		var unmarshaled Level
-		err := unmarshaled.UnmarshalText([]byte(tt.text))
-		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
-		assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
+			if tt.text != "" {
+				lvl := tt.level
+				marshaled, err := lvl.MarshalText()
+				assert.NoError(t, err, "Unexpected error marshaling level %v to text.", &lvl)
+				assert.Equal(t, tt.text, string(marshaled), "Marshaling level %v to text yielded unexpected result.", &lvl)
+			}
+
+			var unmarshaled Level
+			err := unmarshaled.UnmarshalText([]byte(tt.text))
+			assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
+			assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
+		})
 	}
 }
 
 func TestParseLevel(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		text  string
 		level Level
@@ -88,17 +104,24 @@ func TestParseLevel(t *testing.T) {
 		{"FOO", 0, `unrecognized level: "FOO"`},
 	}
 	for _, tt := range tests {
-		parsedLevel, err := ParseLevel(tt.text)
-		if len(tt.err) == 0 {
-			assert.NoError(t, err)
-			assert.Equal(t, tt.level, parsedLevel)
-		} else {
-			assert.ErrorContains(t, err, tt.err)
-		}
+		tt := tt
+		t.Run(tt.text, func(t *testing.T) {
+			t.Parallel()
+
+			parsedLevel, err := ParseLevel(tt.text)
+			if len(tt.err) == 0 {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.level, parsedLevel)
+			} else {
+				assert.ErrorContains(t, err, tt.err)
+			}
+		})
 	}
 }
 
 func TestCapitalLevelsParse(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		text  string
 		level Level
@@ -112,14 +135,21 @@ func TestCapitalLevelsParse(t *testing.T) {
 		{"FATAL", FatalLevel},
 	}
 	for _, tt := range tests {
-		var unmarshaled Level
-		err := unmarshaled.UnmarshalText([]byte(tt.text))
-		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
-		assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
+		tt := tt
+		t.Run(tt.text, func(t *testing.T) {
+			t.Parallel()
+
+			var unmarshaled Level
+			err := unmarshaled.UnmarshalText([]byte(tt.text))
+			assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
+			assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
+		})
 	}
 }
 
 func TestWeirdLevelsParse(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		text  string
 		level Level
@@ -143,14 +173,21 @@ func TestWeirdLevelsParse(t *testing.T) {
 		{"FaTaL", FatalLevel},
 	}
 	for _, tt := range tests {
-		var unmarshaled Level
-		err := unmarshaled.UnmarshalText([]byte(tt.text))
-		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
-		assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
+		tt := tt
+		t.Run(tt.text, func(t *testing.T) {
+			t.Parallel()
+
+			var unmarshaled Level
+			err := unmarshaled.UnmarshalText([]byte(tt.text))
+			assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
+			assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
+		})
 	}
 }
 
 func TestLevelNils(t *testing.T) {
+	t.Parallel()
+
 	var l *Level
 
 	// The String() method will not handle nil level properly.
@@ -167,12 +204,16 @@ func TestLevelNils(t *testing.T) {
 }
 
 func TestLevelUnmarshalUnknownText(t *testing.T) {
+	t.Parallel()
+
 	var l Level
 	err := l.UnmarshalText([]byte("foo"))
 	assert.ErrorContains(t, err, "unrecognized level", "Expected unmarshaling arbitrary text to fail.")
 }
 
 func TestLevelAsFlagValue(t *testing.T) {
+	t.Parallel()
+
 	var (
 		buf bytes.Buffer
 		lvl Level
@@ -213,6 +254,8 @@ func (l *enablerWithCustomLevel) Level() Level {
 }
 
 func TestLevelOf(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc string
 		give LevelEnabler

--- a/zapcore/memory_encoder_test.go
+++ b/zapcore/memory_encoder_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestMapObjectEncoderAdd(t *testing.T) {
+	t.Parallel()
+
 	// Expected output of a turducken.
 	wantTurducken := map[string]interface{}{
 		"ducks": []interface{}{
@@ -248,7 +250,10 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			enc := NewMapObjectEncoder()
 			tt.f(enc)
 			assert.Equal(t, tt.expected, enc.Fields["k"], "Unexpected encoder output.")
@@ -257,6 +262,8 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 }
 
 func TestSliceArrayEncoderAppend(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc     string
 		f        func(ArrayEncoder)
@@ -343,7 +350,10 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
 			enc := NewMapObjectEncoder()
 			assert.NoError(t, enc.AddArray("k", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
 				tt.f(arr)
@@ -359,6 +369,8 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 }
 
 func TestMapObjectEncoderReflectionFailures(t *testing.T) {
+	t.Parallel()
+
 	enc := NewMapObjectEncoder()
 	assert.Error(t, enc.AddObject("object", loggable{false}), "Expected AddObject to fail.")
 	assert.Equal(

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -67,28 +67,38 @@ func writeSequence(core Core, n int, lvl Level) {
 }
 
 func TestSampler(t *testing.T) {
-	for _, lvl := range []Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel, PanicLevel, FatalLevel} {
-		sampler, logs := fakeSampler(DebugLevel, time.Minute, 2, 3)
+	t.Parallel()
 
-		// Ensure that counts aren't shared between levels.
-		probeLevel := DebugLevel
-		if lvl == DebugLevel {
-			probeLevel = InfoLevel
-		}
-		for i := 0; i < 10; i++ {
-			writeSequence(sampler, 1, probeLevel)
-		}
-		// Clear any output.
-		logs.TakeAll()
+	levels := []Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel, PanicLevel, FatalLevel}
+	for _, lvl := range levels {
+		lvl := lvl
+		t.Run(lvl.String(), func(t *testing.T) {
+			t.Parallel()
 
-		for i := 1; i < 10; i++ {
-			writeSequence(sampler, i, lvl)
-		}
-		assertSequence(t, logs.TakeAll(), lvl, 1, 2, 5, 8)
+			sampler, logs := fakeSampler(DebugLevel, time.Minute, 2, 3)
+
+			// Ensure that counts aren't shared between levels.
+			probeLevel := DebugLevel
+			if lvl == DebugLevel {
+				probeLevel = InfoLevel
+			}
+			for i := 0; i < 10; i++ {
+				writeSequence(sampler, 1, probeLevel)
+			}
+			// Clear any output.
+			logs.TakeAll()
+
+			for i := 1; i < 10; i++ {
+				writeSequence(sampler, i, lvl)
+			}
+			assertSequence(t, logs.TakeAll(), lvl, 1, 2, 5, 8)
+		})
 	}
 }
 
 func TestLevelOfSampler(t *testing.T) {
+	t.Parallel()
+
 	levels := []Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel, PanicLevel, FatalLevel}
 	for _, lvl := range levels {
 		lvl := lvl
@@ -102,6 +112,8 @@ func TestLevelOfSampler(t *testing.T) {
 }
 
 func TestSamplerDisabledLevels(t *testing.T) {
+	t.Parallel()
+
 	sampler, logs := fakeSampler(InfoLevel, time.Minute, 1, 100)
 
 	// Shouldn't be counted, because debug logging isn't enabled.
@@ -111,6 +123,8 @@ func TestSamplerDisabledLevels(t *testing.T) {
 }
 
 func TestSamplerTicking(t *testing.T) {
+	t.Parallel()
+
 	// Ensure that we're resetting the sampler's counter every tick.
 	sampler, logs := fakeSampler(DebugLevel, 10*time.Millisecond, 5, 10)
 
@@ -167,6 +181,8 @@ func (*countingCore) Enabled(Level) bool  { return true }
 func (*countingCore) Sync() error         { return nil }
 
 func TestSamplerConcurrent(t *testing.T) {
+	t.Parallel()
+
 	const (
 		logsPerTick   = 10
 		numMessages   = 5
@@ -248,6 +264,8 @@ func TestSamplerConcurrent(t *testing.T) {
 }
 
 func TestSamplerRaces(t *testing.T) {
+	t.Parallel()
+
 	sampler, _ := fakeSampler(DebugLevel, time.Minute, 1, 1000)
 
 	var wg sync.WaitGroup
@@ -269,6 +287,8 @@ func TestSamplerRaces(t *testing.T) {
 }
 
 func TestSamplerUnknownLevels(t *testing.T) {
+	t.Parallel()
+
 	// Prove that out-of-bounds levels don't panic.
 	unknownLevels := []Level{
 		DebugLevel - 1,
@@ -276,7 +296,10 @@ func TestSamplerUnknownLevels(t *testing.T) {
 	}
 
 	for _, lvl := range unknownLevels {
+		lvl := lvl
 		t.Run(lvl.String(), func(t *testing.T) {
+			t.Parallel()
+
 			sampler, logs := fakeSampler(lvl, time.Minute, 2, 3)
 			for i := 1; i < 10; i++ {
 				writeSequence(sampler, i, lvl)
@@ -289,6 +312,8 @@ func TestSamplerUnknownLevels(t *testing.T) {
 }
 
 func TestSamplerWithZeroThereafter(t *testing.T) {
+	t.Parallel()
+
 	var counter countingCore
 
 	// Logs two messages per second.

--- a/zapcore/tee_test.go
+++ b/zapcore/tee_test.go
@@ -39,17 +39,26 @@ func withTee(f func(core Core, debugLogs, warnLogs *observer.ObservedLogs)) {
 }
 
 func TestTeeUnusualInput(t *testing.T) {
+	t.Parallel()
+
 	// Verify that Tee handles receiving one and no inputs correctly.
 	t.Run("one input", func(t *testing.T) {
+		t.Parallel()
+
 		obs, _ := observer.New(DebugLevel)
 		assert.Equal(t, obs, NewTee(obs), "Expected to return single inputs unchanged.")
 	})
+
 	t.Run("no input", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Equal(t, NewNopCore(), NewTee(), "Expected to return NopCore.")
 	})
 }
 
 func TestLevelOfTee(t *testing.T) {
+	t.Parallel()
+
 	debugLogger, _ := observer.New(DebugLevel)
 	warnLogger, _ := observer.New(WarnLevel)
 
@@ -88,6 +97,8 @@ func TestLevelOfTee(t *testing.T) {
 }
 
 func TestTeeCheck(t *testing.T) {
+	t.Parallel()
+
 	withTee(func(tee Core, debugLogs, warnLogs *observer.ObservedLogs) {
 		debugEntry := Entry{Level: DebugLevel, Message: "log-at-debug"}
 		infoEntry := Entry{Level: InfoLevel, Message: "log-at-info"}
@@ -114,6 +125,8 @@ func TestTeeCheck(t *testing.T) {
 }
 
 func TestTeeWrite(t *testing.T) {
+	t.Parallel()
+
 	// Calling the tee's Write method directly should always log, regardless of
 	// the configured level.
 	withTee(func(tee Core, debugLogs, warnLogs *observer.ObservedLogs) {
@@ -133,6 +146,8 @@ func TestTeeWrite(t *testing.T) {
 }
 
 func TestTeeWith(t *testing.T) {
+	t.Parallel()
+
 	withTee(func(tee Core, debugLogs, warnLogs *observer.ObservedLogs) {
 		f := makeInt64Field("k", 42)
 		tee = tee.With([]Field{f})
@@ -150,6 +165,8 @@ func TestTeeWith(t *testing.T) {
 }
 
 func TestTeeEnabled(t *testing.T) {
+	t.Parallel()
+
 	infoLogger, _ := observer.New(InfoLevel)
 	warnLogger, _ := observer.New(WarnLevel)
 	tee := NewTee(infoLogger, warnLogger)
@@ -167,11 +184,18 @@ func TestTeeEnabled(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.enabled, tee.Enabled(tt.lvl), "Unexpected Enabled result for level %s.", tt.lvl)
+		tt := tt
+		t.Run(tt.lvl.String(), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.enabled, tee.Enabled(tt.lvl), "Unexpected Enabled result for level %s.", tt.lvl)
+		})
 	}
 }
 
 func TestTeeSync(t *testing.T) {
+	t.Parallel()
+
 	infoLogger, _ := observer.New(InfoLevel)
 	warnLogger, _ := observer.New(WarnLevel)
 	tee := NewTee(infoLogger, warnLogger)

--- a/zapcore/write_syncer_test.go
+++ b/zapcore/write_syncer_test.go
@@ -43,6 +43,8 @@ func requireWriteWorks(t testing.TB, ws WriteSyncer) {
 }
 
 func TestAddSyncWriteSyncer(t *testing.T) {
+	t.Parallel()
+
 	buf := &bytes.Buffer{}
 	concrete := &writeSyncSpy{Writer: buf}
 	ws := AddSync(concrete)
@@ -56,6 +58,8 @@ func TestAddSyncWriteSyncer(t *testing.T) {
 }
 
 func TestAddSyncWriter(t *testing.T) {
+	t.Parallel()
+
 	// If we pass a plain io.Writer, make sure that we still get a WriteSyncer
 	// with a no-op Sync.
 	buf := &bytes.Buffer{}
@@ -65,6 +69,8 @@ func TestAddSyncWriter(t *testing.T) {
 }
 
 func TestNewMultiWriteSyncerWorksForSingleWriter(t *testing.T) {
+	t.Parallel()
+
 	w := &ztest.Buffer{}
 
 	ws := NewMultiWriteSyncer(w)
@@ -75,6 +81,8 @@ func TestNewMultiWriteSyncerWorksForSingleWriter(t *testing.T) {
 }
 
 func TestMultiWriteSyncerWritesBoth(t *testing.T) {
+	t.Parallel()
+
 	first := &bytes.Buffer{}
 	second := &bytes.Buffer{}
 	ws := NewMultiWriteSyncer(AddSync(first), AddSync(second))
@@ -89,12 +97,16 @@ func TestMultiWriteSyncerWritesBoth(t *testing.T) {
 }
 
 func TestMultiWriteSyncerFailsWrite(t *testing.T) {
+	t.Parallel()
+
 	ws := NewMultiWriteSyncer(AddSync(&ztest.FailWriter{}))
 	_, err := ws.Write([]byte("test"))
 	assert.Error(t, err, "Write error should propagate")
 }
 
 func TestMultiWriteSyncerFailsShortWrite(t *testing.T) {
+	t.Parallel()
+
 	ws := NewMultiWriteSyncer(AddSync(&ztest.ShortWriter{}))
 	n, err := ws.Write([]byte("test"))
 	assert.NoError(t, err, "Expected fake-success from short write")
@@ -102,6 +114,8 @@ func TestMultiWriteSyncerFailsShortWrite(t *testing.T) {
 }
 
 func TestWritestoAllSyncs_EvenIfFirstErrors(t *testing.T) {
+	t.Parallel()
+
 	failer := &ztest.FailWriter{}
 	second := &bytes.Buffer{}
 	ws := NewMultiWriteSyncer(AddSync(failer), AddSync(second))
@@ -112,6 +126,8 @@ func TestWritestoAllSyncs_EvenIfFirstErrors(t *testing.T) {
 }
 
 func TestMultiWriteSyncerSync_PropagatesErrors(t *testing.T) {
+	t.Parallel()
+
 	badsink := &ztest.Buffer{}
 	badsink.SetError(errors.New("sink is full"))
 	ws := NewMultiWriteSyncer(&ztest.Discarder{}, badsink)
@@ -120,11 +136,15 @@ func TestMultiWriteSyncerSync_PropagatesErrors(t *testing.T) {
 }
 
 func TestMultiWriteSyncerSync_NoErrorsOnDiscard(t *testing.T) {
+	t.Parallel()
+
 	ws := NewMultiWriteSyncer(&ztest.Discarder{})
 	assert.NoError(t, ws.Sync(), "Expected error-free sync to /dev/null")
 }
 
 func TestMultiWriteSyncerSync_AllCalled(t *testing.T) {
+	t.Parallel()
+
 	failed, second := &ztest.Buffer{}, &ztest.Buffer{}
 
 	failed.SetError(errors.New("disposal broken"))

--- a/zapgrpc/internal/test/grpc_test.go
+++ b/zapgrpc/internal/test/grpc_test.go
@@ -33,6 +33,8 @@ import (
 )
 
 func TestLoggerV2(t *testing.T) {
+	t.Parallel()
+
 	core, observedLogs := observer.New(zapcore.InfoLevel)
 	zlog := zap.New(core)
 

--- a/zapgrpc/zapgrpc_test.go
+++ b/zapgrpc/zapgrpc_test.go
@@ -32,6 +32,8 @@ import (
 )
 
 func TestLoggerInfoExpected(t *testing.T) {
+	t.Parallel()
+
 	checkMessages(t, zapcore.DebugLevel, nil, zapcore.InfoLevel, []string{
 		"hello",
 		"s1s21 2 3s34s56",
@@ -66,6 +68,8 @@ func TestLoggerInfoExpected(t *testing.T) {
 }
 
 func TestLoggerDebugExpected(t *testing.T) {
+	t.Parallel()
+
 	checkMessages(t, zapcore.DebugLevel, []Option{WithDebug()}, zapcore.DebugLevel, []string{
 		"hello",
 		"s1s21 2 3s34s56",
@@ -86,6 +90,8 @@ func TestLoggerDebugExpected(t *testing.T) {
 }
 
 func TestLoggerDebugSuppressed(t *testing.T) {
+	t.Parallel()
+
 	checkMessages(t, zapcore.InfoLevel, []Option{WithDebug()}, zapcore.DebugLevel, nil, func(logger *Logger) {
 		logger.Print("hello")
 		logger.Printf("%s world", "hello")
@@ -96,6 +102,8 @@ func TestLoggerDebugSuppressed(t *testing.T) {
 }
 
 func TestLoggerWarningExpected(t *testing.T) {
+	t.Parallel()
+
 	checkMessages(t, zapcore.DebugLevel, nil, zapcore.WarnLevel, []string{
 		"hello",
 		"s1s21 2 3s34s56",
@@ -116,6 +124,8 @@ func TestLoggerWarningExpected(t *testing.T) {
 }
 
 func TestLoggerErrorExpected(t *testing.T) {
+	t.Parallel()
+
 	checkMessages(t, zapcore.DebugLevel, nil, zapcore.ErrorLevel, []string{
 		"hello",
 		"s1s21 2 3s34s56",
@@ -136,6 +146,8 @@ func TestLoggerErrorExpected(t *testing.T) {
 }
 
 func TestLoggerFatalExpected(t *testing.T) {
+	t.Parallel()
+
 	checkMessages(t, zapcore.DebugLevel, nil, zapcore.FatalLevel, []string{
 		"hello",
 		"s1s21 2 3s34s56",
@@ -156,6 +168,8 @@ func TestLoggerFatalExpected(t *testing.T) {
 }
 
 func TestLoggerV(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		zapLevel     zapcore.Level
 		grpcEnabled  []int
@@ -197,21 +211,34 @@ func TestLoggerV(t *testing.T) {
 			grpcDisabled: []int{grpcLvlInfo, grpcLvlWarn, grpcLvlError},
 		},
 	}
-	for _, tst := range tests {
-		for _, grpcLvl := range tst.grpcEnabled {
-			t.Run(fmt.Sprintf("enabled %s %d", tst.zapLevel, grpcLvl), func(t *testing.T) {
-				checkLevel(t, tst.zapLevel, true, func(logger *Logger) bool {
-					return logger.V(grpcLvl)
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("zap="+tt.zapLevel.String(), func(t *testing.T) {
+			t.Parallel()
+
+			for _, grpcLvl := range tt.grpcEnabled {
+				grpcLvl := grpcLvl
+				t.Run(fmt.Sprintf("grpc=%d", grpcLvl), func(t *testing.T) {
+					t.Parallel()
+
+					checkLevel(t, tt.zapLevel, true, func(logger *Logger) bool {
+						return logger.V(grpcLvl)
+					})
 				})
-			})
-		}
-		for _, grpcLvl := range tst.grpcDisabled {
-			t.Run(fmt.Sprintf("disabled %s %d", tst.zapLevel, grpcLvl), func(t *testing.T) {
-				checkLevel(t, tst.zapLevel, false, func(logger *Logger) bool {
-					return logger.V(grpcLvl)
+			}
+
+			for _, grpcLvl := range tt.grpcDisabled {
+				grpcLvl := grpcLvl
+				t.Run(fmt.Sprintf("grpc=%d", grpcLvl), func(t *testing.T) {
+					t.Parallel()
+
+					checkLevel(t, tt.zapLevel, false, func(logger *Logger) bool {
+						return logger.V(grpcLvl)
+					})
 				})
-			})
-		}
+			}
+		})
 	}
 }
 

--- a/zapio/writer_test.go
+++ b/zapio/writer_test.go
@@ -170,10 +170,12 @@ func TestWrite_Sync(t *testing.T) {
 	io.WriteString(&w, "foo")
 	io.WriteString(&w, "bar")
 
+	//nolint:paralleltest // shared state
 	t.Run("no sync", func(t *testing.T) {
 		assert.Zero(t, observed.Len(), "Expected no logs yet")
 	})
 
+	//nolint:paralleltest // shared state
 	t.Run("sync", func(t *testing.T) {
 		defer observed.TakeAll()
 
@@ -184,6 +186,7 @@ func TestWrite_Sync(t *testing.T) {
 		}, observed.AllUntimed(), "Log messages did not match")
 	})
 
+	//nolint:paralleltest // shared state
 	t.Run("sync on empty", func(t *testing.T) {
 		require.NoError(t, w.Sync(), "Sync must not fail")
 		assert.Zero(t, observed.Len(), "Expected no logs yet")

--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -35,6 +35,8 @@ import (
 )
 
 func TestTestLogger(t *testing.T) {
+	t.Parallel()
+
 	ts := newTestLogSpy(t)
 	defer ts.AssertPassed()
 
@@ -59,6 +61,8 @@ func TestTestLogger(t *testing.T) {
 }
 
 func TestTestLoggerSupportsLevels(t *testing.T) {
+	t.Parallel()
+
 	ts := newTestLogSpy(t)
 	defer ts.AssertPassed()
 
@@ -81,6 +85,8 @@ func TestTestLoggerSupportsLevels(t *testing.T) {
 }
 
 func TestTestLoggerSupportsWrappedZapOptions(t *testing.T) {
+	t.Parallel()
+
 	ts := newTestLogSpy(t)
 	defer ts.AssertPassed()
 
@@ -96,15 +102,17 @@ func TestTestLoggerSupportsWrappedZapOptions(t *testing.T) {
 	}, "log.Panic should panic")
 
 	ts.AssertMessages(
-		`INFO	zaptest/logger_test.go:89	received work order	{"k1": "v1"}`,
-		`DEBUG	zaptest/logger_test.go:90	starting work	{"k1": "v1"}`,
-		`WARN	zaptest/logger_test.go:91	work may fail	{"k1": "v1"}`,
-		`ERROR	zaptest/logger_test.go:92	work failed	{"k1": "v1", "error": "great sadness"}`,
-		`PANIC	zaptest/logger_test.go:95	failed to do work	{"k1": "v1"}`,
+		`INFO	zaptest/logger_test.go:95	received work order	{"k1": "v1"}`,
+		`DEBUG	zaptest/logger_test.go:96	starting work	{"k1": "v1"}`,
+		`WARN	zaptest/logger_test.go:97	work may fail	{"k1": "v1"}`,
+		`ERROR	zaptest/logger_test.go:98	work failed	{"k1": "v1", "error": "great sadness"}`,
+		`PANIC	zaptest/logger_test.go:101	failed to do work	{"k1": "v1"}`,
 	)
 }
 
 func TestTestingWriter(t *testing.T) {
+	t.Parallel()
+
 	ts := newTestLogSpy(t)
 	w := newTestingWriter(ts)
 
@@ -114,6 +122,8 @@ func TestTestingWriter(t *testing.T) {
 }
 
 func TestTestLoggerErrorOutput(t *testing.T) {
+	t.Parallel()
+
 	// This test verifies that the test logger logs internal messages to the
 	// testing.T and marks the test as failed.
 

--- a/zaptest/observer/logged_entry_test.go
+++ b/zaptest/observer/logged_entry_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestLoggedEntryContextMap(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		msg    string
 		fields []zapcore.Field
@@ -78,7 +80,10 @@ func TestLoggedEntryContextMap(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.msg, func(t *testing.T) {
+			t.Parallel()
+
 			entry := LoggedEntry{
 				Context: tt.fields,
 			}

--- a/zaptest/observer/observer_test.go
+++ b/zaptest/observer/observer_test.go
@@ -38,12 +38,12 @@ func assertEmpty(t testing.TB, logs *ObservedLogs) {
 }
 
 func TestObserver(t *testing.T) {
+	t.Parallel()
+
 	observer, logs := New(zap.InfoLevel)
 	assertEmpty(t, logs)
 
-	t.Run("LevelOf", func(t *testing.T) {
-		assert.Equal(t, zap.InfoLevel, zapcore.LevelOf(observer), "Observer reported the wrong log level.")
-	})
+	assert.Equal(t, zap.InfoLevel, zapcore.LevelOf(observer), "Observer reported the wrong log level.")
 
 	assert.NoError(t, observer.Sync(), "Unexpected failure in no-op Sync")
 
@@ -72,6 +72,8 @@ func TestObserver(t *testing.T) {
 }
 
 func TestObserverWith(t *testing.T) {
+	t.Parallel()
+
 	sf1, logs := New(zap.InfoLevel)
 
 	// need to pad out enough initial fields so that the underlying slice cap()
@@ -124,6 +126,8 @@ func TestObserverWith(t *testing.T) {
 }
 
 func TestFilters(t *testing.T) {
+	t.Parallel()
+
 	logs := []LoggedEntry{
 		{
 			Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "log a"},
@@ -252,7 +256,12 @@ func TestFilters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := tt.filtered.AllUntimed()
-		assert.Equal(t, tt.want, got, tt.msg)
+		tt := tt
+		t.Run(tt.msg, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.filtered.AllUntimed()
+			assert.Equal(t, tt.want, got, tt.msg)
+		})
 	}
 }

--- a/zaptest/timeout_test.go
+++ b/zaptest/timeout_test.go
@@ -28,11 +28,13 @@ import (
 	"go.uber.org/zap/internal/ztest"
 )
 
+//nolint:paralleltest // changes time scaling
 func TestTimeout(t *testing.T) {
 	defer ztest.Initialize("2")()
 	assert.Equal(t, time.Duration(100), Timeout(50), "Expected to scale up timeout.")
 }
 
+//nolint:paralleltest // changes time scaling
 func TestSleep(t *testing.T) {
 	defer ztest.Initialize("2")()
 	const sleepFor = 50 * time.Millisecond

--- a/zaptest/writer_test.go
+++ b/zaptest/writer_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestSyncer(t *testing.T) {
+	t.Parallel()
+
 	err := errors.New("sentinel")
 	s := &Syncer{}
 	s.SetError(err)
@@ -36,6 +38,8 @@ func TestSyncer(t *testing.T) {
 }
 
 func TestDiscarder(t *testing.T) {
+	t.Parallel()
+
 	d := &Discarder{}
 	payload := []byte("foo")
 	n, err := d.Write(payload)
@@ -44,6 +48,8 @@ func TestDiscarder(t *testing.T) {
 }
 
 func TestFailWriter(t *testing.T) {
+	t.Parallel()
+
 	w := &FailWriter{}
 	payload := []byte("foo")
 	n, err := w.Write(payload)
@@ -52,6 +58,8 @@ func TestFailWriter(t *testing.T) {
 }
 
 func TestShortWriter(t *testing.T) {
+	t.Parallel()
+
 	w := &ShortWriter{}
 	payload := []byte("foo")
 	n, err := w.Write(payload)
@@ -60,6 +68,8 @@ func TestShortWriter(t *testing.T) {
 }
 
 func TestBuffer(t *testing.T) {
+	t.Parallel()
+
 	buf := &Buffer{}
 	buf.WriteString("foo\n")
 	buf.WriteString("bar\n")


### PR DESCRIPTION
Enable the paralleltest linter.
This linter checks that all tests and subtests call t.Parallel.

Fix all fixable issues reported by the linter.
For cases where a test cannot be run in parallel,
add a `//nolint:paralleltest` comment with an appropriate explanation.
For example:

    //nolint:paralleltest // modifies global state

Best reviewed by ignoring all whitespace changes.

<details>
<summary>Full list fixed issues</summary>

```
array_test.go:55:1: Function TestArrayWrappers missing the call to method parallel (paralleltest)
buffer/buffer_test.go:32:1: Function TestBufferWrites missing the call to method parallel (paralleltest)
buffer/buffer_test.go:55:2: Range statement for test TestBufferWrites missing the call to method parallel in test Run (paralleltest)
buffer/pool_test.go:30:1: Function TestBuffers missing the call to method parallel (paralleltest)
clock_test.go:39:1: Function TestWithClock missing the call to method parallel (paralleltest)
config_test.go:34:1: Function TestConfig missing the call to method parallel (paralleltest)
config_test.go:59:2: Range statement for test TestConfig missing the call to method parallel in test Run (paralleltest)
config_test.go:88:1: Function TestConfigWithInvalidPaths missing the call to method parallel (paralleltest)
config_test.go:99:2: Range statement for test TestConfigWithInvalidPaths missing the call to method parallel in test Run (paralleltest)
config_test.go:110:1: Function TestConfigWithMissingAttributes missing the call to method parallel (paralleltest)
config_test.go:137:2: Range statement for test TestConfigWithMissingAttributes missing the call to method parallel in test Run (paralleltest)
config_test.go:161:1: Function TestConfigWithSamplingHook missing the call to method parallel (paralleltest)
encoder_test.go:31:1: Function TestRegisterDefaultEncoders missing the call to method parallel (paralleltest)
encoder_test.go:35:1: Function TestRegisterEncoder missing the call to method parallel (paralleltest)
encoder_test.go:42:1: Function TestDuplicateRegisterEncoder missing the call to method parallel (paralleltest)
encoder_test.go:49:1: Function TestRegisterEncoderNoName missing the call to method parallel (paralleltest)
encoder_test.go:53:1: Function TestNewEncoder missing the call to method parallel (paralleltest)
encoder_test.go:62:1: Function TestNewEncoderNotRegistered missing the call to method parallel (paralleltest)
encoder_test.go:67:1: Function TestNewEncoderNoName missing the call to method parallel (paralleltest)
error_test.go:34:1: Function TestErrorConstructors missing the call to method parallel (paralleltest)
error_test.go:58:1: Function TestErrorArrayConstructor missing the call to method parallel (paralleltest)
error_test.go:81:1: Function TestErrorsArraysHandleRichErrors missing the call to method parallel (paralleltest)
field_test.go:63:1: Function TestFieldConstructors missing the call to method parallel (paralleltest)
field_test.go:258:2: Range statement for test TestFieldConstructors missing the call to method parallel in test Run (paralleltest)
field_test.go:268:1: Function TestStackField missing the call to method parallel (paralleltest)
field_test.go:277:1: Function TestStackSkipField missing the call to method parallel (paralleltest)
field_test.go:286:1: Function TestStackSkipFieldWithSkip missing the call to method parallel (paralleltest)
field_test.go:294:1: Function TestDict missing the call to method parallel (paralleltest)
field_test.go:305:2: Range statement for test TestDict missing the call to method parallel in test Run (paralleltest)
flag_test.go:68:1: Function TestLevelFlag missing the call to method parallel (paralleltest)
flag_test.go:90:1: Function TestLevelFlagsAreIndependent missing the call to method parallel (paralleltest)
global_test.go:40:1: Function TestReplaceGlobals missing the call to method parallel (paralleltest)
global_test.go:69:1: Function TestGlobalsConcurrentUse missing the call to method parallel (paralleltest)
global_test.go:100:1: Function TestNewStdLog missing the call to method parallel (paralleltest)
global_test.go:108:1: Function TestNewStdLogAt missing the call to method parallel (paralleltest)
global_test.go:121:1: Function TestNewStdLogAtPanics missing the call to method parallel (paralleltest)
global_test.go:134:1: Function TestNewStdLogAtFatal missing the call to method parallel (paralleltest)
global_test.go:147:1: Function TestNewStdLogAtInvalid missing the call to method parallel (paralleltest)
global_test.go:152:1: Function TestRedirectStdLog missing the call to method parallel (paralleltest)
global_test.go:170:1: Function TestRedirectStdLogCaller missing the call to method parallel (paralleltest)
global_test.go:180:1: Function TestRedirectStdLogAt missing the call to method parallel (paralleltest)
global_test.go:204:1: Function TestRedirectStdLogAtCaller missing the call to method parallel (paralleltest)
global_test.go:220:1: Function TestRedirectStdLogAtPanics missing the call to method parallel (paralleltest)
global_test.go:240:1: Function TestRedirectStdLogAtFatal missing the call to method parallel (paralleltest)
global_test.go:260:1: Function TestRedirectStdLogAtInvalid missing the call to method parallel (paralleltest)
http_handler_test.go:38:1: Function TestAtomicLevelServeHTTP missing the call to method parallel (paralleltest)
http_handler_test.go:155:2: Range statement for test TestAtomicLevelServeHTTP missing the call to method parallel in test Run (paralleltest)
increase_level_test.go:42:1: Function TestIncreaseLevelTryDecrease missing the call to method parallel (paralleltest)
increase_level_test.go:68:1: Function TestIncreaseLevel missing the call to method parallel (paralleltest)
internal/color/color_test.go:29:1: Function TestColorFormatting missing the call to method parallel (paralleltest)
internal/exit/exit_test.go:30:1: Function TestStub missing the call to method parallel (paralleltest)
internal/pool/pool_test.go:36:1: Function TestNew missing the call to method parallel (paralleltest)
internal/pool/pool_test.go:78:1: Function TestNew_Race missing the call to method parallel (paralleltest)
internal/stacktrace/stack_test.go:32:1: Function TestTake missing the call to method parallel (paralleltest)
internal/stacktrace/stack_test.go:44:1: Function TestTakeWithSkip missing the call to method parallel (paralleltest)
internal/stacktrace/stack_test.go:56:1: Function TestTakeWithSkipInnerFunc missing the call to method parallel (paralleltest)
internal/stacktrace/stack_test.go:71:1: Function TestTakeDeepStack missing the call to method parallel (paralleltest)
internal/ztest/clock_test.go:31:1: Function TestMockClock_NewTicker missing the call to method parallel (paralleltest)
internal/ztest/clock_test.go:59:1: Function TestMockClock_NewTicker_slowConsumer missing the call to method parallel (paralleltest)
internal/ztest/clock_test.go:77:1: Function TestMockClock_Add_negative missing the call to method parallel (paralleltest)
level_test.go:33:1: Function TestLevelEnablerFunc missing the call to method parallel (paralleltest)
level_test.go:52:1: Function TestNewAtomicLevel missing the call to method parallel (paralleltest)
level_test.go:61:1: Function TestParseAtomicLevel missing the call to method parallel (paralleltest)
level_test.go:83:1: Function TestAtomicLevelMutation missing the call to method parallel (paralleltest)
level_test.go:101:1: Function TestAtomicLevelText missing the call to method parallel (paralleltest)
logger_test.go:49:1: Function TestLoggerAtomicLevel missing the call to method parallel (paralleltest)
logger_test.go:88:1: Function TestLoggerLevel missing the call to method parallel (paralleltest)
logger_test.go:115:1: Function TestLoggerInitialFields missing the call to method parallel (paralleltest)
logger_test.go:128:1: Function TestLoggerWith missing the call to method parallel (paralleltest)
logger_test.go:155:2: Range statement for test TestLoggerWith missing the call to method parallel in test Run (paralleltest)
logger_test.go:178:1: Function TestLoggerWithCaptures missing the call to method parallel (paralleltest)
logger_test.go:339:2: Range statement for test TestLoggerWithCaptures missing the call to method parallel in test Run (paralleltest)
logger_test.go:375:1: Function TestLoggerLogPanic missing the call to method parallel (paralleltest)
logger_test.go:405:1: Function TestLoggerLogFatal missing the call to method parallel (paralleltest)
logger_test.go:432:1: Function TestLoggerLeveledMethods missing the call to method parallel (paralleltest)
logger_test.go:458:1: Function TestLoggerLogLevels missing the call to method parallel (paralleltest)
logger_test.go:481:1: Function TestLoggerAlwaysPanics missing the call to method parallel (paralleltest)
logger_test.go:497:1: Function TestLoggerAlwaysFatals missing the call to method parallel (paralleltest)
logger_test.go:518:1: Function TestLoggerDPanic missing the call to method parallel (paralleltest)
logger_test.go:539:1: Function TestLoggerNoOpsDisabledLevels missing the call to method parallel (paralleltest)
logger_test.go:551:1: Function TestLoggerNames missing the call to method parallel (paralleltest)
logger_test.go:590:1: Function TestLoggerWriteFailure missing the call to method parallel (paralleltest)
logger_test.go:607:1: Function TestLoggerSync missing the call to method parallel (paralleltest)
logger_test.go:614:1: Function TestLoggerSyncFail missing the call to method parallel (paralleltest)
logger_test.go:627:1: Function TestLoggerAddCaller missing the call to method parallel (paralleltest)
logger_test.go:659:1: Function TestLoggerAddCallerFunction missing the call to method parallel (paralleltest)
logger_test.go:739:1: Function TestLoggerAddCallerFail missing the call to method parallel (paralleltest)
logger_test.go:762:1: Function TestLoggerReplaceCore missing the call to method parallel (paralleltest)
logger_test.go:774:1: Function TestLoggerIncreaseLevel missing the call to method parallel (paralleltest)
logger_test.go:789:1: Function TestLoggerHooks missing the call to method parallel (paralleltest)
logger_test.go:798:1: Function TestLoggerConcurrent missing the call to method parallel (paralleltest)
logger_test.go:828:1: Function TestLoggerFatalOnNoop missing the call to method parallel (paralleltest)
logger_test.go:839:1: Function TestLoggerCustomOnFatal missing the call to method parallel (paralleltest)
logger_test.go:857:2: Range statement for test TestLoggerCustomOnFatal missing the call to method parallel in test Run (paralleltest)
logger_test.go:891:1: Function TestLoggerWithFatalHook missing the call to method parallel (paralleltest)
logger_test.go:900:1: Function TestNopLogger missing the call to method parallel (paralleltest)
logger_test.go:903:2: Function TestNopLogger missing the call to method parallel in the test run (paralleltest)
logger_test.go:910:2: Function TestNopLogger missing the call to method parallel in the test run (paralleltest)
logger_test.go:914:2: Function TestNopLogger missing the call to method parallel in the test run (paralleltest)
logger_test.go:921:1: Function TestMust missing the call to method parallel (paralleltest)
logger_test.go:922:2: Function TestMust missing the call to method parallel in the test run (paralleltest)
logger_test.go:926:2: Function TestMust missing the call to method parallel in the test run (paralleltest)
sink_test.go:47:1: Function TestRegisterSink missing the call to method parallel (paralleltest)
sink_test.go:86:1: Function TestRegisterSinkErrors missing the call to method parallel (paralleltest)
sink_test.go:100:2: Range statement for test TestRegisterSinkErrors missing the call to method parallel in test Run (paralleltest)
stacktrace_ext_test.go:49:1: Function TestStacktraceFiltersZapLog missing the call to method parallel (paralleltest)
stacktrace_ext_test.go:59:1: Function TestStacktraceFiltersZapMarshal missing the call to method parallel (paralleltest)
stacktrace_ext_test.go:86:1: Function TestStacktraceFiltersVendorZap missing the call to method parallel (paralleltest)
stacktrace_ext_test.go:122:1: Function TestStacktraceWithoutCallerSkip missing the call to method parallel (paralleltest)
stacktrace_ext_test.go:133:1: Function TestStacktraceWithCallerSkip missing the call to method parallel (paralleltest)
sugar_test.go:36:1: Function TestSugarWith missing the call to method parallel (paralleltest)
sugar_test.go:187:1: Function TestSugarFieldsInvalidPairs missing the call to method parallel (paralleltest)
sugar_test.go:207:1: Function TestSugarStructuredLogging missing the call to method parallel (paralleltest)
sugar_test.go:244:1: Function TestSugarConcatenatingLogging missing the call to method parallel (paralleltest)
sugar_test.go:276:1: Function TestSugarTemplatedLogging missing the call to method parallel (paralleltest)
sugar_test.go:312:1: Function TestSugarLnLogging missing the call to method parallel (paralleltest)
sugar_test.go:348:1: Function TestSugarLnLoggingIgnored missing the call to method parallel (paralleltest)
sugar_test.go:355:1: Function TestSugarPanicLogging missing the call to method parallel (paralleltest)
sugar_test.go:390:1: Function TestSugarFatalLogging missing the call to method parallel (paralleltest)
sugar_test.go:426:1: Function TestSugarAddCaller missing the call to method parallel (paralleltest)
sugar_test.go:451:1: Function TestSugarAddCallerFail missing the call to method parallel (paralleltest)
sugar_test.go:469:1: Function TestSugarWithOptionsIncreaseLevel missing the call to method parallel (paralleltest)
sugar_test.go:485:1: Function TestSugarLnWithOptionsIncreaseLevel missing the call to method parallel (paralleltest)
time_test.go:30:1: Function TestTimeToMillis missing the call to method parallel (paralleltest)
writer_test.go:38:1: Function TestOpenNoPaths missing the call to method parallel (paralleltest)
writer_test.go:51:1: Function TestOpen missing the call to method parallel (paralleltest)
writer_test.go:82:2: Range statement for test TestOpen missing the call to method parallel in test Run (paralleltest)
writer_test.go:96:1: Function TestOpenPathsNotFound missing the call to method parallel (paralleltest)
writer_test.go:124:2: Range statement for test TestOpenPathsNotFound missing the call to method parallel in test Run (paralleltest)
writer_test.go:142:1: Function TestOpenRelativePath missing the call to method parallel (paralleltest)
writer_test.go:162:1: Function TestOpenFails missing the call to method parallel (paralleltest)
writer_test.go:179:1: Function TestOpenOtherErrors missing the call to method parallel (paralleltest)
writer_test.go:214:2: Range statement for test TestOpenOtherErrors missing the call to method parallel in test Run (paralleltest)
writer_test.go:241:1: Function TestOpenWithErroringSinkFactory missing the call to method parallel (paralleltest)
writer_test.go:254:1: Function TestCombineWriteSyncers missing the call to method parallel (paralleltest)
zapcore/buffered_write_syncer_test.go:33:1: Function TestBufferWriter missing the call to method parallel (paralleltest)
zapcore/buffered_write_syncer_test.go:36:2: Function TestBufferWriter missing the call to method parallel in the test run (paralleltest)
zapcore/buffered_write_syncer_test.go:47:2: Function TestBufferWriter missing the call to method parallel in the test run (paralleltest)
zapcore/buffered_write_syncer_test.go:56:2: Function TestBufferWriter missing the call to method parallel in the test run (paralleltest)
zapcore/buffered_write_syncer_test.go:64:2: Function TestBufferWriter missing the call to method parallel in the test run (paralleltest)
zapcore/buffered_write_syncer_test.go:77:2: Function TestBufferWriter missing the call to method parallel in the test run (paralleltest)
zapcore/buffered_write_syncer_test.go:88:2: Function TestBufferWriter missing the call to method parallel in the test run (paralleltest)
zapcore/buffered_write_syncer_test.go:99:2: Function TestBufferWriter missing the call to method parallel in the test run (paralleltest)
zapcore/buffered_write_syncer_test.go:109:2: Function TestBufferWriter missing the call to method parallel in the test run (paralleltest)
zapcore/buffered_write_syncer_test.go:130:1: Function TestBufferWriterWithoutStart missing the call to method parallel (paralleltest)
zapcore/buffered_write_syncer_test.go:131:2: Function TestBufferWriterWithoutStart missing the call to method parallel in the test run (paralleltest)
zapcore/buffered_write_syncer_test.go:136:2: Function TestBufferWriterWithoutStart missing the call to method parallel in the test run (paralleltest)
zapcore/clock_test.go:33:1: Function TestSystemClock_NewTicker missing the call to method parallel (paralleltest)
zapcore/console_encoder_test.go:38:1: Function TestConsoleSeparator missing the call to method parallel (paralleltest)
zapcore/console_encoder_test.go:66:2: Range statement for test TestConsoleSeparator missing the call to method parallel in test Run (paralleltest)
zapcore/core_test.go:40:1: Function TestNopCore missing the call to method parallel (paralleltest)
zapcore/core_test.go:69:1: Function TestIOCore missing the call to method parallel (paralleltest)
zapcore/core_test.go:110:1: Function TestIOCoreSyncFail missing the call to method parallel (paralleltest)
zapcore/core_test.go:129:1: Function TestIOCoreSyncsOutput missing the call to method parallel (paralleltest)
zapcore/core_test.go:156:1: Function TestIOCoreWriteFailure missing the call to method parallel (paralleltest)
zapcore/encoder_test.go:77:1: Function TestEncoderConfiguration missing the call to method parallel (paralleltest)
zapcore/encoder_test.go:563:1: Function TestLevelEncoders missing the call to method parallel (paralleltest)
zapcore/encoder_test.go:586:1: Function TestTimeEncoders missing the call to method parallel (paralleltest)
zapcore/encoder_test.go:618:1: Function TestTimeEncodersWrongYAML missing the call to method parallel (paralleltest)
zapcore/encoder_test.go:629:1: Function TestTimeEncodersParseFromJSON missing the call to method parallel (paralleltest)
zapcore/encoder_test.go:652:1: Function TestDurationEncoders missing the call to method parallel (paralleltest)
zapcore/encoder_test.go:677:1: Function TestCallerEncoders missing the call to method parallel (paralleltest)
zapcore/encoder_test.go:701:1: Function TestNameEncoders missing the call to method parallel (paralleltest)
zapcore/entry_test.go:48:1: Function TestPutNilEntry missing the call to method parallel (paralleltest)
zapcore/entry_test.go:76:1: Function TestEntryCaller missing the call to method parallel (paralleltest)
zapcore/entry_test.go:106:1: Function TestCheckedEntryWrite missing the call to method parallel (paralleltest)
zapcore/entry_test.go:107:2: Function TestCheckedEntryWrite missing the call to method parallel in the test run (paralleltest)
zapcore/entry_test.go:112:2: Function TestCheckedEntryWrite missing the call to method parallel in the test run (paralleltest)
zapcore/entry_test.go:118:2: Function TestCheckedEntryWrite missing the call to method parallel in the test run (paralleltest)
zapcore/entry_test.go:124:2: Function TestCheckedEntryWrite missing the call to method parallel in the test run (paralleltest)
zapcore/entry_test.go:134:2: Function TestCheckedEntryWrite missing the call to method parallel in the test run (paralleltest)
zapcore/error_test.go:67:1: Function TestErrorEncoding missing the call to method parallel (paralleltest)
zapcore/error_test.go:155:1: Function TestRichErrorSupport missing the call to method parallel (paralleltest)
zapcore/field_test.go:96:1: Function TestUnknownFieldType missing the call to method parallel (paralleltest)
zapcore/field_test.go:104:1: Function TestFieldAddingError missing the call to method parallel (paralleltest)
zapcore/field_test.go:130:1: Function TestFields missing the call to method parallel (paralleltest)
zapcore/field_test.go:183:1: Function TestInlineMarshaler missing the call to method parallel (paralleltest)
zapcore/field_test.go:204:1: Function TestEquals missing the call to method parallel (paralleltest)
zapcore/hook_test.go:33:1: Function TestHooks missing the call to method parallel (paralleltest)
zapcore/hook_test.go:44:2: Range statement for test TestHooks missing the call to method parallel in test Run (paralleltest)
zapcore/increase_level_test.go:34:1: Function TestIncreaseLevel missing the call to method parallel (paralleltest)
zapcore/increase_level_test.go:80:2: Range statement for test TestIncreaseLevel missing the call to method parallel in test Run (paralleltest)
zapcore/json_encoder_impl_test.go:47:1: Function TestJSONClone missing the call to method parallel (paralleltest)
zapcore/json_encoder_impl_test.go:60:1: Function TestJSONEscaping missing the call to method parallel (paralleltest)
zapcore/json_encoder_impl_test.go:95:2: Function TestJSONEscaping missing the call to method parallel in the test run (paralleltest)
zapcore/json_encoder_impl_test.go:103:2: Function TestJSONEscaping missing the call to method parallel in the test run (paralleltest)
zapcore/json_encoder_impl_test.go:112:1: Function TestJSONEncoderObjectFields missing the call to method parallel (paralleltest)
zapcore/json_encoder_impl_test.go:284:2: Range statement for test TestJSONEncoderObjectFields missing the call to method parallel in test Run (paralleltest)
zapcore/json_encoder_impl_test.go:291:1: Function TestJSONEncoderTimeFormats missing the call to method parallel (paralleltest)
zapcore/json_encoder_impl_test.go:333:2: Range statement for test TestJSONEncoderTimeFormats missing the call to method parallel in test Run (paralleltest)
zapcore/json_encoder_impl_test.go:340:1: Function TestJSONEncoderArrays missing the call to method parallel (paralleltest)
zapcore/json_encoder_impl_test.go:442:2: Range statement for test TestJSONEncoderArrays missing the call to method parallel in test Run (paralleltest)
zapcore/json_encoder_impl_test.go:459:1: Function TestJSONEncoderTimeArrays missing the call to method parallel (paralleltest)
zapcore/json_encoder_impl_test.go:493:2: Range statement for test TestJSONEncoderTimeArrays missing the call to method parallel in test Run (paralleltest)
zapcore/json_encoder_impl_test.go:655:1: Function TestJSONQuick missing the call to method parallel (paralleltest)
zapcore/json_encoder_test.go:39:1: Function TestJSONEncodeEntry missing the call to method parallel (paralleltest)
zapcore/json_encoder_test.go:128:2: Range statement for test TestJSONEncodeEntry missing the call to method parallel in test Run (paralleltest)
zapcore/json_encoder_test.go:139:1: Function TestNoEncodeLevelSupplied missing the call to method parallel (paralleltest)
zapcore/json_encoder_test.go:168:1: Function TestJSONEmptyConfig missing the call to method parallel (paralleltest)
zapcore/json_encoder_test.go:186:2: Range statement for test TestJSONEmptyConfig missing the call to method parallel in test Run (paralleltest)
zapcore/json_encoder_test.go:215:1: Function TestJSONCustomReflectedEncoder missing the call to method parallel (paralleltest)
zapcore/lazy_with_test.go:60:1: Function TestLazyCore missing the call to method parallel (paralleltest)
zapcore/lazy_with_test.go:122:2: Range statement for test TestLazyCore missing the call to method parallel in test Run (paralleltest)
zapcore/level_strings_test.go:29:1: Function TestAllLevelsCoveredByLevelString missing the call to method parallel (paralleltest)
zapcore/level_test.go:32:1: Function TestLevelString missing the call to method parallel (paralleltest)
zapcore/level_test.go:51:1: Function TestLevelText missing the call to method parallel (paralleltest)
zapcore/level_test.go:80:1: Function TestParseLevel missing the call to method parallel (paralleltest)
zapcore/level_test.go:101:1: Function TestCapitalLevelsParse missing the call to method parallel (paralleltest)
zapcore/level_test.go:122:1: Function TestWeirdLevelsParse missing the call to method parallel (paralleltest)
zapcore/level_test.go:153:1: Function TestLevelNils missing the call to method parallel (paralleltest)
zapcore/level_test.go:169:1: Function TestLevelUnmarshalUnknownText missing the call to method parallel (paralleltest)
zapcore/level_test.go:175:1: Function TestLevelAsFlagValue missing the call to method parallel (paralleltest)
zapcore/level_test.go:215:1: Function TestLevelOf missing the call to method parallel (paralleltest)
zapcore/memory_encoder_test.go:31:1: Function TestMapObjectEncoderAdd missing the call to method parallel (paralleltest)
zapcore/memory_encoder_test.go:250:2: Range statement for test TestMapObjectEncoderAdd missing the call to method parallel in test Run (paralleltest)
zapcore/memory_encoder_test.go:259:1: Function TestSliceArrayEncoderAppend missing the call to method parallel (paralleltest)
zapcore/memory_encoder_test.go:345:2: Range statement for test TestSliceArrayEncoderAppend missing the call to method parallel in test Run (paralleltest)
zapcore/memory_encoder_test.go:361:1: Function TestMapObjectEncoderReflectionFailures missing the call to method parallel (paralleltest)
zapcore/sampler_test.go:69:1: Function TestSampler missing the call to method parallel (paralleltest)
zapcore/sampler_test.go:91:1: Function TestLevelOfSampler missing the call to method parallel (paralleltest)
zapcore/sampler_test.go:104:1: Function TestSamplerDisabledLevels missing the call to method parallel (paralleltest)
zapcore/sampler_test.go:113:1: Function TestSamplerTicking missing the call to method parallel (paralleltest)
zapcore/sampler_test.go:169:1: Function TestSamplerConcurrent missing the call to method parallel (paralleltest)
zapcore/sampler_test.go:250:1: Function TestSamplerRaces missing the call to method parallel (paralleltest)
zapcore/sampler_test.go:271:1: Function TestSamplerUnknownLevels missing the call to method parallel (paralleltest)
zapcore/sampler_test.go:278:2: Range statement for test TestSamplerUnknownLevels missing the call to method parallel in test Run (paralleltest)
zapcore/sampler_test.go:291:1: Function TestSamplerWithZeroThereafter missing the call to method parallel (paralleltest)
zapcore/tee_test.go:41:1: Function TestTeeUnusualInput missing the call to method parallel (paralleltest)
zapcore/tee_test.go:43:2: Function TestTeeUnusualInput missing the call to method parallel in the test run (paralleltest)
zapcore/tee_test.go:47:2: Function TestTeeUnusualInput missing the call to method parallel in the test run (paralleltest)
zapcore/tee_test.go:52:1: Function TestLevelOfTee missing the call to method parallel (paralleltest)
zapcore/tee_test.go:90:1: Function TestTeeCheck missing the call to method parallel (paralleltest)
zapcore/tee_test.go:116:1: Function TestTeeWrite missing the call to method parallel (paralleltest)
zapcore/tee_test.go:135:1: Function TestTeeWith missing the call to method parallel (paralleltest)
zapcore/tee_test.go:152:1: Function TestTeeEnabled missing the call to method parallel (paralleltest)
zapcore/tee_test.go:174:1: Function TestTeeSync missing the call to method parallel (paralleltest)
zapcore/write_syncer_test.go:45:1: Function TestAddSyncWriteSyncer missing the call to method parallel (paralleltest)
zapcore/write_syncer_test.go:58:1: Function TestAddSyncWriter missing the call to method parallel (paralleltest)
zapcore/write_syncer_test.go:67:1: Function TestNewMultiWriteSyncerWorksForSingleWriter missing the call to method parallel (paralleltest)
zapcore/write_syncer_test.go:77:1: Function TestMultiWriteSyncerWritesBoth missing the call to method parallel (paralleltest)
zapcore/write_syncer_test.go:91:1: Function TestMultiWriteSyncerFailsWrite missing the call to method parallel (paralleltest)
zapcore/write_syncer_test.go:97:1: Function TestMultiWriteSyncerFailsShortWrite missing the call to method parallel (paralleltest)
zapcore/write_syncer_test.go:104:1: Function TestWritestoAllSyncs_EvenIfFirstErrors missing the call to method parallel (paralleltest)
zapcore/write_syncer_test.go:114:1: Function TestMultiWriteSyncerSync_PropagatesErrors missing the call to method parallel (paralleltest)
zapcore/write_syncer_test.go:122:1: Function TestMultiWriteSyncerSync_NoErrorsOnDiscard missing the call to method parallel (paralleltest)
zapcore/write_syncer_test.go:127:1: Function TestMultiWriteSyncerSync_AllCalled missing the call to method parallel (paralleltest)
zapgrpc/zapgrpc_test.go:34:1: Function TestLoggerInfoExpected missing the call to method parallel (paralleltest)
zapgrpc/zapgrpc_test.go:68:1: Function TestLoggerDebugExpected missing the call to method parallel (paralleltest)
zapgrpc/zapgrpc_test.go:88:1: Function TestLoggerDebugSuppressed missing the call to method parallel (paralleltest)
zapgrpc/zapgrpc_test.go:98:1: Function TestLoggerWarningExpected missing the call to method parallel (paralleltest)
zapgrpc/zapgrpc_test.go:118:1: Function TestLoggerErrorExpected missing the call to method parallel (paralleltest)
zapgrpc/zapgrpc_test.go:138:1: Function TestLoggerFatalExpected missing the call to method parallel (paralleltest)
zapgrpc/zapgrpc_test.go:158:1: Function TestLoggerV missing the call to method parallel (paralleltest)
zapgrpc/zapgrpc_test.go:200:2: Range statement for test TestLoggerV missing the call to method parallel in test Run (paralleltest)
zapio/writer_test.go:173:2: Function TestWrite_Sync missing the call to method parallel in the test run (paralleltest)
zapio/writer_test.go:177:2: Function TestWrite_Sync missing the call to method parallel in the test run (paralleltest)
zapio/writer_test.go:187:2: Function TestWrite_Sync missing the call to method parallel in the test run (paralleltest)
zaptest/logger_test.go:37:1: Function TestTestLogger missing the call to method parallel (paralleltest)
zaptest/logger_test.go:61:1: Function TestTestLoggerSupportsLevels missing the call to method parallel (paralleltest)
zaptest/logger_test.go:83:1: Function TestTestLoggerSupportsWrappedZapOptions missing the call to method parallel (paralleltest)
zaptest/logger_test.go:107:1: Function TestTestingWriter missing the call to method parallel (paralleltest)
zaptest/logger_test.go:116:1: Function TestTestLoggerErrorOutput missing the call to method parallel (paralleltest)
zaptest/observer/logged_entry_test.go:32:1: Function TestLoggedEntryContextMap missing the call to method parallel (paralleltest)
zaptest/observer/logged_entry_test.go:80:2: Range statement for test TestLoggedEntryContextMap missing the call to method parallel in test Run (paralleltest)
zaptest/observer/observer_test.go:40:1: Function TestObserver missing the call to method parallel (paralleltest)
zaptest/observer/observer_test.go:74:1: Function TestObserverWith missing the call to method parallel (paralleltest)
zaptest/observer/observer_test.go:126:1: Function TestFilters missing the call to method parallel (paralleltest)
zaptest/timeout_test.go:31:1: Function TestTimeout missing the call to method parallel (paralleltest)
zaptest/timeout_test.go:36:1: Function TestSleep missing the call to method parallel (paralleltest)
zaptest/writer_test.go:30:1: Function TestSyncer missing the call to method parallel (paralleltest)
zaptest/writer_test.go:38:1: Function TestDiscarder missing the call to method parallel (paralleltest)
zaptest/writer_test.go:46:1: Function TestFailWriter missing the call to method parallel (paralleltest)
zaptest/writer_test.go:54:1: Function TestShortWriter missing the call to method parallel (paralleltest)
zaptest/writer_test.go:62:1: Function TestBuffer missing the call to method parallel (paralleltest)
exp/zapfield/zapfield_test.go:38:1: Function TestFieldConstructors missing the call to method parallel (paralleltest)
exp/zapslog/handler_test.go:53:1: Function TestAddStack missing the call to method parallel (paralleltest)
exp/zapslog/handler_test.go:73:1: Function TestAddStackSkip missing the call to method parallel (paralleltest)
exp/zapslog/handler_test.go:93:2: Function TestEmptyAttr missing the call to method parallel in the test run (paralleltest)
exp/zapslog/handler_test.go:107:2: Function TestEmptyAttr missing the call to method parallel in the test run (paralleltest)
exp/zapslog/handler_test.go:117:2: Function TestEmptyAttr missing the call to method parallel in the test run (paralleltest)
exp/zapslog/handler_test.go:133:2: Function TestWithName missing the call to method parallel in the test run (paralleltest)
exp/zapslog/handler_test.go:142:2: Function TestWithName missing the call to method parallel in the test run (paralleltest)
exp/zapslog/handler_test.go:159:1: Function TestAttrKinds missing the call to method parallel (paralleltest)
zapgrpc/internal/test/grpc_test.go:35:1: Function TestLoggerV2 missing the call to method parallel (paralleltest)
```

</details>
