### PR TITLE
zapcore: Ignore nil Entry.Time in encoders

### DIFF
--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -23,17 +23,13 @@
 package zapslog
 
 import (
-	"bytes"
-	"encoding/json"
 	"log/slog"
 	"testing"
-	"testing/slogtest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 )
 
@@ -192,43 +188,4 @@ func TestAttrKinds(t *testing.T) {
 			"any":       "what am i?",
 		},
 		entry.ContextMap())
-}
-
-func TestSlogtest(t *testing.T) {
-	t.Skip() // TODO: skip for now until test failures are fixed (#1334)
-	var buff bytes.Buffer
-	core := zapcore.NewCore(
-		zapcore.NewJSONEncoder(zapcore.EncoderConfig{
-			TimeKey:     slog.TimeKey,
-			MessageKey:  slog.MessageKey,
-			LevelKey:    slog.LevelKey,
-			EncodeLevel: zapcore.CapitalLevelEncoder,
-			EncodeTime:  zapcore.RFC3339TimeEncoder,
-		}),
-		zapcore.AddSync(&buff),
-		zapcore.DebugLevel,
-	)
-
-	// zaptest doesn't expose the underlying core,
-	// so we'll extract it from the logger.
-	testCore := zaptest.NewLogger(t).Core()
-
-	handler := NewHandler(zapcore.NewTee(core, testCore))
-	err := slogtest.TestHandler(
-		handler,
-		func() []map[string]any {
-			// Parse the newline-delimited JSON in buff.
-			var entries []map[string]any
-
-			dec := json.NewDecoder(bytes.NewReader(buff.Bytes()))
-			for dec.More() {
-				var ent map[string]any
-				require.NoError(t, dec.Decode(&ent), "Error decoding log message")
-				entries = append(entries, ent)
-			}
-
-			return entries
-		},
-	)
-	require.NoError(t, err, "Unexpected error from slogtest.TestHandler")
 }

--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -23,13 +23,17 @@
 package zapslog
 
 import (
+	"bytes"
+	"encoding/json"
 	"log/slog"
 	"testing"
+	"testing/slogtest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 )
 
@@ -188,4 +192,43 @@ func TestAttrKinds(t *testing.T) {
 			"any":       "what am i?",
 		},
 		entry.ContextMap())
+}
+
+func TestSlogtest(t *testing.T) {
+	t.Skip() // TODO: skip for now until test failures are fixed (#1334)
+	var buff bytes.Buffer
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(zapcore.EncoderConfig{
+			TimeKey:     slog.TimeKey,
+			MessageKey:  slog.MessageKey,
+			LevelKey:    slog.LevelKey,
+			EncodeLevel: zapcore.CapitalLevelEncoder,
+			EncodeTime:  zapcore.RFC3339TimeEncoder,
+		}),
+		zapcore.AddSync(&buff),
+		zapcore.DebugLevel,
+	)
+
+	// zaptest doesn't expose the underlying core,
+	// so we'll extract it from the logger.
+	testCore := zaptest.NewLogger(t).Core()
+
+	handler := NewHandler(zapcore.NewTee(core, testCore))
+	err := slogtest.TestHandler(
+		handler,
+		func() []map[string]any {
+			// Parse the newline-delimited JSON in buff.
+			var entries []map[string]any
+
+			dec := json.NewDecoder(bytes.NewReader(buff.Bytes()))
+			for dec.More() {
+				var ent map[string]any
+				require.NoError(t, dec.Decode(&ent), "Error decoding log message")
+				entries = append(entries, ent)
+			}
+
+			return entries
+		},
+	)
+	require.NoError(t, err, "Unexpected error from slogtest.TestHandler")
 }

--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -77,7 +77,7 @@ func (c consoleEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 	// If this ever becomes a performance bottleneck, we can implement
 	// ArrayEncoder for our plain-text format.
 	arr := getSliceEncoder()
-	if c.TimeKey != "" && c.EncodeTime != nil {
+	if c.TimeKey != "" && c.EncodeTime != nil && !ent.Time.IsZero() {
 		c.EncodeTime(ent.Time, arr)
 	}
 	if c.LevelKey != "" && c.EncodeLevel != nil {

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -372,7 +372,7 @@ func (enc *jsonEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 			final.AppendString(ent.Level.String())
 		}
 	}
-	if final.TimeKey != "" {
+	if final.TimeKey != "" && !ent.Time.IsZero() {
 		final.AddTime(final.TimeKey, ent.Time)
 	}
 	if ent.LoggerName != "" && final.NameKey != "" {

--- a/zapcore/json_encoder_test.go
+++ b/zapcore/json_encoder_test.go
@@ -109,6 +109,20 @@ func TestJSONEncodeEntry(t *testing.T) {
 				}),
 			},
 		},
+		{
+			desc: "zero_time_omitted",
+			expected: `{
+				"L": "info",
+				"N": "name",
+				"M": "message"
+			}`,
+			ent: zapcore.Entry{
+				Level:      zapcore.InfoLevel,
+				Time:       time.Time{},
+				LoggerName: "name",
+				Message:    "message",
+			},
+		},
 	}
 
 	enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{


### PR DESCRIPTION
Per the comment on `Encoder.EncodeEntry`, any fields that are empty including fields on the `Entry` type should be omitted. Omit the `Time` field when we have empty time.
This also aligns with slog.Handler contract.

Refs #1334
Discovered by #1335