### PR TITLE
ci: Test with Go 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.20.x", "1.21.x", "1.22.0-rc.2"]
+        go: ["1.21.x", "1.22.x"]
         include:
-        - go: 1.21.x
+        - go: 1.22.x
 
     steps:
     - name: Checkout code
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/setup-go@v4
       name: Set up Go
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
         cache: false  # managed by golangci-lint
 
     - uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.20.x", "1.21.x"]
+        go: ["1.20.x", "1.21.x", "1.22.0-rc.2"]
         include:
         - go: 1.21.x
 


### PR DESCRIPTION
With the release of Go 1.22,
CI should run against Go 1.21 and 1.22