### PR TITLE
Allow retrieval of previously added fields from the Core

### DIFF
--- a/zapcore/core.go
+++ b/zapcore/core.go
@@ -42,6 +42,8 @@ type Core interface {
 	Write(Entry, []Field) error
 	// Sync flushes buffered logs (if any).
 	Sync() error
+	// Fields returns any added structured context from the Core.
+	Fields() []Field
 }
 
 type nopCore struct{}
@@ -50,6 +52,7 @@ type nopCore struct{}
 func NewNopCore() Core                                        { return nopCore{} }
 func (nopCore) Enabled(Level) bool                            { return false }
 func (n nopCore) With([]Field) Core                           { return n }
+func (n nopCore) Fields() []Field                             { return nil }
 func (nopCore) Check(_ Entry, ce *CheckedEntry) *CheckedEntry { return ce }
 func (nopCore) Write(Entry, []Field) error                    { return nil }
 func (nopCore) Sync() error                                   { return nil }
@@ -65,8 +68,9 @@ func NewCore(enc Encoder, ws WriteSyncer, enab LevelEnabler) Core {
 
 type ioCore struct {
 	LevelEnabler
-	enc Encoder
-	out WriteSyncer
+	enc    Encoder
+	out    WriteSyncer
+	fields []Field
 }
 
 var (
@@ -80,8 +84,13 @@ func (c *ioCore) Level() Level {
 
 func (c *ioCore) With(fields []Field) Core {
 	clone := c.clone()
+	clone.fields = fields
 	addFields(clone.enc, fields)
 	return clone
+}
+
+func (c *ioCore) Fields() []Field {
+	return c.fields
 }
 
 func (c *ioCore) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {

--- a/zapcore/core.go
+++ b/zapcore/core.go
@@ -84,7 +84,7 @@ func (c *ioCore) Level() Level {
 
 func (c *ioCore) With(fields []Field) Core {
 	clone := c.clone()
-	clone.fields = fields
+	clone.fields = append(clone.fields, fields...)
 	addFields(clone.enc, fields)
 	return clone
 }
@@ -127,5 +127,6 @@ func (c *ioCore) clone() *ioCore {
 		LevelEnabler: c.LevelEnabler,
 		enc:          c.enc.Clone(),
 		out:          c.out,
+		fields:       c.fields,
 	}
 }

--- a/zapcore/core_test.go
+++ b/zapcore/core_test.go
@@ -164,3 +164,17 @@ func TestIOCoreWriteFailure(t *testing.T) {
 	// Should log the error.
 	assert.Error(t, err, "Expected writing Entry to fail.")
 }
+
+func TestIOCoreFields(t *testing.T) {
+	fields := []Field{makeInt64Field("k", 1)}
+
+	core := NewCore(
+		NewJSONEncoder(testEncoderConfig()),
+		Lock(os.Stderr),
+		DebugLevel,
+	).With(fields)
+
+	expectedFields := core.Fields()
+	assert.Greater(t, len(expectedFields), 0, "Expected non-empty fields.")
+	assert.Equal(t, fields, expectedFields, "Unexpected Fields.")
+}

--- a/zapcore/core_test.go
+++ b/zapcore/core_test.go
@@ -175,6 +175,10 @@ func TestIOCoreFields(t *testing.T) {
 	).With(fields)
 
 	expectedFields := core.Fields()
-	assert.Greater(t, len(expectedFields), 0, "Expected non-empty fields.")
+	assert.Len(t, expectedFields, 1, "Expected one field.")
 	assert.Equal(t, fields, expectedFields, "Unexpected Fields.")
+
+	core = core.With([]Field{makeInt64Field("w", 2)})
+	expectedFields = core.Fields()
+	assert.Len(t, expectedFields, 2, "Expected two fields.")
 }

--- a/zapcore/increase_level.go
+++ b/zapcore/increase_level.go
@@ -58,6 +58,10 @@ func (c *levelFilterCore) With(fields []Field) Core {
 	return &levelFilterCore{c.core.With(fields), c.level}
 }
 
+func (c *levelFilterCore) Fields() []Field {
+	return c.core.Fields()
+}
+
 func (c *levelFilterCore) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
 	if !c.Enabled(ent.Level) {
 		return ce

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -164,6 +164,7 @@ func (c *countingCore) Write(Entry, []Field) error {
 }
 
 func (c *countingCore) With([]Field) Core { return c }
+func (c *countingCore) Fields() []Field   { return nil }
 func (*countingCore) Enabled(Level) bool  { return true }
 func (*countingCore) Sync() error         { return nil }
 

--- a/zapcore/tee.go
+++ b/zapcore/tee.go
@@ -53,6 +53,16 @@ func (mc multiCore) With(fields []Field) Core {
 	return clone
 }
 
+func (mc multiCore) Fields() []Field {
+	var fields []Field
+
+	if len(mc) == 0 {
+		return fields
+	}
+
+	return mc[0].Fields()
+}
+
 func (mc multiCore) Level() Level {
 	minLvl := _maxLevel // mc is never empty
 	for i := range mc {

--- a/zapcore/tee_test.go
+++ b/zapcore/tee_test.go
@@ -150,6 +150,17 @@ func TestTeeWith(t *testing.T) {
 	})
 }
 
+func TestTeeFields(t *testing.T) {
+	withTee(func(tee Core, debugLogs, warnLogs *observer.ObservedLogs) {
+		fields := []Field{makeInt64Field("k", 42)}
+		tee = tee.With(fields)
+
+		expectedFields := tee.Fields()
+		assert.Greater(t, len(expectedFields), 0, "Expected non-empty fields.")
+		assert.Equal(t, fields, expectedFields, "Unexpected fields.")
+	})
+}
+
 func TestTeeEnabled(t *testing.T) {
 	infoLogger, _ := observer.New(InfoLevel)
 	warnLogger, _ := observer.New(WarnLevel)

--- a/zaptest/observer/observer.go
+++ b/zaptest/observer/observer.go
@@ -183,6 +183,10 @@ func (co *contextObserver) With(fields []zapcore.Field) zapcore.Core {
 	}
 }
 
+func (co *contextObserver) Fields() []zapcore.Field {
+	return co.context
+}
+
 func (co *contextObserver) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 	all := make([]zapcore.Field, 0, len(fields)+len(co.context))
 	all = append(all, co.context...)


### PR DESCRIPTION
As per the feature requested opened [here](https://github.com/uber-go/zap/issues/1394):

- extended the `Core` interface with `Fields()` which can be used to retrieve fields that have been previously added to the core
- updated the `ioCore.With` to store the fields in an internal private array
- updated the `ioCore.Clone` to clone the fields as well
- added unit tests to cover these cases
- updated the types implementing `Core` to also have `Fields()`

