### PR TITLE
lint: Pass zapcore and zaptest packages

### DIFF
--- a/zapcore/console_encoder_bench_test.go
+++ b/zapcore/console_encoder_bench_test.go
@@ -23,6 +23,7 @@ package zapcore_test
 import (
 	"testing"
 
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 )
 

--- a/zapcore/console_encoder_test.go
+++ b/zapcore/console_encoder_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 )
 

--- a/zapcore/core_test.go
+++ b/zapcore/core_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"go.uber.org/zap/internal/ztest"
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"

--- a/zapcore/encoder_test.go
+++ b/zapcore/encoder_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 )
 

--- a/zapcore/error_test.go
+++ b/zapcore/error_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.uber.org/multierr"
-	"go.uber.org/zap/zapcore"
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 )
 
@@ -205,6 +205,6 @@ func (enc brokenArrayObjectEncoder) AddArray(key string, marshaler ArrayMarshale
 		}))
 }
 
-func (enc brokenArrayObjectEncoder) AppendObject(zapcore.ObjectMarshaler) error {
+func (enc brokenArrayObjectEncoder) AppendObject(ObjectMarshaler) error {
 	return enc.Err
 }

--- a/zapcore/field_test.go
+++ b/zapcore/field_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 )
 
@@ -88,9 +90,8 @@ type errObj struct {
 func (eobj *errObj) Error() string {
 	if eobj.kind == 1 {
 		panic("panic in Error() method")
-	} else {
-		return eobj.errMsg
 	}
+	return eobj.errMsg
 }
 
 func TestUnknownFieldType(t *testing.T) {

--- a/zapcore/hook_test.go
+++ b/zapcore/hook_test.go
@@ -23,6 +23,7 @@ package zapcore_test
 import (
 	"testing"
 
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 

--- a/zapcore/increase_level_test.go
+++ b/zapcore/increase_level_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )

--- a/zapcore/json_encoder_bench_test.go
+++ b/zapcore/json_encoder_bench_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 )
 

--- a/zapcore/sampler_bench_test.go
+++ b/zapcore/sampler_bench_test.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/internal/ztest"
+
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 )
 

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"go.uber.org/zap/internal/ztest"
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 

--- a/zapcore/tee_logger_bench_test.go
+++ b/zapcore/tee_logger_bench_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap/internal/ztest"
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 )
 

--- a/zapcore/tee_test.go
+++ b/zapcore/tee_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap/internal/ztest"
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 

--- a/zaptest/observer/observer_test.go
+++ b/zaptest/observer/observer_test.go
@@ -29,6 +29,8 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	//revive:disable:dot-imports
 	. "go.uber.org/zap/zaptest/observer"
 )
 


### PR DESCRIPTION
golangci-lint running revive currently fails on master. Exempt the dot-import failures since these are used to reduce a large number of qualifiers in the zapcore packages's _test package tests.

This change also simplifies an if/else statement with a logical equivalent and standardizes a test that imported a package and a dot-import of the same package simultaneously.