### PR TITLE
Update `Any` documentation to point at go compiler stack reuse issue

### DIFF
--- a/field.go
+++ b/field.go
@@ -460,6 +460,8 @@ func (d dictObject) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // - https://github.com/uber-go/zap/pull/1304
 // - https://github.com/uber-go/zap/pull/1305
 // - https://github.com/uber-go/zap/pull/1308
+//
+// See https://github.com/golang/go/issues/62077 for upstream issue.
 type anyFieldC[T any] func(string, T) Field
 
 func (f anyFieldC[T]) Any(key string, val any) Field {


### PR DESCRIPTION
See discussion in https://github.com/uber-go/zap/pull/1310/files#r1280107231. 

https://github.com/golang/go/issues/62077 now exists, so we can link it.