### PR TITLE
Revert "lint: Enable paralleltest, fix issues (#1367)"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,8 +18,7 @@ linters:
 
     # Our own extras:
     - gofumpt
-    - nolintlint   # lints nolint directives
-    - paralleltest # requires t.Parallel on all tests
+    - nolintlint # lints nolint directives
     - revive
 
 linters-settings:

--- a/array_test.go
+++ b/array_test.go
@@ -53,8 +53,6 @@ func BenchmarkBoolsReflect(b *testing.B) {
 }
 
 func TestArrayWrappers(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc     string
 		field    Field
@@ -103,16 +101,11 @@ func TestArrayWrappers(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
-			enc := zapcore.NewMapObjectEncoder()
-			tt.field.Key = "k"
-			tt.field.AddTo(enc)
-			assert.Equal(t, tt.expected, enc.Fields["k"], "unexpected map contents")
-			assert.Equal(t, 1, len(enc.Fields), "found extra keys in map: %v", enc.Fields)
-		})
+		enc := zapcore.NewMapObjectEncoder()
+		tt.field.Key = "k"
+		tt.field.AddTo(enc)
+		assert.Equal(t, tt.expected, enc.Fields["k"], "%s: unexpected map contents.", tt.desc)
+		assert.Equal(t, 1, len(enc.Fields), "%s: found extra keys in map: %v", tt.desc, enc.Fields)
 	}
 }
 

--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -30,86 +30,32 @@ import (
 )
 
 func TestBufferWrites(t *testing.T) {
-	t.Parallel()
+	buf := NewPool().Get()
 
 	tests := []struct {
 		desc string
-		f    func(*Buffer)
+		f    func()
 		want string
 	}{
-		{
-			desc: "AppendByte",
-			f:    func(buf *Buffer) { buf.AppendByte('v') },
-			want: "v",
-		},
-		{
-			desc: "AppendString",
-			f:    func(buf *Buffer) { buf.AppendString("foo") },
-			want: "foo",
-		},
-		{
-			desc: "AppendIntPositive",
-			f:    func(buf *Buffer) { buf.AppendInt(42) },
-			want: "42",
-		},
-		{
-			desc: "AppendIntNegative",
-			f:    func(buf *Buffer) { buf.AppendInt(-42) },
-			want: "-42",
-		},
-		{
-			desc: "AppendUint",
-			f:    func(buf *Buffer) { buf.AppendUint(42) },
-			want: "42",
-		},
-		{
-			desc: "AppendBool",
-			f:    func(buf *Buffer) { buf.AppendBool(true) },
-			want: "true",
-		},
-		{
-			desc: "AppendFloat64",
-			f:    func(buf *Buffer) { buf.AppendFloat(3.14, 64) },
-			want: "3.14",
-		},
+		{"AppendByte", func() { buf.AppendByte('v') }, "v"},
+		{"AppendString", func() { buf.AppendString("foo") }, "foo"},
+		{"AppendIntPositive", func() { buf.AppendInt(42) }, "42"},
+		{"AppendIntNegative", func() { buf.AppendInt(-42) }, "-42"},
+		{"AppendUint", func() { buf.AppendUint(42) }, "42"},
+		{"AppendBool", func() { buf.AppendBool(true) }, "true"},
+		{"AppendFloat64", func() { buf.AppendFloat(3.14, 64) }, "3.14"},
 		// Intentionally introduce some floating-point error.
-		{
-			desc: "AppendFloat32",
-			f:    func(buf *Buffer) { buf.AppendFloat(float64(float32(3.14)), 32) },
-			want: "3.14",
-		},
-		{
-			desc: "AppendWrite",
-			f:    func(buf *Buffer) { buf.Write([]byte("foo")) },
-			want: "foo",
-		},
-		{
-			desc: "AppendTime",
-			f:    func(buf *Buffer) { buf.AppendTime(time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC), time.RFC3339) },
-			want: "2000-01-02T03:04:05Z",
-		},
-		{
-			desc: "WriteByte",
-			f:    func(buf *Buffer) { buf.WriteByte('v') },
-			want: "v",
-		},
-		{
-			desc: "WriteString",
-			f:    func(buf *Buffer) { buf.WriteString("foo") },
-			want: "foo",
-		},
+		{"AppendFloat32", func() { buf.AppendFloat(float64(float32(3.14)), 32) }, "3.14"},
+		{"AppendWrite", func() { buf.Write([]byte("foo")) }, "foo"},
+		{"AppendTime", func() { buf.AppendTime(time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC), time.RFC3339) }, "2000-01-02T03:04:05Z"},
+		{"WriteByte", func() { buf.WriteByte('v') }, "v"},
+		{"WriteString", func() { buf.WriteString("foo") }, "foo"},
 	}
 
-	pool := NewPool()
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
-			buf := pool.Get()
-			defer buf.Free()
-
-			tt.f(buf)
+			buf.Reset()
+			tt.f()
 			assert.Equal(t, tt.want, buf.String(), "Unexpected buffer.String().")
 			assert.Equal(t, tt.want, string(buf.Bytes()), "Unexpected string(buffer.Bytes()).")
 			assert.Equal(t, len(tt.want), buf.Len(), "Unexpected buffer length.")

--- a/buffer/pool_test.go
+++ b/buffer/pool_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestBuffers(t *testing.T) {
-	t.Parallel()
-
 	const dummyData = "dummy data"
 	p := NewPool()
 

--- a/clock_test.go
+++ b/clock_test.go
@@ -37,8 +37,6 @@ func (c constantClock) NewTicker(d time.Duration) *time.Ticker {
 }
 
 func TestWithClock(t *testing.T) {
-	t.Parallel()
-
 	date := time.Date(2077, 1, 23, 10, 15, 13, 441, time.UTC)
 	clock := constantClock(date)
 	withLogger(t, DebugLevel, []Option{WithClock(clock)}, func(log *Logger, logs *observer.ObservedLogs) {

--- a/config_test.go
+++ b/config_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc     string
 		cfg      Config
@@ -59,10 +57,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			logOut := filepath.Join(t.TempDir(), "test.log")
 
 			tt.cfg.OutputPaths = []string{logOut}
@@ -91,8 +86,6 @@ func TestConfig(t *testing.T) {
 }
 
 func TestConfigWithInvalidPaths(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc      string
 		output    string
@@ -104,10 +97,7 @@ func TestConfigWithInvalidPaths(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			cfg := NewProductionConfig()
 			cfg.OutputPaths = []string{tt.output}
 			cfg.ErrorOutputPaths = []string{tt.errOutput}
@@ -118,8 +108,6 @@ func TestConfigWithInvalidPaths(t *testing.T) {
 }
 
 func TestConfigWithMissingAttributes(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc      string
 		cfg       Config
@@ -147,10 +135,7 @@ func TestConfigWithMissingAttributes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			cfg := tt.cfg
 			_, err := cfg.Build()
 			assert.EqualError(t, err, tt.expectErr)
@@ -174,8 +159,6 @@ func makeSamplerCountingHook() (h func(zapcore.Entry, zapcore.SamplingDecision),
 }
 
 func TestConfigWithSamplingHook(t *testing.T) {
-	t.Parallel()
-
 	shook, dcount, scount := makeSamplerCountingHook()
 	cfg := Config{
 		Level:       NewAtomicLevelAt(InfoLevel),

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -29,12 +29,9 @@ import (
 )
 
 func TestRegisterDefaultEncoders(t *testing.T) {
-	t.Parallel()
-
 	testEncodersRegistered(t, "console", "json")
 }
 
-//nolint:paralleltest // modifies global registry
 func TestRegisterEncoder(t *testing.T) {
 	testEncoders(func() {
 		assert.NoError(t, RegisterEncoder("foo", newNilEncoder), "expected to be able to register the encoder foo")
@@ -42,7 +39,6 @@ func TestRegisterEncoder(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest // modifies global registry
 func TestDuplicateRegisterEncoder(t *testing.T) {
 	testEncoders(func() {
 		assert.NoError(t, RegisterEncoder("foo", newNilEncoder), "expected to be able to register the encoder foo")
@@ -51,12 +47,9 @@ func TestDuplicateRegisterEncoder(t *testing.T) {
 }
 
 func TestRegisterEncoderNoName(t *testing.T) {
-	t.Parallel()
-
 	assert.Equal(t, errNoEncoderNameSpecified, RegisterEncoder("", newNilEncoder), "expected an error when registering an encoder with no name")
 }
 
-//nolint:paralleltest // modifies global registry
 func TestNewEncoder(t *testing.T) {
 	testEncoders(func() {
 		assert.NoError(t, RegisterEncoder("foo", newNilEncoder), "expected to be able to register the encoder foo")
@@ -67,15 +60,11 @@ func TestNewEncoder(t *testing.T) {
 }
 
 func TestNewEncoderNotRegistered(t *testing.T) {
-	t.Parallel()
-
 	_, err := newEncoder("foo", zapcore.EncoderConfig{})
 	assert.Error(t, err, "expected an error when trying to create an encoder of an unregistered name")
 }
 
 func TestNewEncoderNoName(t *testing.T) {
-	t.Parallel()
-
 	_, err := newEncoder("", zapcore.EncoderConfig{})
 	assert.Equal(t, errNoEncoderNameSpecified, err, "expected an error when creating an encoder with no name")
 }

--- a/error_test.go
+++ b/error_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 func TestErrorConstructors(t *testing.T) {
-	t.Parallel()
-
 	fail := errors.New("fail")
 
 	tests := []struct {
@@ -50,21 +48,14 @@ func TestErrorConstructors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			if !assert.Equal(t, tt.expect, tt.field, "Unexpected output from convenience field constructor %s.", tt.name) {
-				t.Logf("type expected: %T\nGot: %T", tt.expect.Interface, tt.field.Interface)
-			}
-			assertCanBeReused(t, tt.field)
-		})
+		if !assert.Equal(t, tt.expect, tt.field, "Unexpected output from convenience field constructor %s.", tt.name) {
+			t.Logf("type expected: %T\nGot: %T", tt.expect.Interface, tt.field.Interface)
+		}
+		assertCanBeReused(t, tt.field)
 	}
 }
 
 func TestErrorArrayConstructor(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc     string
 		field    Field
@@ -79,22 +70,15 @@ func TestErrorArrayConstructor(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
-			enc := zapcore.NewMapObjectEncoder()
-			tt.field.Key = "k"
-			tt.field.AddTo(enc)
-			assert.Equal(t, tt.expected, enc.Fields["k"], "%s: unexpected map contents.", tt.desc)
-			assert.Equal(t, 1, len(enc.Fields), "%s: found extra keys in map: %v", tt.desc, enc.Fields)
-		})
+		enc := zapcore.NewMapObjectEncoder()
+		tt.field.Key = "k"
+		tt.field.AddTo(enc)
+		assert.Equal(t, tt.expected, enc.Fields["k"], "%s: unexpected map contents.", tt.desc)
+		assert.Equal(t, 1, len(enc.Fields), "%s: found extra keys in map: %v", tt.desc, enc.Fields)
 	}
 }
 
 func TestErrorsArraysHandleRichErrors(t *testing.T) {
-	t.Parallel()
-
 	errs := []error{fmt.Errorf("egad")}
 
 	enc := zapcore.NewMapObjectEncoder()

--- a/exp/zapfield/zapfield_test.go
+++ b/exp/zapfield/zapfield_test.go
@@ -36,8 +36,6 @@ type (
 )
 
 func TestFieldConstructors(t *testing.T) {
-	t.Parallel()
-
 	var (
 		key    = MyKey("test key")
 		value  = MyValue("test value")
@@ -57,15 +55,10 @@ func TestFieldConstructors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			if !assert.Equal(t, tt.expect, tt.field, "Unexpected output from convenience field constructor %s.", tt.name) {
-				t.Logf("type expected: %T\nGot: %T", tt.expect.Interface, tt.field.Interface)
-			}
-			assertCanBeReused(t, tt.field)
-		})
+		if !assert.Equal(t, tt.expect, tt.field, "Unexpected output from convenience field constructor %s.", tt.name) {
+			t.Logf("type expected: %T\nGot: %T", tt.expect.Interface, tt.field.Interface)
+		}
+		assertCanBeReused(t, tt.field)
 	}
 }
 

--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -51,8 +51,6 @@ func TestAddCaller(t *testing.T) {
 }
 
 func TestAddStack(t *testing.T) {
-	t.Parallel()
-
 	fac, logs := observer.New(zapcore.DebugLevel)
 	sl := slog.New(NewHandler(fac, AddStacktraceAt(slog.LevelDebug)))
 	sl.Info("msg")
@@ -73,8 +71,6 @@ func TestAddStack(t *testing.T) {
 }
 
 func TestAddStackSkip(t *testing.T) {
-	t.Parallel()
-
 	fac, logs := observer.New(zapcore.DebugLevel)
 	sl := slog.New(NewHandler(fac, AddStacktraceAt(slog.LevelDebug), WithCallerSkip(1)))
 	sl.Info("msg")
@@ -91,12 +87,10 @@ func TestAddStackSkip(t *testing.T) {
 func TestEmptyAttr(t *testing.T) {
 	t.Parallel()
 
+	fac, observedLogs := observer.New(zapcore.DebugLevel)
+	sl := slog.New(NewHandler(fac))
+
 	t.Run("Handle", func(t *testing.T) {
-		t.Parallel()
-
-		fac, observedLogs := observer.New(zapcore.DebugLevel)
-		sl := slog.New(NewHandler(fac))
-
 		sl.Info(
 			"msg",
 			slog.String("foo", "bar"),
@@ -111,11 +105,6 @@ func TestEmptyAttr(t *testing.T) {
 	})
 
 	t.Run("WithAttrs", func(t *testing.T) {
-		t.Parallel()
-
-		fac, observedLogs := observer.New(zapcore.DebugLevel)
-		sl := slog.New(NewHandler(fac))
-
 		sl.With(slog.String("foo", "bar"), slog.Attr{}).Info("msg")
 
 		logs := observedLogs.TakeAll()
@@ -126,11 +115,6 @@ func TestEmptyAttr(t *testing.T) {
 	})
 
 	t.Run("Group", func(t *testing.T) {
-		t.Parallel()
-
-		fac, observedLogs := observer.New(zapcore.DebugLevel)
-		sl := slog.New(NewHandler(fac))
-
 		sl.With("k", slog.GroupValue(slog.String("foo", "bar"), slog.Attr{})).Info("msg")
 
 		logs := observedLogs.TakeAll()
@@ -145,11 +129,8 @@ func TestEmptyAttr(t *testing.T) {
 
 func TestWithName(t *testing.T) {
 	t.Parallel()
-
+	fac, observedLogs := observer.New(zapcore.DebugLevel)
 	t.Run("default", func(t *testing.T) {
-		t.Parallel()
-
-		fac, observedLogs := observer.New(zapcore.DebugLevel)
 		sl := slog.New(NewHandler(fac))
 		sl.Info("msg")
 
@@ -158,11 +139,7 @@ func TestWithName(t *testing.T) {
 		entry := logs[0]
 		assert.Equal(t, "", entry.LoggerName, "Unexpected logger name")
 	})
-
 	t.Run("with name", func(t *testing.T) {
-		t.Parallel()
-
-		fac, observedLogs := observer.New(zapcore.DebugLevel)
 		sl := slog.New(NewHandler(fac, WithName("test-name")))
 		sl.Info("msg")
 
@@ -180,8 +157,6 @@ func (Token) LogValue() slog.Value {
 }
 
 func TestAttrKinds(t *testing.T) {
-	t.Parallel()
-
 	fac, logs := observer.New(zapcore.DebugLevel)
 	sl := slog.New(NewHandler(fac))
 	testToken := Token("no")

--- a/field_test.go
+++ b/field_test.go
@@ -61,8 +61,6 @@ func assertCanBeReused(t testing.TB, field Field) {
 }
 
 func TestFieldConstructors(t *testing.T) {
-	t.Parallel()
-
 	// Interface types.
 	addr := net.ParseIP("1.2.3.4")
 	name := username("phil")
@@ -258,10 +256,7 @@ func TestFieldConstructors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			if !assert.Equal(t, tt.expect, tt.field, "Unexpected output from convenience field constructor") {
 				t.Logf("type expected: %T\nGot: %T", tt.expect.Interface, tt.field.Interface)
 			}
@@ -271,8 +266,6 @@ func TestFieldConstructors(t *testing.T) {
 }
 
 func TestStackField(t *testing.T) {
-	t.Parallel()
-
 	f := Stack("stacktrace")
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
@@ -282,8 +275,6 @@ func TestStackField(t *testing.T) {
 }
 
 func TestStackSkipField(t *testing.T) {
-	t.Parallel()
-
 	f := StackSkip("stacktrace", 0)
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
@@ -293,8 +284,6 @@ func TestStackSkipField(t *testing.T) {
 }
 
 func TestStackSkipFieldWithSkip(t *testing.T) {
-	t.Parallel()
-
 	f := StackSkip("stacktrace", 1)
 	assert.Equal(t, "stacktrace", f.Key, "Unexpected field key.")
 	assert.Equal(t, zapcore.StringType, f.Type, "Unexpected field type.")
@@ -303,8 +292,6 @@ func TestStackSkipFieldWithSkip(t *testing.T) {
 }
 
 func TestDict(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc     string
 		field    Field
@@ -316,10 +303,7 @@ func TestDict(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			enc := zapcore.NewMapObjectEncoder()
 			tt.field.Key = "k"
 			tt.field.AddTo(enc)

--- a/flag_test.go
+++ b/flag_test.go
@@ -65,7 +65,6 @@ func (tc flagTestCase) run(t testing.TB, set *flag.FlagSet, actual *zapcore.Leve
 	}
 }
 
-//nolint:paralleltest // modifies global flag set
 func TestLevelFlag(t *testing.T) {
 	tests := []flagTestCase{
 		{
@@ -88,7 +87,6 @@ func TestLevelFlag(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // modifies global flag set
 func TestLevelFlagsAreIndependent(t *testing.T) {
 	origCommandLine := flag.CommandLine
 	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)

--- a/global_test.go
+++ b/global_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:paralleltest // modifies global logger
 func TestReplaceGlobals(t *testing.T) {
 	initialL := *L()
 	initialS := *S()
@@ -67,7 +66,6 @@ func TestReplaceGlobals(t *testing.T) {
 	assert.Equal(t, initialS, *S(), "Expected func returned from ReplaceGlobals to restore initial S.")
 }
 
-//nolint:paralleltest // modifies global logger
 func TestGlobalsConcurrentUse(t *testing.T) {
 	var (
 		stop atomic.Bool
@@ -100,8 +98,6 @@ func TestGlobalsConcurrentUse(t *testing.T) {
 }
 
 func TestNewStdLog(t *testing.T) {
-	t.Parallel()
-
 	withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
 		std := NewStdLog(l)
 		std.Print("redirected")
@@ -110,8 +106,6 @@ func TestNewStdLog(t *testing.T) {
 }
 
 func TestNewStdLogAt(t *testing.T) {
-	t.Parallel()
-
 	// include DPanicLevel here, but do not include Development in options
 	levels := []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
 	for _, level := range levels {
@@ -125,8 +119,6 @@ func TestNewStdLogAt(t *testing.T) {
 }
 
 func TestNewStdLogAtPanics(t *testing.T) {
-	t.Parallel()
-
 	// include DPanicLevel here and enable Development in options
 	levels := []zapcore.Level{DPanicLevel, PanicLevel}
 	for _, level := range levels {
@@ -140,8 +132,6 @@ func TestNewStdLogAtPanics(t *testing.T) {
 }
 
 func TestNewStdLogAtFatal(t *testing.T) {
-	t.Parallel()
-
 	withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
 		stub := exit.WithStub(func() {
 			std, err := NewStdLogAt(l, FatalLevel)
@@ -155,13 +145,10 @@ func TestNewStdLogAtFatal(t *testing.T) {
 }
 
 func TestNewStdLogAtInvalid(t *testing.T) {
-	t.Parallel()
-
 	_, err := NewStdLogAt(NewNop(), zapcore.Level(99))
 	assert.ErrorContains(t, err, "99", "Expected level code in error message")
 }
 
-//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLog(t *testing.T) {
 	initialFlags := log.Flags()
 	initialPrefix := log.Prefix()
@@ -180,7 +167,6 @@ func TestRedirectStdLog(t *testing.T) {
 	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
 }
 
-//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogCaller(t *testing.T) {
 	withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
 		defer RedirectStdLog(l)()
@@ -191,7 +177,6 @@ func TestRedirectStdLogCaller(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogAt(t *testing.T) {
 	initialFlags := log.Flags()
 	initialPrefix := log.Prefix()
@@ -216,7 +201,6 @@ func TestRedirectStdLogAt(t *testing.T) {
 	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
 }
 
-//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogAtCaller(t *testing.T) {
 	// include DPanicLevel here, but do not include Development in options
 	levels := []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
@@ -233,7 +217,6 @@ func TestRedirectStdLogAtCaller(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogAtPanics(t *testing.T) {
 	initialFlags := log.Flags()
 	initialPrefix := log.Prefix()
@@ -254,7 +237,6 @@ func TestRedirectStdLogAtPanics(t *testing.T) {
 	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
 }
 
-//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogAtFatal(t *testing.T) {
 	initialFlags := log.Flags()
 	initialPrefix := log.Prefix()
@@ -275,7 +257,6 @@ func TestRedirectStdLogAtFatal(t *testing.T) {
 	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
 }
 
-//nolint:paralleltest // modifies global std logger
 func TestRedirectStdLogAtInvalid(t *testing.T) {
 	restore, err := RedirectStdLogAt(NewNop(), zapcore.Level(99))
 	defer func() {

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -36,8 +36,6 @@ import (
 )
 
 func TestAtomicLevelServeHTTP(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc          string
 		method        string
@@ -155,10 +153,7 @@ func TestAtomicLevelServeHTTP(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			lvl := zap.NewAtomicLevel()
 			lvl.SetLevel(zapcore.InfoLevel)
 

--- a/increase_level_test.go
+++ b/increase_level_test.go
@@ -40,8 +40,6 @@ func newLoggedEntry(level zapcore.Level, msg string, fields ...zapcore.Field) ob
 }
 
 func TestIncreaseLevelTryDecrease(t *testing.T) {
-	t.Parallel()
-
 	errorOut := &bytes.Buffer{}
 	opts := []Option{
 		ErrorOutput(zapcore.AddSync(errorOut)),
@@ -68,8 +66,6 @@ func TestIncreaseLevelTryDecrease(t *testing.T) {
 }
 
 func TestIncreaseLevel(t *testing.T) {
-	t.Parallel()
-
 	errorOut := &bytes.Buffer{}
 	opts := []Option{
 		ErrorOutput(zapcore.AddSync(errorOut)),

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestColorFormatting(t *testing.T) {
-	t.Parallel()
-
 	assert.Equal(
 		t,
 		"\x1b[31mfoo\x1b[0m",

--- a/internal/exit/exit_test.go
+++ b/internal/exit/exit_test.go
@@ -27,7 +27,6 @@ import (
 	"go.uber.org/zap/internal/exit"
 )
 
-//nolint:paralleltest // stubs global exit
 func TestStub(t *testing.T) {
 	type want struct {
 		exit bool

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -33,7 +33,6 @@ type pooledValue[T any] struct {
 	value T
 }
 
-//nolint:paralleltest // disables GC temporarily
 func TestNew(t *testing.T) {
 	// Disable GC to avoid the victim cache during the test.
 	defer debug.SetGCPercent(debug.SetGCPercent(-1))
@@ -77,8 +76,6 @@ func TestNew(t *testing.T) {
 }
 
 func TestNew_Race(t *testing.T) {
-	t.Parallel()
-
 	p := pool.New(func() *pooledValue[int] {
 		return &pooledValue[int]{
 			value: -1,

--- a/internal/stacktrace/stack_test.go
+++ b/internal/stacktrace/stack_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func TestTake(t *testing.T) {
-	t.Parallel()
-
 	trace := Take(0)
 	lines := strings.Split(trace, "\n")
 	require.NotEmpty(t, lines, "Expected stacktrace to have at least one frame.")
@@ -44,8 +42,6 @@ func TestTake(t *testing.T) {
 }
 
 func TestTakeWithSkip(t *testing.T) {
-	t.Parallel()
-
 	trace := Take(1)
 	lines := strings.Split(trace, "\n")
 	require.NotEmpty(t, lines, "Expected stacktrace to have at least one frame.")
@@ -58,8 +54,6 @@ func TestTakeWithSkip(t *testing.T) {
 }
 
 func TestTakeWithSkipInnerFunc(t *testing.T) {
-	t.Parallel()
-
 	var trace string
 	func() {
 		trace = Take(2)
@@ -75,8 +69,6 @@ func TestTakeWithSkipInnerFunc(t *testing.T) {
 }
 
 func TestTakeDeepStack(t *testing.T) {
-	t.Parallel()
-
 	const (
 		N                  = 500
 		withStackDepthName = "go.uber.org/zap/internal/stacktrace.withStackDepth"

--- a/internal/ztest/clock_test.go
+++ b/internal/ztest/clock_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestMockClock_NewTicker(t *testing.T) {
-	t.Parallel()
-
 	var n atomic.Int32
 	clock := NewMockClock()
 
@@ -59,8 +57,6 @@ func TestMockClock_NewTicker(t *testing.T) {
 }
 
 func TestMockClock_NewTicker_slowConsumer(t *testing.T) {
-	t.Parallel()
-
 	clock := NewMockClock()
 
 	ticker := clock.NewTicker(time.Microsecond)
@@ -79,8 +75,6 @@ func TestMockClock_NewTicker_slowConsumer(t *testing.T) {
 }
 
 func TestMockClock_Add_negative(t *testing.T) {
-	t.Parallel()
-
 	clock := NewMockClock()
 	assert.Panics(t, func() { clock.Add(-1) })
 }

--- a/level_test.go
+++ b/level_test.go
@@ -31,8 +31,6 @@ import (
 )
 
 func TestLevelEnablerFunc(t *testing.T) {
-	t.Parallel()
-
 	enab := LevelEnablerFunc(func(l zapcore.Level) bool { return l == zapcore.InfoLevel })
 	tests := []struct {
 		level   zapcore.Level
@@ -52,8 +50,6 @@ func TestLevelEnablerFunc(t *testing.T) {
 }
 
 func TestNewAtomicLevel(t *testing.T) {
-	t.Parallel()
-
 	lvl := NewAtomicLevel()
 	assert.Equal(t, InfoLevel, lvl.Level(), "Unexpected initial level.")
 	lvl.SetLevel(ErrorLevel)
@@ -63,8 +59,6 @@ func TestNewAtomicLevel(t *testing.T) {
 }
 
 func TestParseAtomicLevel(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		text  string
 		level AtomicLevel
@@ -76,24 +70,17 @@ func TestParseAtomicLevel(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.text, func(t *testing.T) {
-			t.Parallel()
-
-			parsedAtomicLevel, err := ParseAtomicLevel(tt.text)
-			if len(tt.err) == 0 {
-				require.NoError(t, err)
-				assert.Equal(t, tt.level, parsedAtomicLevel)
-			} else {
-				assert.ErrorContains(t, err, tt.err)
-			}
-		})
+		parsedAtomicLevel, err := ParseAtomicLevel(tt.text)
+		if len(tt.err) == 0 {
+			require.NoError(t, err)
+			assert.Equal(t, tt.level, parsedAtomicLevel)
+		} else {
+			assert.ErrorContains(t, err, tt.err)
+		}
 	}
 }
 
 func TestAtomicLevelMutation(t *testing.T) {
-	t.Parallel()
-
 	lvl := NewAtomicLevel()
 	lvl.SetLevel(WarnLevel)
 	// Trigger races for non-atomic level mutations.
@@ -112,8 +99,6 @@ func TestAtomicLevelMutation(t *testing.T) {
 }
 
 func TestAtomicLevelText(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		text   string
 		expect zapcore.Level
@@ -131,30 +116,25 @@ func TestAtomicLevelText(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.text, func(t *testing.T) {
-			t.Parallel()
-
-			var lvl AtomicLevel
-			// Test both initial unmarshaling and overwriting existing value.
-			for i := 0; i < 2; i++ {
-				if tt.err {
-					assert.Error(t, lvl.UnmarshalText([]byte(tt.text)), "Expected unmarshaling %q to fail.", tt.text)
-				} else {
-					assert.NoError(t, lvl.UnmarshalText([]byte(tt.text)), "Expected unmarshaling %q to succeed.", tt.text)
-				}
-				assert.Equal(t, tt.expect, lvl.Level(), "Unexpected level after unmarshaling.")
-				lvl.SetLevel(InfoLevel)
+		var lvl AtomicLevel
+		// Test both initial unmarshaling and overwriting existing value.
+		for i := 0; i < 2; i++ {
+			if tt.err {
+				assert.Error(t, lvl.UnmarshalText([]byte(tt.text)), "Expected unmarshaling %q to fail.", tt.text)
+			} else {
+				assert.NoError(t, lvl.UnmarshalText([]byte(tt.text)), "Expected unmarshaling %q to succeed.", tt.text)
 			}
+			assert.Equal(t, tt.expect, lvl.Level(), "Unexpected level after unmarshaling.")
+			lvl.SetLevel(InfoLevel)
+		}
 
-			// Test marshalling
-			if tt.text != "" && !tt.err {
-				lvl.SetLevel(tt.expect)
-				marshaled, err := lvl.MarshalText()
-				assert.NoError(t, err, `Unexpected error marshalling level "%v" to text.`, tt.expect)
-				assert.Equal(t, tt.text, string(marshaled), "Expected marshaled text to match")
-				assert.Equal(t, tt.text, lvl.String(), "Expected Stringer call to match")
-			}
-		})
+		// Test marshalling
+		if tt.text != "" && !tt.err {
+			lvl.SetLevel(tt.expect)
+			marshaled, err := lvl.MarshalText()
+			assert.NoError(t, err, `Unexpected error marshalling level "%v" to text.`, tt.expect)
+			assert.Equal(t, tt.text, string(marshaled), "Expected marshaled text to match")
+			assert.Equal(t, tt.text, lvl.String(), "Expected Stringer call to match")
+		}
 	}
 }

--- a/sink_test.go
+++ b/sink_test.go
@@ -44,7 +44,6 @@ func stubSinkRegistry(t testing.TB) *sinkRegistry {
 	return r
 }
 
-//nolint:paralleltest // stubs global registry
 func TestRegisterSink(t *testing.T) {
 	stubSinkRegistry(t)
 
@@ -85,8 +84,6 @@ func TestRegisterSink(t *testing.T) {
 }
 
 func TestRegisterSinkErrors(t *testing.T) {
-	t.Parallel()
-
 	nopFactory := func(_ *url.URL) (Sink, error) {
 		return nopCloserSink{zapcore.AddSync(io.Discard)}, nil
 	}
@@ -101,10 +98,7 @@ func TestRegisterSinkErrors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run("scheme-"+tt.scheme, func(t *testing.T) {
-			t.Parallel()
-
 			r := newSinkRegistry()
 			err := r.RegisterSink(tt.scheme, nopFactory)
 			assert.ErrorContains(t, err, tt.err)

--- a/stacktrace_ext_test.go
+++ b/stacktrace_ext_test.go
@@ -47,8 +47,6 @@ var _zapPackages = []string{
 }
 
 func TestStacktraceFiltersZapLog(t *testing.T) {
-	t.Parallel()
-
 	withLogger(t, func(logger *zap.Logger, out *bytes.Buffer) {
 		logger.Error("test log")
 		logger.Sugar().Error("sugar test log")
@@ -59,8 +57,6 @@ func TestStacktraceFiltersZapLog(t *testing.T) {
 }
 
 func TestStacktraceFiltersZapMarshal(t *testing.T) {
-	t.Parallel()
-
 	withLogger(t, func(logger *zap.Logger, out *bytes.Buffer) {
 		marshal := func(enc zapcore.ObjectEncoder) error {
 			logger.Warn("marshal caused warn")
@@ -87,7 +83,6 @@ func TestStacktraceFiltersZapMarshal(t *testing.T) {
 	})
 }
 
-//nolint:paralleltest // modifies process global state
 func TestStacktraceFiltersVendorZap(t *testing.T) {
 	// We already have the dependencies downloaded so this should be
 	// instant.
@@ -125,8 +120,6 @@ func TestStacktraceFiltersVendorZap(t *testing.T) {
 }
 
 func TestStacktraceWithoutCallerSkip(t *testing.T) {
-	t.Parallel()
-
 	withLogger(t, func(logger *zap.Logger, out *bytes.Buffer) {
 		func() {
 			logger.Error("test log")
@@ -138,8 +131,6 @@ func TestStacktraceWithoutCallerSkip(t *testing.T) {
 }
 
 func TestStacktraceWithCallerSkip(t *testing.T) {
-	t.Parallel()
-
 	withLogger(t, func(logger *zap.Logger, out *bytes.Buffer) {
 		logger = logger.WithOptions(zap.AddCallerSkip(2))
 		func() {

--- a/time_test.go
+++ b/time_test.go
@@ -21,7 +21,6 @@
 package zap
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
@@ -29,8 +28,6 @@ import (
 )
 
 func TestTimeToMillis(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		t     time.Time
 		stamp int64
@@ -39,13 +36,7 @@ func TestTimeToMillis(t *testing.T) {
 		{t: time.Unix(1, 0), stamp: 1000},
 		{t: time.Unix(1, int64(500*time.Millisecond)), stamp: 1500},
 	}
-
-	for i, tt := range tests {
-		i, tt := i, tt
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tt.stamp, timeToMillis(tt.t), "Unexpected timestamp for time %v.", tt.t)
-		})
+	for _, tt := range tests {
+		assert.Equal(t, tt.stamp, timeToMillis(tt.t), "Unexpected timestamp for time %v.", tt.t)
 	}
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -27,7 +27,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,8 +36,6 @@ import (
 )
 
 func TestOpenNoPaths(t *testing.T) {
-	t.Parallel()
-
 	ws, cleanup, err := Open()
 	defer cleanup()
 
@@ -52,8 +49,6 @@ func TestOpenNoPaths(t *testing.T) {
 }
 
 func TestOpen(t *testing.T) {
-	t.Parallel()
-
 	tempName := filepath.Join(t.TempDir(), "test.log")
 	assert.False(t, fileExists(tempName))
 	require.True(t, filepath.IsAbs(tempName), "Expected absolute temp file path.")
@@ -85,10 +80,7 @@ func TestOpen(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.msg, func(t *testing.T) {
-			t.Parallel()
-
 			_, cleanup, err := Open(tt.paths...)
 			if err == nil {
 				defer cleanup()
@@ -98,17 +90,10 @@ func TestOpen(t *testing.T) {
 		})
 	}
 
-	// t.Parallel for subtests will unblock t.Run right away.
-	// This assertion should run *after* all subtests have completed
-	// so it needs to be with a t.Cleanup.
-	t.Cleanup(func() {
-		assert.True(t, fileExists(tempName))
-	})
+	assert.True(t, fileExists(tempName))
 }
 
 func TestOpenPathsNotFound(t *testing.T) {
-	t.Parallel()
-
 	tempName := filepath.Join(t.TempDir(), "test.log")
 
 	tests := []struct {
@@ -137,10 +122,7 @@ func TestOpenPathsNotFound(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.msg, func(t *testing.T) {
-			t.Parallel()
-
 			_, cleanup, err := Open(tt.paths...)
 			if !assert.Error(t, err, "Open must fail.") {
 				cleanup()
@@ -158,8 +140,6 @@ func TestOpenPathsNotFound(t *testing.T) {
 }
 
 func TestOpenRelativePath(t *testing.T) {
-	t.Parallel()
-
 	const name = "test-relative-path.txt"
 
 	require.False(t, fileExists(name), "Test file already exists.")
@@ -180,8 +160,6 @@ func TestOpenRelativePath(t *testing.T) {
 }
 
 func TestOpenFails(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		paths []string
 	}{
@@ -191,21 +169,14 @@ func TestOpenFails(t *testing.T) {
 		{paths: []string{"mem://somewhere"}},                   // scheme not registered
 	}
 
-	for i, tt := range tests {
-		i, tt := i, tt
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			t.Parallel()
-
-			_, cleanup, err := Open(tt.paths...)
-			require.Nil(t, cleanup, "Cleanup function should never be nil")
-			assert.Error(t, err, "Open with invalid URL should fail.")
-		})
+	for _, tt := range tests {
+		_, cleanup, err := Open(tt.paths...)
+		require.Nil(t, cleanup, "Cleanup function should never be nil")
+		assert.Error(t, err, "Open with invalid URL should fail.")
 	}
 }
 
 func TestOpenOtherErrors(t *testing.T) {
-	t.Parallel()
-
 	tempName := filepath.Join(t.TempDir(), "test.log")
 
 	tests := []struct {
@@ -241,10 +212,7 @@ func TestOpenOtherErrors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.msg, func(t *testing.T) {
-			t.Parallel()
-
 			_, cleanup, err := Open(tt.paths...)
 			if !assert.Error(t, err, "Open must fail.") {
 				cleanup()
@@ -270,7 +238,6 @@ func (w *testWriter) Sync() error {
 	return nil
 }
 
-//nolint:paralleltest // stubs global registry
 func TestOpenWithErroringSinkFactory(t *testing.T) {
 	stubSinkRegistry(t)
 
@@ -285,8 +252,6 @@ func TestOpenWithErroringSinkFactory(t *testing.T) {
 }
 
 func TestCombineWriteSyncers(t *testing.T) {
-	t.Parallel()
-
 	tw := &testWriter{"test", t}
 	w := CombineWriteSyncers(tw)
 	_, err := w.Write([]byte("test"))

--- a/zapcore/buffered_write_syncer_test.go
+++ b/zapcore/buffered_write_syncer_test.go
@@ -31,13 +31,9 @@ import (
 )
 
 func TestBufferWriter(t *testing.T) {
-	t.Parallel()
-
 	// If we pass a plain io.Writer, make sure that we still get a WriteSyncer
 	// with a no-op Sync.
 	t.Run("sync", func(t *testing.T) {
-		t.Parallel()
-
 		buf := &bytes.Buffer{}
 		ws := &BufferedWriteSyncer{WS: AddSync(buf)}
 
@@ -49,8 +45,6 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("stop", func(t *testing.T) {
-		t.Parallel()
-
 		buf := &bytes.Buffer{}
 		ws := &BufferedWriteSyncer{WS: AddSync(buf)}
 		requireWriteWorks(t, ws)
@@ -60,8 +54,6 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("stop twice", func(t *testing.T) {
-		t.Parallel()
-
 		ws := &BufferedWriteSyncer{WS: &ztest.FailWriter{}}
 		_, err := ws.Write([]byte("foo"))
 		require.NoError(t, err, "Unexpected error writing to WriteSyncer.")
@@ -70,8 +62,6 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("wrap twice", func(t *testing.T) {
-		t.Parallel()
-
 		buf := &bytes.Buffer{}
 		bufsync := &BufferedWriteSyncer{WS: AddSync(buf)}
 		ws := &BufferedWriteSyncer{WS: bufsync}
@@ -85,8 +75,6 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("small buffer", func(t *testing.T) {
-		t.Parallel()
-
 		buf := &bytes.Buffer{}
 		ws := &BufferedWriteSyncer{WS: AddSync(buf), Size: 5}
 
@@ -98,8 +86,6 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("with lockedWriteSyncer", func(t *testing.T) {
-		t.Parallel()
-
 		buf := &bytes.Buffer{}
 		ws := &BufferedWriteSyncer{WS: Lock(AddSync(buf)), Size: 5}
 
@@ -111,8 +97,6 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("flush error", func(t *testing.T) {
-		t.Parallel()
-
 		ws := &BufferedWriteSyncer{WS: &ztest.FailWriter{}, Size: 4}
 		n, err := ws.Write([]byte("foo"))
 		require.NoError(t, err, "Unexpected error writing to WriteSyncer.")
@@ -123,8 +107,6 @@ func TestBufferWriter(t *testing.T) {
 	})
 
 	t.Run("flush timer", func(t *testing.T) {
-		t.Parallel()
-
 		buf := &bytes.Buffer{}
 		clock := ztest.NewMockClock()
 		ws := &BufferedWriteSyncer{
@@ -146,18 +128,12 @@ func TestBufferWriter(t *testing.T) {
 }
 
 func TestBufferWriterWithoutStart(t *testing.T) {
-	t.Parallel()
-
 	t.Run("stop", func(t *testing.T) {
-		t.Parallel()
-
 		ws := &BufferedWriteSyncer{WS: AddSync(new(bytes.Buffer))}
 		assert.NoError(t, ws.Stop(), "Stop must not fail")
 	})
 
 	t.Run("Sync", func(t *testing.T) {
-		t.Parallel()
-
 		ws := &BufferedWriteSyncer{WS: AddSync(new(bytes.Buffer))}
 		assert.NoError(t, ws.Sync(), "Sync must not fail")
 	})

--- a/zapcore/clock_test.go
+++ b/zapcore/clock_test.go
@@ -31,8 +31,6 @@ import (
 var _ Clock = (*ztest.MockClock)(nil)
 
 func TestSystemClock_NewTicker(t *testing.T) {
-	t.Parallel()
-
 	want := 3
 
 	var n int

--- a/zapcore/console_encoder_test.go
+++ b/zapcore/console_encoder_test.go
@@ -36,8 +36,6 @@ var testEntry = Entry{
 }
 
 func TestConsoleSeparator(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc        string
 		separator   string
@@ -66,11 +64,8 @@ func TestConsoleSeparator(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
+		console := NewConsoleEncoder(encoderTestEncoderConfig(tt.separator))
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
-			console := NewConsoleEncoder(encoderTestEncoderConfig(tt.separator))
 			entry := testEntry
 			consoleOut, err := console.EncodeEntry(entry, nil)
 			if !assert.NoError(t, err) {

--- a/zapcore/encoder_test.go
+++ b/zapcore/encoder_test.go
@@ -75,8 +75,6 @@ func capitalNameEncoder(loggerName string, enc PrimitiveArrayEncoder) {
 }
 
 func TestEncoderConfiguration(t *testing.T) {
-	t.Parallel()
-
 	base := testEncoderConfig()
 
 	tests := []struct {
@@ -531,45 +529,38 @@ func TestEncoderConfiguration(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		i, tt := i, tt
-		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
-			json := NewJSONEncoder(tt.cfg)
-			console := NewConsoleEncoder(tt.cfg)
-			if tt.extra != nil {
-				tt.extra(json)
-				tt.extra(console)
-			}
-			entry := _testEntry
-			if tt.amendEntry != nil {
-				entry = tt.amendEntry(_testEntry)
-			}
-			jsonOut, jsonErr := json.EncodeEntry(entry, nil)
-			if assert.NoError(t, jsonErr, "Unexpected error JSON-encoding entry in case #%d.", i) {
-				assert.Equal(
-					t,
-					tt.expectedJSON,
-					jsonOut.String(),
-					"Unexpected JSON output: expected to %v.", tt.desc,
-				)
-			}
-			consoleOut, consoleErr := console.EncodeEntry(entry, nil)
-			if assert.NoError(t, consoleErr, "Unexpected error console-encoding entry in case #%d.", i) {
-				assert.Equal(
-					t,
-					tt.expectedConsole,
-					consoleOut.String(),
-					"Unexpected console output: expected to %v.", tt.desc,
-				)
-			}
-		})
+		json := NewJSONEncoder(tt.cfg)
+		console := NewConsoleEncoder(tt.cfg)
+		if tt.extra != nil {
+			tt.extra(json)
+			tt.extra(console)
+		}
+		entry := _testEntry
+		if tt.amendEntry != nil {
+			entry = tt.amendEntry(_testEntry)
+		}
+		jsonOut, jsonErr := json.EncodeEntry(entry, nil)
+		if assert.NoError(t, jsonErr, "Unexpected error JSON-encoding entry in case #%d.", i) {
+			assert.Equal(
+				t,
+				tt.expectedJSON,
+				jsonOut.String(),
+				"Unexpected JSON output: expected to %v.", tt.desc,
+			)
+		}
+		consoleOut, consoleErr := console.EncodeEntry(entry, nil)
+		if assert.NoError(t, consoleErr, "Unexpected error console-encoding entry in case #%d.", i) {
+			assert.Equal(
+				t,
+				tt.expectedConsole,
+				consoleOut.String(),
+				"Unexpected console output: expected to %v.", tt.desc,
+			)
+		}
 	}
 }
 
 func TestLevelEncoders(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name     string
 		expected interface{} // output of encoding InfoLevel
@@ -581,114 +572,84 @@ func TestLevelEncoders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var le LevelEncoder
-			require.NoError(t, le.UnmarshalText([]byte(tt.name)), "Unexpected error unmarshaling %q.", tt.name)
-			assertAppended(
-				t,
-				tt.expected,
-				func(arr ArrayEncoder) { le(InfoLevel, arr) },
-				"Unexpected output serializing InfoLevel with %q.", tt.name,
-			)
-		})
+		var le LevelEncoder
+		require.NoError(t, le.UnmarshalText([]byte(tt.name)), "Unexpected error unmarshaling %q.", tt.name)
+		assertAppended(
+			t,
+			tt.expected,
+			func(arr ArrayEncoder) { le(InfoLevel, arr) },
+			"Unexpected output serializing InfoLevel with %q.", tt.name,
+		)
 	}
 }
 
 func TestTimeEncoders(t *testing.T) {
-	t.Parallel()
-
 	moment := time.Unix(100, 50005000).UTC()
 	tests := []struct {
-		name     string
 		yamlDoc  string
 		expected interface{} // output of serializing moment
 	}{
-		{"iso8601", "timeEncoder: iso8601", "1970-01-01T00:01:40.050Z"},
-		{"ISO8601", "timeEncoder: ISO8601", "1970-01-01T00:01:40.050Z"},
-		{"millis", "timeEncoder: millis", 100050.005},
-		{"nanos", "timeEncoder: nanos", int64(100050005000)},
-		{"manual", "timeEncoder: {layout: 06/01/02 03:04pm}", "70/01/01 12:01am"},
-		{"empty", "timeEncoder: ''", 100.050005},
-		{"something-random", "timeEncoder: something-random", 100.050005},
-		{"rfc3339", "timeEncoder: rfc3339", "1970-01-01T00:01:40Z"},
-		{"RFC3339", "timeEncoder: RFC3339", "1970-01-01T00:01:40Z"},
-		{"rfc3339nano", "timeEncoder: rfc3339nano", "1970-01-01T00:01:40.050005Z"},
-		{"RFC3339Nano", "timeEncoder: RFC3339Nano", "1970-01-01T00:01:40.050005Z"},
+		{"timeEncoder: iso8601", "1970-01-01T00:01:40.050Z"},
+		{"timeEncoder: ISO8601", "1970-01-01T00:01:40.050Z"},
+		{"timeEncoder: millis", 100050.005},
+		{"timeEncoder: nanos", int64(100050005000)},
+		{"timeEncoder: {layout: 06/01/02 03:04pm}", "70/01/01 12:01am"},
+		{"timeEncoder: ''", 100.050005},
+		{"timeEncoder: something-random", 100.050005},
+		{"timeEncoder: rfc3339", "1970-01-01T00:01:40Z"},
+		{"timeEncoder: RFC3339", "1970-01-01T00:01:40Z"},
+		{"timeEncoder: rfc3339nano", "1970-01-01T00:01:40.050005Z"},
+		{"timeEncoder: RFC3339Nano", "1970-01-01T00:01:40.050005Z"},
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			cfg := EncoderConfig{}
-			require.NoError(t, yaml.Unmarshal([]byte(tt.yamlDoc), &cfg), "Unexpected error unmarshaling %q.", tt.yamlDoc)
-			require.NotNil(t, cfg.EncodeTime, "Unmashalled timeEncoder is nil for %q.", tt.yamlDoc)
-			assertAppended(
-				t,
-				tt.expected,
-				func(arr ArrayEncoder) { cfg.EncodeTime(moment, arr) },
-				"Unexpected output serializing %v with %q.", moment, tt.yamlDoc,
-			)
-		})
+		cfg := EncoderConfig{}
+		require.NoError(t, yaml.Unmarshal([]byte(tt.yamlDoc), &cfg), "Unexpected error unmarshaling %q.", tt.yamlDoc)
+		require.NotNil(t, cfg.EncodeTime, "Unmashalled timeEncoder is nil for %q.", tt.yamlDoc)
+		assertAppended(
+			t,
+			tt.expected,
+			func(arr ArrayEncoder) { cfg.EncodeTime(moment, arr) },
+			"Unexpected output serializing %v with %q.", moment, tt.yamlDoc,
+		)
 	}
 }
 
 func TestTimeEncodersWrongYAML(t *testing.T) {
-	t.Parallel()
-
 	tests := []string{
 		"timeEncoder: [1, 2, 3]", // wrong type
 		"timeEncoder: {foo:bar",  // broken yaml
 	}
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt, func(t *testing.T) {
-			t.Parallel()
-
-			cfg := EncoderConfig{}
-			assert.Error(t, yaml.Unmarshal([]byte(tt), &cfg), "Expected unmarshaling %q to become error, but not.", tt)
-		})
+		cfg := EncoderConfig{}
+		assert.Error(t, yaml.Unmarshal([]byte(tt), &cfg), "Expected unmarshaling %q to become error, but not.", tt)
 	}
 }
 
 func TestTimeEncodersParseFromJSON(t *testing.T) {
-	t.Parallel()
-
 	moment := time.Unix(100, 50005000).UTC()
 	tests := []struct {
-		desc     string
 		jsonDoc  string
 		expected interface{} // output of serializing moment
 	}{
-		{"iso8601", `{"timeEncoder": "iso8601"}`, "1970-01-01T00:01:40.050Z"},
-		{"manual", `{"timeEncoder": {"layout": "06/01/02 03:04pm"}}`, "70/01/01 12:01am"},
+		{`{"timeEncoder": "iso8601"}`, "1970-01-01T00:01:40.050Z"},
+		{`{"timeEncoder": {"layout": "06/01/02 03:04pm"}}`, "70/01/01 12:01am"},
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
-			cfg := EncoderConfig{}
-			require.NoError(t, json.Unmarshal([]byte(tt.jsonDoc), &cfg), "Unexpected error unmarshaling %q.", tt.jsonDoc)
-			require.NotNil(t, cfg.EncodeTime, "Unmashalled timeEncoder is nil for %q.", tt.jsonDoc)
-			assertAppended(
-				t,
-				tt.expected,
-				func(arr ArrayEncoder) { cfg.EncodeTime(moment, arr) },
-				"Unexpected output serializing %v with %q.", moment, tt.jsonDoc,
-			)
-		})
+		cfg := EncoderConfig{}
+		require.NoError(t, json.Unmarshal([]byte(tt.jsonDoc), &cfg), "Unexpected error unmarshaling %q.", tt.jsonDoc)
+		require.NotNil(t, cfg.EncodeTime, "Unmashalled timeEncoder is nil for %q.", tt.jsonDoc)
+		assertAppended(
+			t,
+			tt.expected,
+			func(arr ArrayEncoder) { cfg.EncodeTime(moment, arr) },
+			"Unexpected output serializing %v with %q.", moment, tt.jsonDoc,
+		)
 	}
 }
 
 func TestDurationEncoders(t *testing.T) {
-	t.Parallel()
-
 	elapsed := time.Second + 500*time.Nanosecond
 	tests := []struct {
 		name     string
@@ -702,25 +663,18 @@ func TestDurationEncoders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var de DurationEncoder
-			require.NoError(t, de.UnmarshalText([]byte(tt.name)), "Unexpected error unmarshaling %q.", tt.name)
-			assertAppended(
-				t,
-				tt.expected,
-				func(arr ArrayEncoder) { de(elapsed, arr) },
-				"Unexpected output serializing %v with %q.", elapsed, tt.name,
-			)
-		})
+		var de DurationEncoder
+		require.NoError(t, de.UnmarshalText([]byte(tt.name)), "Unexpected error unmarshaling %q.", tt.name)
+		assertAppended(
+			t,
+			tt.expected,
+			func(arr ArrayEncoder) { de(elapsed, arr) },
+			"Unexpected output serializing %v with %q.", elapsed, tt.name,
+		)
 	}
 }
 
 func TestCallerEncoders(t *testing.T) {
-	t.Parallel()
-
 	caller := EntryCaller{Defined: true, File: "/home/jack/src/github.com/foo/foo.go", Line: 42}
 	tests := []struct {
 		name     string
@@ -733,25 +687,18 @@ func TestCallerEncoders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var ce CallerEncoder
-			require.NoError(t, ce.UnmarshalText([]byte(tt.name)), "Unexpected error unmarshaling %q.", tt.name)
-			assertAppended(
-				t,
-				tt.expected,
-				func(arr ArrayEncoder) { ce(caller, arr) },
-				"Unexpected output serializing file name as %v with %q.", tt.expected, tt.name,
-			)
-		})
+		var ce CallerEncoder
+		require.NoError(t, ce.UnmarshalText([]byte(tt.name)), "Unexpected error unmarshaling %q.", tt.name)
+		assertAppended(
+			t,
+			tt.expected,
+			func(arr ArrayEncoder) { ce(caller, arr) },
+			"Unexpected output serializing file name as %v with %q.", tt.expected, tt.name,
+		)
 	}
 }
 
 func TestNameEncoders(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name     string
 		expected interface{} // output of encoding InfoLevel
@@ -762,19 +709,14 @@ func TestNameEncoders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			var ne NameEncoder
-			require.NoError(t, ne.UnmarshalText([]byte(tt.name)), "Unexpected error unmarshaling %q.", tt.name)
-			assertAppended(
-				t,
-				tt.expected,
-				func(arr ArrayEncoder) { ne("main", arr) },
-				"Unexpected output serializing logger name with %q.", tt.name,
-			)
-		})
+		var ne NameEncoder
+		require.NoError(t, ne.UnmarshalText([]byte(tt.name)), "Unexpected error unmarshaling %q.", tt.name)
+		assertAppended(
+			t,
+			tt.expected,
+			func(arr ArrayEncoder) { ne("main", arr) },
+			"Unexpected output serializing logger name with %q.", tt.name,
+		)
 	}
 }
 

--- a/zapcore/entry_test.go
+++ b/zapcore/entry_test.go
@@ -46,8 +46,6 @@ func assertGoexit(t *testing.T, f func()) {
 }
 
 func TestPutNilEntry(t *testing.T) {
-	t.Parallel()
-
 	// Pooling nil entries defeats the purpose.
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -76,28 +74,22 @@ func TestPutNilEntry(t *testing.T) {
 }
 
 func TestEntryCaller(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
-		name   string
 		caller EntryCaller
 		full   string
 		short  string
 	}{
 		{
-			name:   "unknown",
 			caller: NewEntryCaller(100, "/path/to/foo.go", 42, false),
 			full:   "undefined",
 			short:  "undefined",
 		},
 		{
-			name:   "absolute",
 			caller: NewEntryCaller(100, "/path/to/foo.go", 42, true),
 			full:   "/path/to/foo.go:42",
 			short:  "to/foo.go:42",
 		},
 		{
-			name:   "relative",
 			caller: NewEntryCaller(100, "to/foo.go", 42, true),
 			full:   "to/foo.go:42",
 			short:  "to/foo.go:42",
@@ -105,37 +97,25 @@ func TestEntryCaller(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tt.full, tt.caller.String(), "Unexpected string from EntryCaller.")
-			assert.Equal(t, tt.full, tt.caller.FullPath(), "Unexpected FullPath from EntryCaller.")
-			assert.Equal(t, tt.short, tt.caller.TrimmedPath(), "Unexpected TrimmedPath from EntryCaller.")
-		})
+		assert.Equal(t, tt.full, tt.caller.String(), "Unexpected string from EntryCaller.")
+		assert.Equal(t, tt.full, tt.caller.FullPath(), "Unexpected FullPath from EntryCaller.")
+		assert.Equal(t, tt.short, tt.caller.TrimmedPath(), "Unexpected TrimmedPath from EntryCaller.")
 	}
 }
 
-//nolint:paralleltest // stubs exit func
 func TestCheckedEntryWrite(t *testing.T) {
 	t.Run("nil is safe", func(t *testing.T) {
-		t.Parallel()
-
 		var ce *CheckedEntry
 		assert.NotPanics(t, func() { ce.Write() }, "Unexpected panic writing nil CheckedEntry.")
 	})
 
 	t.Run("WriteThenPanic", func(t *testing.T) {
-		t.Parallel()
-
 		var ce *CheckedEntry
 		ce = ce.After(Entry{}, WriteThenPanic)
 		assert.Panics(t, func() { ce.Write() }, "Expected to panic when WriteThenPanic is set.")
 	})
 
 	t.Run("WriteThenGoexit", func(t *testing.T) {
-		t.Parallel()
-
 		var ce *CheckedEntry
 		ce = ce.After(Entry{}, WriteThenGoexit)
 		assertGoexit(t, func() { ce.Write() })
@@ -152,8 +132,6 @@ func TestCheckedEntryWrite(t *testing.T) {
 	})
 
 	t.Run("After", func(t *testing.T) {
-		t.Parallel()
-
 		var ce *CheckedEntry
 		hook := &customHook{}
 		ce = ce.After(Entry{}, hook)

--- a/zapcore/error_test.go
+++ b/zapcore/error_test.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,8 +65,6 @@ func (e customMultierr) Errors() []error {
 }
 
 func TestErrorEncoding(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		k     string
 		t     FieldType // defaults to ErrorType
@@ -143,26 +140,19 @@ func TestErrorEncoding(t *testing.T) {
 		},
 	}
 
-	for i, tt := range tests {
-		i, tt := i, tt
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			t.Parallel()
+	for _, tt := range tests {
+		if tt.t == UnknownType {
+			tt.t = ErrorType
+		}
 
-			if tt.t == UnknownType {
-				tt.t = ErrorType
-			}
-
-			enc := NewMapObjectEncoder()
-			f := Field{Key: tt.k, Type: tt.t, Interface: tt.iface}
-			f.AddTo(enc)
-			assert.Equal(t, tt.want, enc.Fields, "Unexpected output from field %+v.", f)
-		})
+		enc := NewMapObjectEncoder()
+		f := Field{Key: tt.k, Type: tt.t, Interface: tt.iface}
+		f.AddTo(enc)
+		assert.Equal(t, tt.want, enc.Fields, "Unexpected output from field %+v.", f)
 	}
 }
 
 func TestRichErrorSupport(t *testing.T) {
-	t.Parallel()
-
 	f := Field{
 		Type:      ErrorType,
 		Interface: fmt.Errorf("failed: %w", errors.New("egad")),

--- a/zapcore/hook_test.go
+++ b/zapcore/hook_test.go
@@ -21,7 +21,6 @@
 package zapcore_test
 
 import (
-	"strconv"
 	"testing"
 
 	. "go.uber.org/zap/zapcore"
@@ -32,8 +31,6 @@ import (
 )
 
 func TestHooks(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		entryLevel Level
 		coreLevel  Level
@@ -44,47 +41,42 @@ func TestHooks(t *testing.T) {
 		{WarnLevel, InfoLevel, true},
 	}
 
-	for i, tt := range tests {
-		i, tt := i, tt
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			t.Parallel()
+	for _, tt := range tests {
+		fac, logs := observer.New(tt.coreLevel)
 
-			fac, logs := observer.New(tt.coreLevel)
+		// sanity check
+		require.Equal(t, tt.coreLevel, LevelOf(fac), "Original logger has the wrong level")
 
-			// sanity check
-			require.Equal(t, tt.coreLevel, LevelOf(fac), "Original logger has the wrong level")
+		intField := makeInt64Field("foo", 42)
+		ent := Entry{Message: "bar", Level: tt.entryLevel}
 
-			intField := makeInt64Field("foo", 42)
-			ent := Entry{Message: "bar", Level: tt.entryLevel}
+		var called int
+		f := func(e Entry) error {
+			called++
+			assert.Equal(t, ent, e, "Hook called with unexpected Entry.")
+			return nil
+		}
 
-			var called int
-			f := func(e Entry) error {
-				called++
-				assert.Equal(t, ent, e, "Hook called with unexpected Entry.")
-				return nil
-			}
+		h := RegisterHooks(fac, f)
+		if ce := h.With([]Field{intField}).Check(ent, nil); ce != nil {
+			ce.Write()
+		}
 
-			h := RegisterHooks(fac, f)
-			if ce := h.With([]Field{intField}).Check(ent, nil); ce != nil {
-				ce.Write()
-			}
-
-			t.Run("LevelOf", func(t *testing.T) {
-				assert.Equal(t, tt.coreLevel, LevelOf(h), "Wrapped logger has the wrong log level")
-			})
-
-			if tt.expectCall {
-				assert.Equal(t, 1, called, "Expected to call hook once.")
-				assert.Equal(
-					t,
-					[]observer.LoggedEntry{{Entry: ent, Context: []Field{intField}}},
-					logs.AllUntimed(),
-					"Unexpected logs written out.",
-				)
-			} else {
-				assert.Equal(t, 0, called, "Didn't expect to call hook.")
-				assert.Equal(t, 0, logs.Len(), "Unexpected logs written out.")
-			}
+		t.Run("LevelOf", func(t *testing.T) {
+			assert.Equal(t, tt.coreLevel, LevelOf(h), "Wrapped logger has the wrong log level")
 		})
+
+		if tt.expectCall {
+			assert.Equal(t, 1, called, "Expected to call hook once.")
+			assert.Equal(
+				t,
+				[]observer.LoggedEntry{{Entry: ent, Context: []Field{intField}}},
+				logs.AllUntimed(),
+				"Unexpected logs written out.",
+			)
+		} else {
+			assert.Equal(t, 0, called, "Didn't expect to call hook.")
+			assert.Equal(t, 0, logs.Len(), "Unexpected logs written out.")
+		}
 	}
 }

--- a/zapcore/increase_level_test.go
+++ b/zapcore/increase_level_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 func TestIncreaseLevel(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		coreLevel     Level
 		increaseLevel Level
@@ -80,11 +78,8 @@ func TestIncreaseLevel(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		msg := fmt.Sprintf("increase %v to %v", tt.coreLevel, tt.increaseLevel)
 		t.Run(msg, func(t *testing.T) {
-			t.Parallel()
-
 			logger, logs := observer.New(tt.coreLevel)
 
 			// sanity check

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -45,8 +45,6 @@ var _defaultEncoderConfig = EncoderConfig{
 }
 
 func TestJSONClone(t *testing.T) {
-	t.Parallel()
-
 	// The parent encoder is created with plenty of excess capacity.
 	parent := &jsonEncoder{buf: bufferpool.Get()}
 	clone := parent.Clone()
@@ -60,8 +58,6 @@ func TestJSONClone(t *testing.T) {
 }
 
 func TestJSONEscaping(t *testing.T) {
-	t.Parallel()
-
 	enc := &jsonEncoder{buf: bufferpool.Get()}
 	// Test all the edge cases of JSON escaping directly.
 	cases := map[string]string{
@@ -96,7 +92,6 @@ func TestJSONEscaping(t *testing.T) {
 		"foo\xed\xa0\x80": `foo\ufffd\ufffd\ufffd`,
 	}
 
-	//nolint:paralleltest // shared state
 	t.Run("String", func(t *testing.T) {
 		for input, output := range cases {
 			enc.truncate()
@@ -105,7 +100,6 @@ func TestJSONEscaping(t *testing.T) {
 		}
 	})
 
-	//nolint:paralleltest // shared state
 	t.Run("ByteString", func(t *testing.T) {
 		for input, output := range cases {
 			enc.truncate()
@@ -116,8 +110,6 @@ func TestJSONEscaping(t *testing.T) {
 }
 
 func TestJSONEncoderObjectFields(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc     string
 		expected string
@@ -290,18 +282,13 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			assertOutput(t, _defaultEncoderConfig, tt.expected, tt.f)
 		})
 	}
 }
 
 func TestJSONEncoderTimeFormats(t *testing.T) {
-	t.Parallel()
-
 	date := time.Date(2000, time.January, 2, 3, 4, 5, 6, time.UTC)
 
 	f := func(e Encoder) {
@@ -344,18 +331,13 @@ func TestJSONEncoderTimeFormats(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			assertOutput(t, tt.cfg, tt.expected, f)
 		})
 	}
 }
 
 func TestJSONEncoderArrays(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc     string
 		expected string // expect f to be called twice
@@ -458,10 +440,7 @@ func TestJSONEncoderArrays(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			f := func(enc Encoder) error {
 				return enc.AddArray("array", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
 					tt.f(arr)
@@ -478,8 +457,6 @@ func TestJSONEncoderArrays(t *testing.T) {
 }
 
 func TestJSONEncoderTimeArrays(t *testing.T) {
-	t.Parallel()
-
 	times := []time.Time{
 		time.Unix(1008720000, 0).UTC(), // 2001-12-19
 		time.Unix(1040169600, 0).UTC(), // 2002-12-18
@@ -514,10 +491,7 @@ func TestJSONEncoderTimeArrays(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			cfg := _defaultEncoderConfig
 			cfg.EncodeTime = tt.encoder
 
@@ -679,8 +653,6 @@ func asciiRoundTripsCorrectlyByteString(s ASCII) bool {
 }
 
 func TestJSONQuick(t *testing.T) {
-	t.Parallel()
-
 	check := func(f interface{}) {
 		err := quick.Check(f, &quick.Config{MaxCountScale: 100.0})
 		assert.NoError(t, err)

--- a/zapcore/json_encoder_test.go
+++ b/zapcore/json_encoder_test.go
@@ -37,8 +37,6 @@ import (
 // zapcore_test package, so that it can import the toplevel zap package for
 // field constructor convenience.
 func TestJSONEncodeEntry(t *testing.T) {
-	t.Parallel()
-
 	type bar struct {
 		Key string  `json:"key"`
 		Val float64 `json:"val"`
@@ -128,10 +126,7 @@ func TestJSONEncodeEntry(t *testing.T) {
 	})
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			buf, err := enc.EncodeEntry(tt.ent, tt.fields)
 			if assert.NoError(t, err, "Unexpected JSON encoding error.") {
 				assert.JSONEq(t, tt.expected, buf.String(), "Incorrect encoded JSON entry.")
@@ -142,8 +137,6 @@ func TestJSONEncodeEntry(t *testing.T) {
 }
 
 func TestNoEncodeLevelSupplied(t *testing.T) {
-	t.Parallel()
-
 	enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{
 		MessageKey:     "M",
 		LevelKey:       "L",
@@ -173,8 +166,6 @@ func TestNoEncodeLevelSupplied(t *testing.T) {
 }
 
 func TestJSONEmptyConfig(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name     string
 		field    zapcore.Field
@@ -193,10 +184,7 @@ func TestJSONEmptyConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{})
 
 			buf, err := enc.EncodeEntry(zapcore.Entry{
@@ -225,8 +213,6 @@ func (enc *emptyReflectedEncoder) Encode(obj interface{}) error {
 }
 
 func TestJSONCustomReflectedEncoder(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name     string
 		field    zapcore.Field

--- a/zapcore/lazy_with_test.go
+++ b/zapcore/lazy_with_test.go
@@ -58,8 +58,6 @@ func withLazyCore(f func(zapcore.Core, *proxyCore, *observer.ObservedLogs), init
 }
 
 func TestLazyCore(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name          string
 		entries       []zapcore.Entry
@@ -122,10 +120,7 @@ func TestLazyCore(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			withLazyCore(func(lazy zapcore.Core, proxy *proxyCore, logs *observer.ObservedLogs) {
 				checkCounts := func(withCount int64, msg string) {
 					assert.Equal(t, withCount, proxy.withCount.Load(), msg)

--- a/zapcore/level_strings_test.go
+++ b/zapcore/level_strings_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestAllLevelsCoveredByLevelString(t *testing.T) {
-	t.Parallel()
-
 	numLevels := int((_maxLevel - _minLevel) + 1)
 
 	isComplete := func(m map[Level]string) bool {

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func TestLevelString(t *testing.T) {
-	t.Parallel()
-
 	tests := map[Level]string{
 		DebugLevel:   "debug",
 		InfoLevel:    "info",
@@ -45,19 +43,12 @@ func TestLevelString(t *testing.T) {
 	}
 
 	for lvl, stringLevel := range tests {
-		lvl, stringLevel := lvl, stringLevel
-		t.Run(stringLevel, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, stringLevel, lvl.String(), "Unexpected lowercase level string.")
-			assert.Equal(t, strings.ToUpper(stringLevel), lvl.CapitalString(), "Unexpected all-caps level string.")
-		})
+		assert.Equal(t, stringLevel, lvl.String(), "Unexpected lowercase level string.")
+		assert.Equal(t, strings.ToUpper(stringLevel), lvl.CapitalString(), "Unexpected all-caps level string.")
 	}
 }
 
 func TestLevelText(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		text  string
 		level Level
@@ -72,28 +63,21 @@ func TestLevelText(t *testing.T) {
 		{"fatal", FatalLevel},
 	}
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.text, func(t *testing.T) {
-			t.Parallel()
+		if tt.text != "" {
+			lvl := tt.level
+			marshaled, err := lvl.MarshalText()
+			assert.NoError(t, err, "Unexpected error marshaling level %v to text.", &lvl)
+			assert.Equal(t, tt.text, string(marshaled), "Marshaling level %v to text yielded unexpected result.", &lvl)
+		}
 
-			if tt.text != "" {
-				lvl := tt.level
-				marshaled, err := lvl.MarshalText()
-				assert.NoError(t, err, "Unexpected error marshaling level %v to text.", &lvl)
-				assert.Equal(t, tt.text, string(marshaled), "Marshaling level %v to text yielded unexpected result.", &lvl)
-			}
-
-			var unmarshaled Level
-			err := unmarshaled.UnmarshalText([]byte(tt.text))
-			assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
-			assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
-		})
+		var unmarshaled Level
+		err := unmarshaled.UnmarshalText([]byte(tt.text))
+		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
+		assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
 	}
 }
 
 func TestParseLevel(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		text  string
 		level Level
@@ -104,24 +88,17 @@ func TestParseLevel(t *testing.T) {
 		{"FOO", 0, `unrecognized level: "FOO"`},
 	}
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.text, func(t *testing.T) {
-			t.Parallel()
-
-			parsedLevel, err := ParseLevel(tt.text)
-			if len(tt.err) == 0 {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.level, parsedLevel)
-			} else {
-				assert.ErrorContains(t, err, tt.err)
-			}
-		})
+		parsedLevel, err := ParseLevel(tt.text)
+		if len(tt.err) == 0 {
+			assert.NoError(t, err)
+			assert.Equal(t, tt.level, parsedLevel)
+		} else {
+			assert.ErrorContains(t, err, tt.err)
+		}
 	}
 }
 
 func TestCapitalLevelsParse(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		text  string
 		level Level
@@ -135,21 +112,14 @@ func TestCapitalLevelsParse(t *testing.T) {
 		{"FATAL", FatalLevel},
 	}
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.text, func(t *testing.T) {
-			t.Parallel()
-
-			var unmarshaled Level
-			err := unmarshaled.UnmarshalText([]byte(tt.text))
-			assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
-			assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
-		})
+		var unmarshaled Level
+		err := unmarshaled.UnmarshalText([]byte(tt.text))
+		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
+		assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
 	}
 }
 
 func TestWeirdLevelsParse(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		text  string
 		level Level
@@ -173,21 +143,14 @@ func TestWeirdLevelsParse(t *testing.T) {
 		{"FaTaL", FatalLevel},
 	}
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.text, func(t *testing.T) {
-			t.Parallel()
-
-			var unmarshaled Level
-			err := unmarshaled.UnmarshalText([]byte(tt.text))
-			assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
-			assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
-		})
+		var unmarshaled Level
+		err := unmarshaled.UnmarshalText([]byte(tt.text))
+		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
+		assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
 	}
 }
 
 func TestLevelNils(t *testing.T) {
-	t.Parallel()
-
 	var l *Level
 
 	// The String() method will not handle nil level properly.
@@ -204,16 +167,12 @@ func TestLevelNils(t *testing.T) {
 }
 
 func TestLevelUnmarshalUnknownText(t *testing.T) {
-	t.Parallel()
-
 	var l Level
 	err := l.UnmarshalText([]byte("foo"))
 	assert.ErrorContains(t, err, "unrecognized level", "Expected unmarshaling arbitrary text to fail.")
 }
 
 func TestLevelAsFlagValue(t *testing.T) {
-	t.Parallel()
-
 	var (
 		buf bytes.Buffer
 		lvl Level
@@ -254,8 +213,6 @@ func (l *enablerWithCustomLevel) Level() Level {
 }
 
 func TestLevelOf(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc string
 		give LevelEnabler

--- a/zapcore/memory_encoder_test.go
+++ b/zapcore/memory_encoder_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestMapObjectEncoderAdd(t *testing.T) {
-	t.Parallel()
-
 	// Expected output of a turducken.
 	wantTurducken := map[string]interface{}{
 		"ducks": []interface{}{
@@ -250,10 +248,7 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			enc := NewMapObjectEncoder()
 			tt.f(enc)
 			assert.Equal(t, tt.expected, enc.Fields["k"], "Unexpected encoder output.")
@@ -262,8 +257,6 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 }
 
 func TestSliceArrayEncoderAppend(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		desc     string
 		f        func(ArrayEncoder)
@@ -350,10 +343,7 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			t.Parallel()
-
 			enc := NewMapObjectEncoder()
 			assert.NoError(t, enc.AddArray("k", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
 				tt.f(arr)
@@ -369,8 +359,6 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 }
 
 func TestMapObjectEncoderReflectionFailures(t *testing.T) {
-	t.Parallel()
-
 	enc := NewMapObjectEncoder()
 	assert.Error(t, enc.AddObject("object", loggable{false}), "Expected AddObject to fail.")
 	assert.Equal(

--- a/zapcore/tee_test.go
+++ b/zapcore/tee_test.go
@@ -39,26 +39,17 @@ func withTee(f func(core Core, debugLogs, warnLogs *observer.ObservedLogs)) {
 }
 
 func TestTeeUnusualInput(t *testing.T) {
-	t.Parallel()
-
 	// Verify that Tee handles receiving one and no inputs correctly.
 	t.Run("one input", func(t *testing.T) {
-		t.Parallel()
-
 		obs, _ := observer.New(DebugLevel)
 		assert.Equal(t, obs, NewTee(obs), "Expected to return single inputs unchanged.")
 	})
-
 	t.Run("no input", func(t *testing.T) {
-		t.Parallel()
-
 		assert.Equal(t, NewNopCore(), NewTee(), "Expected to return NopCore.")
 	})
 }
 
 func TestLevelOfTee(t *testing.T) {
-	t.Parallel()
-
 	debugLogger, _ := observer.New(DebugLevel)
 	warnLogger, _ := observer.New(WarnLevel)
 
@@ -97,8 +88,6 @@ func TestLevelOfTee(t *testing.T) {
 }
 
 func TestTeeCheck(t *testing.T) {
-	t.Parallel()
-
 	withTee(func(tee Core, debugLogs, warnLogs *observer.ObservedLogs) {
 		debugEntry := Entry{Level: DebugLevel, Message: "log-at-debug"}
 		infoEntry := Entry{Level: InfoLevel, Message: "log-at-info"}
@@ -125,8 +114,6 @@ func TestTeeCheck(t *testing.T) {
 }
 
 func TestTeeWrite(t *testing.T) {
-	t.Parallel()
-
 	// Calling the tee's Write method directly should always log, regardless of
 	// the configured level.
 	withTee(func(tee Core, debugLogs, warnLogs *observer.ObservedLogs) {
@@ -146,8 +133,6 @@ func TestTeeWrite(t *testing.T) {
 }
 
 func TestTeeWith(t *testing.T) {
-	t.Parallel()
-
 	withTee(func(tee Core, debugLogs, warnLogs *observer.ObservedLogs) {
 		f := makeInt64Field("k", 42)
 		tee = tee.With([]Field{f})
@@ -165,8 +150,6 @@ func TestTeeWith(t *testing.T) {
 }
 
 func TestTeeEnabled(t *testing.T) {
-	t.Parallel()
-
 	infoLogger, _ := observer.New(InfoLevel)
 	warnLogger, _ := observer.New(WarnLevel)
 	tee := NewTee(infoLogger, warnLogger)
@@ -184,18 +167,11 @@ func TestTeeEnabled(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.lvl.String(), func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tt.enabled, tee.Enabled(tt.lvl), "Unexpected Enabled result for level %s.", tt.lvl)
-		})
+		assert.Equal(t, tt.enabled, tee.Enabled(tt.lvl), "Unexpected Enabled result for level %s.", tt.lvl)
 	}
 }
 
 func TestTeeSync(t *testing.T) {
-	t.Parallel()
-
 	infoLogger, _ := observer.New(InfoLevel)
 	warnLogger, _ := observer.New(WarnLevel)
 	tee := NewTee(infoLogger, warnLogger)

--- a/zapcore/write_syncer_test.go
+++ b/zapcore/write_syncer_test.go
@@ -43,8 +43,6 @@ func requireWriteWorks(t testing.TB, ws WriteSyncer) {
 }
 
 func TestAddSyncWriteSyncer(t *testing.T) {
-	t.Parallel()
-
 	buf := &bytes.Buffer{}
 	concrete := &writeSyncSpy{Writer: buf}
 	ws := AddSync(concrete)
@@ -58,8 +56,6 @@ func TestAddSyncWriteSyncer(t *testing.T) {
 }
 
 func TestAddSyncWriter(t *testing.T) {
-	t.Parallel()
-
 	// If we pass a plain io.Writer, make sure that we still get a WriteSyncer
 	// with a no-op Sync.
 	buf := &bytes.Buffer{}
@@ -69,8 +65,6 @@ func TestAddSyncWriter(t *testing.T) {
 }
 
 func TestNewMultiWriteSyncerWorksForSingleWriter(t *testing.T) {
-	t.Parallel()
-
 	w := &ztest.Buffer{}
 
 	ws := NewMultiWriteSyncer(w)
@@ -81,8 +75,6 @@ func TestNewMultiWriteSyncerWorksForSingleWriter(t *testing.T) {
 }
 
 func TestMultiWriteSyncerWritesBoth(t *testing.T) {
-	t.Parallel()
-
 	first := &bytes.Buffer{}
 	second := &bytes.Buffer{}
 	ws := NewMultiWriteSyncer(AddSync(first), AddSync(second))
@@ -97,16 +89,12 @@ func TestMultiWriteSyncerWritesBoth(t *testing.T) {
 }
 
 func TestMultiWriteSyncerFailsWrite(t *testing.T) {
-	t.Parallel()
-
 	ws := NewMultiWriteSyncer(AddSync(&ztest.FailWriter{}))
 	_, err := ws.Write([]byte("test"))
 	assert.Error(t, err, "Write error should propagate")
 }
 
 func TestMultiWriteSyncerFailsShortWrite(t *testing.T) {
-	t.Parallel()
-
 	ws := NewMultiWriteSyncer(AddSync(&ztest.ShortWriter{}))
 	n, err := ws.Write([]byte("test"))
 	assert.NoError(t, err, "Expected fake-success from short write")
@@ -114,8 +102,6 @@ func TestMultiWriteSyncerFailsShortWrite(t *testing.T) {
 }
 
 func TestWritestoAllSyncs_EvenIfFirstErrors(t *testing.T) {
-	t.Parallel()
-
 	failer := &ztest.FailWriter{}
 	second := &bytes.Buffer{}
 	ws := NewMultiWriteSyncer(AddSync(failer), AddSync(second))
@@ -126,8 +112,6 @@ func TestWritestoAllSyncs_EvenIfFirstErrors(t *testing.T) {
 }
 
 func TestMultiWriteSyncerSync_PropagatesErrors(t *testing.T) {
-	t.Parallel()
-
 	badsink := &ztest.Buffer{}
 	badsink.SetError(errors.New("sink is full"))
 	ws := NewMultiWriteSyncer(&ztest.Discarder{}, badsink)
@@ -136,15 +120,11 @@ func TestMultiWriteSyncerSync_PropagatesErrors(t *testing.T) {
 }
 
 func TestMultiWriteSyncerSync_NoErrorsOnDiscard(t *testing.T) {
-	t.Parallel()
-
 	ws := NewMultiWriteSyncer(&ztest.Discarder{})
 	assert.NoError(t, ws.Sync(), "Expected error-free sync to /dev/null")
 }
 
 func TestMultiWriteSyncerSync_AllCalled(t *testing.T) {
-	t.Parallel()
-
 	failed, second := &ztest.Buffer{}, &ztest.Buffer{}
 
 	failed.SetError(errors.New("disposal broken"))

--- a/zapgrpc/internal/test/grpc_test.go
+++ b/zapgrpc/internal/test/grpc_test.go
@@ -33,8 +33,6 @@ import (
 )
 
 func TestLoggerV2(t *testing.T) {
-	t.Parallel()
-
 	core, observedLogs := observer.New(zapcore.InfoLevel)
 	zlog := zap.New(core)
 

--- a/zapgrpc/zapgrpc_test.go
+++ b/zapgrpc/zapgrpc_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 func TestLoggerInfoExpected(t *testing.T) {
-	t.Parallel()
-
 	checkMessages(t, zapcore.DebugLevel, nil, zapcore.InfoLevel, []string{
 		"hello",
 		"s1s21 2 3s34s56",
@@ -68,8 +66,6 @@ func TestLoggerInfoExpected(t *testing.T) {
 }
 
 func TestLoggerDebugExpected(t *testing.T) {
-	t.Parallel()
-
 	checkMessages(t, zapcore.DebugLevel, []Option{WithDebug()}, zapcore.DebugLevel, []string{
 		"hello",
 		"s1s21 2 3s34s56",
@@ -90,8 +86,6 @@ func TestLoggerDebugExpected(t *testing.T) {
 }
 
 func TestLoggerDebugSuppressed(t *testing.T) {
-	t.Parallel()
-
 	checkMessages(t, zapcore.InfoLevel, []Option{WithDebug()}, zapcore.DebugLevel, nil, func(logger *Logger) {
 		logger.Print("hello")
 		logger.Printf("%s world", "hello")
@@ -102,8 +96,6 @@ func TestLoggerDebugSuppressed(t *testing.T) {
 }
 
 func TestLoggerWarningExpected(t *testing.T) {
-	t.Parallel()
-
 	checkMessages(t, zapcore.DebugLevel, nil, zapcore.WarnLevel, []string{
 		"hello",
 		"s1s21 2 3s34s56",
@@ -124,8 +116,6 @@ func TestLoggerWarningExpected(t *testing.T) {
 }
 
 func TestLoggerErrorExpected(t *testing.T) {
-	t.Parallel()
-
 	checkMessages(t, zapcore.DebugLevel, nil, zapcore.ErrorLevel, []string{
 		"hello",
 		"s1s21 2 3s34s56",
@@ -146,8 +136,6 @@ func TestLoggerErrorExpected(t *testing.T) {
 }
 
 func TestLoggerFatalExpected(t *testing.T) {
-	t.Parallel()
-
 	checkMessages(t, zapcore.DebugLevel, nil, zapcore.FatalLevel, []string{
 		"hello",
 		"s1s21 2 3s34s56",
@@ -168,8 +156,6 @@ func TestLoggerFatalExpected(t *testing.T) {
 }
 
 func TestLoggerV(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		zapLevel     zapcore.Level
 		grpcEnabled  []int
@@ -211,34 +197,21 @@ func TestLoggerV(t *testing.T) {
 			grpcDisabled: []int{grpcLvlInfo, grpcLvlWarn, grpcLvlError},
 		},
 	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run("zap="+tt.zapLevel.String(), func(t *testing.T) {
-			t.Parallel()
-
-			for _, grpcLvl := range tt.grpcEnabled {
-				grpcLvl := grpcLvl
-				t.Run(fmt.Sprintf("grpc=%d", grpcLvl), func(t *testing.T) {
-					t.Parallel()
-
-					checkLevel(t, tt.zapLevel, true, func(logger *Logger) bool {
-						return logger.V(grpcLvl)
-					})
+	for _, tst := range tests {
+		for _, grpcLvl := range tst.grpcEnabled {
+			t.Run(fmt.Sprintf("enabled %s %d", tst.zapLevel, grpcLvl), func(t *testing.T) {
+				checkLevel(t, tst.zapLevel, true, func(logger *Logger) bool {
+					return logger.V(grpcLvl)
 				})
-			}
-
-			for _, grpcLvl := range tt.grpcDisabled {
-				grpcLvl := grpcLvl
-				t.Run(fmt.Sprintf("grpc=%d", grpcLvl), func(t *testing.T) {
-					t.Parallel()
-
-					checkLevel(t, tt.zapLevel, false, func(logger *Logger) bool {
-						return logger.V(grpcLvl)
-					})
+			})
+		}
+		for _, grpcLvl := range tst.grpcDisabled {
+			t.Run(fmt.Sprintf("disabled %s %d", tst.zapLevel, grpcLvl), func(t *testing.T) {
+				checkLevel(t, tst.zapLevel, false, func(logger *Logger) bool {
+					return logger.V(grpcLvl)
 				})
-			}
-		})
+			})
+		}
 	}
 }
 

--- a/zapio/writer_test.go
+++ b/zapio/writer_test.go
@@ -170,12 +170,10 @@ func TestWrite_Sync(t *testing.T) {
 	io.WriteString(&w, "foo")
 	io.WriteString(&w, "bar")
 
-	//nolint:paralleltest // shared state
 	t.Run("no sync", func(t *testing.T) {
 		assert.Zero(t, observed.Len(), "Expected no logs yet")
 	})
 
-	//nolint:paralleltest // shared state
 	t.Run("sync", func(t *testing.T) {
 		defer observed.TakeAll()
 
@@ -186,7 +184,6 @@ func TestWrite_Sync(t *testing.T) {
 		}, observed.AllUntimed(), "Log messages did not match")
 	})
 
-	//nolint:paralleltest // shared state
 	t.Run("sync on empty", func(t *testing.T) {
 		require.NoError(t, w.Sync(), "Sync must not fail")
 		assert.Zero(t, observed.Len(), "Expected no logs yet")

--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -35,8 +35,6 @@ import (
 )
 
 func TestTestLogger(t *testing.T) {
-	t.Parallel()
-
 	ts := newTestLogSpy(t)
 	defer ts.AssertPassed()
 
@@ -61,8 +59,6 @@ func TestTestLogger(t *testing.T) {
 }
 
 func TestTestLoggerSupportsLevels(t *testing.T) {
-	t.Parallel()
-
 	ts := newTestLogSpy(t)
 	defer ts.AssertPassed()
 
@@ -85,8 +81,6 @@ func TestTestLoggerSupportsLevels(t *testing.T) {
 }
 
 func TestTestLoggerSupportsWrappedZapOptions(t *testing.T) {
-	t.Parallel()
-
 	ts := newTestLogSpy(t)
 	defer ts.AssertPassed()
 
@@ -102,17 +96,15 @@ func TestTestLoggerSupportsWrappedZapOptions(t *testing.T) {
 	}, "log.Panic should panic")
 
 	ts.AssertMessages(
-		`INFO	zaptest/logger_test.go:95	received work order	{"k1": "v1"}`,
-		`DEBUG	zaptest/logger_test.go:96	starting work	{"k1": "v1"}`,
-		`WARN	zaptest/logger_test.go:97	work may fail	{"k1": "v1"}`,
-		`ERROR	zaptest/logger_test.go:98	work failed	{"k1": "v1", "error": "great sadness"}`,
-		`PANIC	zaptest/logger_test.go:101	failed to do work	{"k1": "v1"}`,
+		`INFO	zaptest/logger_test.go:89	received work order	{"k1": "v1"}`,
+		`DEBUG	zaptest/logger_test.go:90	starting work	{"k1": "v1"}`,
+		`WARN	zaptest/logger_test.go:91	work may fail	{"k1": "v1"}`,
+		`ERROR	zaptest/logger_test.go:92	work failed	{"k1": "v1", "error": "great sadness"}`,
+		`PANIC	zaptest/logger_test.go:95	failed to do work	{"k1": "v1"}`,
 	)
 }
 
 func TestTestingWriter(t *testing.T) {
-	t.Parallel()
-
 	ts := newTestLogSpy(t)
 	w := newTestingWriter(ts)
 
@@ -122,8 +114,6 @@ func TestTestingWriter(t *testing.T) {
 }
 
 func TestTestLoggerErrorOutput(t *testing.T) {
-	t.Parallel()
-
 	// This test verifies that the test logger logs internal messages to the
 	// testing.T and marks the test as failed.
 

--- a/zaptest/observer/logged_entry_test.go
+++ b/zaptest/observer/logged_entry_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func TestLoggedEntryContextMap(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		msg    string
 		fields []zapcore.Field
@@ -80,10 +78,7 @@ func TestLoggedEntryContextMap(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.msg, func(t *testing.T) {
-			t.Parallel()
-
 			entry := LoggedEntry{
 				Context: tt.fields,
 			}

--- a/zaptest/observer/observer_test.go
+++ b/zaptest/observer/observer_test.go
@@ -38,12 +38,12 @@ func assertEmpty(t testing.TB, logs *ObservedLogs) {
 }
 
 func TestObserver(t *testing.T) {
-	t.Parallel()
-
 	observer, logs := New(zap.InfoLevel)
 	assertEmpty(t, logs)
 
-	assert.Equal(t, zap.InfoLevel, zapcore.LevelOf(observer), "Observer reported the wrong log level.")
+	t.Run("LevelOf", func(t *testing.T) {
+		assert.Equal(t, zap.InfoLevel, zapcore.LevelOf(observer), "Observer reported the wrong log level.")
+	})
 
 	assert.NoError(t, observer.Sync(), "Unexpected failure in no-op Sync")
 
@@ -72,8 +72,6 @@ func TestObserver(t *testing.T) {
 }
 
 func TestObserverWith(t *testing.T) {
-	t.Parallel()
-
 	sf1, logs := New(zap.InfoLevel)
 
 	// need to pad out enough initial fields so that the underlying slice cap()
@@ -126,8 +124,6 @@ func TestObserverWith(t *testing.T) {
 }
 
 func TestFilters(t *testing.T) {
-	t.Parallel()
-
 	logs := []LoggedEntry{
 		{
 			Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "log a"},
@@ -256,12 +252,7 @@ func TestFilters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.msg, func(t *testing.T) {
-			t.Parallel()
-
-			got := tt.filtered.AllUntimed()
-			assert.Equal(t, tt.want, got, tt.msg)
-		})
+		got := tt.filtered.AllUntimed()
+		assert.Equal(t, tt.want, got, tt.msg)
 	}
 }

--- a/zaptest/timeout_test.go
+++ b/zaptest/timeout_test.go
@@ -28,13 +28,11 @@ import (
 	"go.uber.org/zap/internal/ztest"
 )
 
-//nolint:paralleltest // changes time scaling
 func TestTimeout(t *testing.T) {
 	defer ztest.Initialize("2")()
 	assert.Equal(t, time.Duration(100), Timeout(50), "Expected to scale up timeout.")
 }
 
-//nolint:paralleltest // changes time scaling
 func TestSleep(t *testing.T) {
 	defer ztest.Initialize("2")()
 	const sleepFor = 50 * time.Millisecond

--- a/zaptest/writer_test.go
+++ b/zaptest/writer_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestSyncer(t *testing.T) {
-	t.Parallel()
-
 	err := errors.New("sentinel")
 	s := &Syncer{}
 	s.SetError(err)
@@ -38,8 +36,6 @@ func TestSyncer(t *testing.T) {
 }
 
 func TestDiscarder(t *testing.T) {
-	t.Parallel()
-
 	d := &Discarder{}
 	payload := []byte("foo")
 	n, err := d.Write(payload)
@@ -48,8 +44,6 @@ func TestDiscarder(t *testing.T) {
 }
 
 func TestFailWriter(t *testing.T) {
-	t.Parallel()
-
 	w := &FailWriter{}
 	payload := []byte("foo")
 	n, err := w.Write(payload)
@@ -58,8 +52,6 @@ func TestFailWriter(t *testing.T) {
 }
 
 func TestShortWriter(t *testing.T) {
-	t.Parallel()
-
 	w := &ShortWriter{}
 	payload := []byte("foo")
 	n, err := w.Write(payload)
@@ -68,8 +60,6 @@ func TestShortWriter(t *testing.T) {
 }
 
 func TestBuffer(t *testing.T) {
-	t.Parallel()
-
 	buf := &Buffer{}
 	buf.WriteString("foo\n")
 	buf.WriteString("bar\n")


### PR DESCRIPTION
The PR was merged prematurely.
Maintainers are not yet in agreement about this change.

This reverts commit 7b6c114a56867df0878eb99fd03a6f463252dabc.
