### PR TITLE
Make it possible to extract fields from the context in the slog adapter

### DIFF
--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -70,3 +70,10 @@ func AddStacktraceAt(lvl slog.Level) Option {
 		log.addStackAt = lvl
 	})
 }
+
+// .WithContextExtractor configures the Logger to extract fields from the context,
+func WithContextExtractor(extractor ContextExtractor) Option {
+	return optionFunc(func(log *Handler) {
+		log.contextExtractor = extractor
+	})
+}


### PR DESCRIPTION
Since slog has context logging built in it would be nice to be able to utilize that with a zap handler, for example to log tracing context.