### PR TITLE
zapslog: Apply callerSkip when addCaller

### DIFF
--- a/exp/zapslog/handler.go
+++ b/exp/zapslog/handler.go
@@ -137,6 +137,11 @@ func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
 	}
 
 	if h.addCaller && record.PC != 0 {
+		if h.callerSkip != 0 {
+			var pcs [1]uintptr
+			runtime.Callers(4+h.callerSkip, pcs[:])
+			record.PC = pcs[0]
+		}
 		frame, _ := runtime.CallersFrames([]uintptr{record.PC}).Next()
 		if frame.PC != 0 {
 			ce.Caller = zapcore.EntryCaller{


### PR DESCRIPTION
CallerSkip was added to the Handler but only used for the stacktrace, it should also be applied to the caller with an appropriate offset.

Currently the stacktrace can be correct for a wrapped logger but there is no way to fix the caller information.

Here is the equivalent logger functionality where the skip is applied for the caller:

https://github.com/uber-go/zap/blob/c17272e1a53876c9e27a3b92888b9a116a9c489f/logger.go#L393-L414