### PR TITLE
`zapcore/field.go`: Fixed typo on comment line indicating that the type is of complex64.

### DIFF
--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -47,7 +47,7 @@ const (
 	ByteStringType
 	// Complex128Type indicates that the field carries a complex128.
 	Complex128Type
-	// Complex64Type indicates that the field carries a complex128.
+	// Complex64Type indicates that the field carries a complex64.
 	Complex64Type
 	// DurationType indicates that the field carries a time.Duration.
 	DurationType


### PR DESCRIPTION
Fixing a typo in the zapcore documentation for the **FieldType** `complex64`.

```Go
// Complex64Type indicates that the field carries a complex64.
Complex64Type
```