### PR TITLE
zapslog: fix all with slogtest, support inline group, ignore empty group.

### DIFF
--- a/exp/zapslog/handler.go
+++ b/exp/zapslog/handler.go
@@ -88,6 +88,10 @@ func convertAttrToField(attr slog.Attr) zapcore.Field {
 	case slog.KindUint64:
 		return zap.Uint64(attr.Key, attr.Value.Uint64())
 	case slog.KindGroup:
+		if attr.Key == "" {
+			// Inlines recursively.
+			return zap.Inline(groupObject(attr.Value.Group()))
+		}
 		return zap.Object(attr.Key, groupObject(attr.Value.Group()))
 	case slog.KindLogValuer:
 		return convertAttrToField(slog.Attr{


### PR DESCRIPTION
Support all slog features, add `testing/slogtest`, and fixes all slogtest failure.

- part of #1333
- fixes #1334
  - fixes #1402
  - fixes #1401
  - closes #1263