### PR TITLE
zapslog: Handler options changes via WithOptions

### DIFF
--- a/exp/zapslog/handler.go
+++ b/exp/zapslog/handler.go
@@ -48,10 +48,7 @@ func NewHandler(core zapcore.Core, opts ...Option) *Handler {
 		core:       core,
 		addStackAt: slog.LevelError,
 	}
-	for _, v := range opts {
-		v.apply(h)
-	}
-	return h
+	return h.WithOptions(opts...)
 }
 
 var _ slog.Handler = (*Handler)(nil)
@@ -182,9 +179,23 @@ func (h *Handler) WithGroup(group string) slog.Handler {
 	return h.withFields(zap.Namespace(group))
 }
 
+// WithOptions returns a new Handler with the given options.
+func (h *Handler) WithOptions(opts ...Option) *Handler {
+	cloned := h.clone()
+	for _, v := range opts {
+		v.apply(cloned)
+	}
+	return cloned
+}
+
 // withFields returns a cloned Handler with the given fields.
 func (h *Handler) withFields(fields ...zapcore.Field) *Handler {
-	cloned := *h
+	cloned := h.clone()
 	cloned.core = h.core.With(fields)
+	return cloned
+}
+
+func (h *Handler) clone() *Handler {
+	cloned := *h
 	return &cloned
 }


### PR DESCRIPTION
Add a `WithOptions` method to `Handler` to allow option changes after initial creation.

This would be useful if wrapping a logger and needing to preserve attributes but also have correct source/stacktrace details.

This is similar to the options functionality in the logger:
https://github.com/uber-go/zap/blob/c17272e1a53876c9e27a3b92888b9a116a9c489f/logger.go#L58-L79
https://github.com/uber-go/zap/blob/c17272e1a53876c9e27a3b92888b9a116a9c489f/logger.go#L166-L174