### PR TITLE
zapslog: rename Option to HandlerOption

### DIFF
--- a/exp/zapslog/handler.go
+++ b/exp/zapslog/handler.go
@@ -50,7 +50,7 @@ type Handler struct {
 
 // NewHandler builds a [Handler] that writes to the supplied [zapcore.Core]
 // with options.
-func NewHandler(core zapcore.Core, opts ...Option) *Handler {
+func NewHandler(core zapcore.Core, opts ...HandlerOption) *Handler {
 	h := &Handler{
 		core:       core,
 		addStackAt: slog.LevelError,

--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -24,29 +24,29 @@ package zapslog
 
 import "log/slog"
 
-// An Option configures a slog Handler.
-type Option interface {
+// An HandlerOption configures a slog Handler.
+type HandlerOption interface {
 	apply(*Handler)
 }
 
-// optionFunc wraps a func so it satisfies the Option interface.
-type optionFunc func(*Handler)
+// handlerOptionFunc wraps a func so it satisfies the Option interface.
+type handlerOptionFunc func(*Handler)
 
-func (f optionFunc) apply(handler *Handler) {
+func (f handlerOptionFunc) apply(handler *Handler) {
 	f(handler)
 }
 
 // WithName configures the Logger to annotate each message with the logger name.
-func WithName(name string) Option {
-	return optionFunc(func(h *Handler) {
+func WithName(name string) HandlerOption {
+	return handlerOptionFunc(func(h *Handler) {
 		h.name = name
 	})
 }
 
 // WithCaller configures the Logger to include the filename and line number
 // of the caller in log messages--if available.
-func WithCaller(enabled bool) Option {
-	return optionFunc(func(handler *Handler) {
+func WithCaller(enabled bool) HandlerOption {
+	return handlerOptionFunc(func(handler *Handler) {
 		handler.addCaller = enabled
 	})
 }
@@ -57,16 +57,16 @@ func WithCaller(enabled bool) Option {
 // When building wrappers around the Logger,
 // supplying this Option prevents Zap from always reporting
 // the wrapper code as the caller.
-func WithCallerSkip(skip int) Option {
-	return optionFunc(func(log *Handler) {
+func WithCallerSkip(skip int) HandlerOption {
+	return handlerOptionFunc(func(log *Handler) {
 		log.callerSkip += skip
 	})
 }
 
 // AddStacktraceAt configures the Logger to record a stack trace
 // for all messages at or above a given level.
-func AddStacktraceAt(lvl slog.Level) Option {
-	return optionFunc(func(log *Handler) {
+func AddStacktraceAt(lvl slog.Level) HandlerOption {
+	return handlerOptionFunc(func(log *Handler) {
 		log.addStackAt = lvl
 	})
 }

--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -24,7 +24,7 @@ package zapslog
 
 import "log/slog"
 
-// An HandlerOption configures a slog Handler.
+// A HandlerOption configures a slog Handler.
 type HandlerOption interface {
 	apply(*Handler)
 }


### PR DESCRIPTION
- relates #1333

Rename `Option` to `HandlerOption` to avoid future conflicts with [zap.Option](https://pkg.go.dev/go.uber.org/zap#Option).
There is no change in functionality.