### PR TITLE
zapslog: Bump zap from v1.24.0 to v1.26.0

### DIFF
--- a/exp/go.mod
+++ b/exp/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1
-	go.uber.org/zap v1.24.0
+	go.uber.org/zap v1.26.0
 )
 
 require (


### PR DESCRIPTION
- Bump zap from v1.24.0 to v1.26.0
  - https://github.com/uber-go/zap/compare/v1.24.0...v1.26.0