### PR TITLE
Make zaptest.NewTestingWriter public

### DIFF
--- a/zaptest/logger.go
+++ b/zaptest/logger.go
@@ -82,7 +82,7 @@ func NewLogger(t TestingT, opts ...LoggerOption) *zap.Logger {
 		o.applyLoggerOption(&cfg)
 	}
 
-	writer := newTestingWriter(t)
+	writer := NewTestingWriter(t)
 	zapOptions := []zap.Option{
 		// Send zap errors to the same writer and mark the test as failed if
 		// that happens.
@@ -100,27 +100,27 @@ func NewLogger(t TestingT, opts ...LoggerOption) *zap.Logger {
 	)
 }
 
-// testingWriter is a WriteSyncer that writes to the given testing.TB.
-type testingWriter struct {
+// TestingWriter is a WriteSyncer that writes to the given testing.TB.
+type TestingWriter struct {
 	t TestingT
 
-	// If true, the test will be marked as failed if this testingWriter is
+	// If true, the test will be marked as failed if this TestingWriter is
 	// ever used.
 	markFailed bool
 }
 
-func newTestingWriter(t TestingT) testingWriter {
-	return testingWriter{t: t}
+func NewTestingWriter(t TestingT) TestingWriter {
+	return TestingWriter{t: t}
 }
 
 // WithMarkFailed returns a copy of this testingWriter with markFailed set to
 // the provided value.
-func (w testingWriter) WithMarkFailed(v bool) testingWriter {
+func (w TestingWriter) WithMarkFailed(v bool) TestingWriter {
 	w.markFailed = v
 	return w
 }
 
-func (w testingWriter) Write(p []byte) (n int, err error) {
+func (w TestingWriter) Write(p []byte) (n int, err error) {
 	n = len(p)
 
 	// Strip trailing newline because t.Log always adds one.
@@ -135,6 +135,6 @@ func (w testingWriter) Write(p []byte) (n int, err error) {
 	return n, nil
 }
 
-func (w testingWriter) Sync() error {
+func (w TestingWriter) Sync() error {
 	return nil
 }

--- a/zaptest/logger.go
+++ b/zaptest/logger.go
@@ -109,17 +109,33 @@ type TestingWriter struct {
 	markFailed bool
 }
 
+// NewTestingWriter builds a new TestingWriter that writes to the given
+// testing.TB.
+//
+// Use this if you need more flexibility when creating *zap.Logger
+// than zaptest.NewLogger() provides.
+//
+// E.g., if you want to use custom core with zaptest.TestingWriter:
+//
+//	encoder := newCustomEncoder()
+//	writer := zaptest.NewTestingWriter(t)
+//	level := zap.NewAtomicLevelAt(zapcore.DebugLevel)
+//
+//	core := newCustomCore(encoder, writer, level)
+//
+//	logger := zap.New(core, zap.AddCaller())
 func NewTestingWriter(t TestingT) TestingWriter {
 	return TestingWriter{t: t}
 }
 
-// WithMarkFailed returns a copy of this testingWriter with markFailed set to
+// WithMarkFailed returns a copy of this TestingWriter with markFailed set to
 // the provided value.
 func (w TestingWriter) WithMarkFailed(v bool) TestingWriter {
 	w.markFailed = v
 	return w
 }
 
+// Write writes bytes from p to the underlying testing.TB.
 func (w TestingWriter) Write(p []byte) (n int, err error) {
 	n = len(p)
 
@@ -135,6 +151,7 @@ func (w TestingWriter) Write(p []byte) (n int, err error) {
 	return n, nil
 }
 
+// Sync commits the current contents (a no-op for TestingWriter).
 func (w TestingWriter) Sync() error {
 	return nil
 }

--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -106,7 +106,7 @@ func TestTestLoggerSupportsWrappedZapOptions(t *testing.T) {
 
 func TestTestingWriter(t *testing.T) {
 	ts := newTestLogSpy(t)
-	w := newTestingWriter(ts)
+	w := NewTestingWriter(ts)
 
 	n, err := io.WriteString(w, "hello\n\n")
 	assert.NoError(t, err, "WriteString must not fail")


### PR DESCRIPTION
**Add more flexibility in configuring zap logger for tests.**

The default `zapcore.Core`, which is created in `zaptest.NewLogger()` may not be suitable for all use-cases.

```
func NewLogger(t TestingT, opts ...LoggerOption) *zap.Logger {
...
	return zap.New(
		zapcore.NewCore(
			zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
			writer,
			cfg.Level,
		),
		zapOptions...,
	)
```

E.g., we may need custom encoder or encoder config.

This PR allows us to do such customization:
```
writer := zaptest.NewTestingWriter(t)
core := zapcore.NewCore(encoder, writer, level)
logger := zap.New(core, zap.AddCaller())
```