### PR TITLE
Add WithPanicHook logger option for panic log tests

### DIFF
--- a/options.go
+++ b/options.go
@@ -132,6 +132,21 @@ func IncreaseLevel(lvl zapcore.LevelEnabler) Option {
 	})
 }
 
+// WithPanicHook sets a CheckWriteHook to run on Panic/DPanic logs.
+// Zap will call this hook after writing a log statement with a Panic/DPanic level.
+//
+// For example, the following builds a logger that will exit the current
+// goroutine after writing a Panic/DPanic log message, but it will not start a panic.
+//
+//	zap.New(core, zap.WithPanicHook(zapcore.WriteThenGoexit))
+//
+// This is useful for testing Panic/DPanic log output.
+func WithPanicHook(hook zapcore.CheckWriteHook) Option {
+	return optionFunc(func(log *Logger) {
+		log.onPanic = hook
+	})
+}
+
 // OnFatal sets the action to take on fatal logs.
 //
 // Deprecated: Use [WithFatalHook] instead.


### PR DESCRIPTION
Add a `WithPanicHook` logger option that allows callers to specify custom behavior besides panicking on Panic/DPanic logs. This is similar to what we already have with the WithFatal hook implemented in https://github.com/uber-go/zap/pull/861.

This will make it possible to unit test Panic log cases like the one we had with our periodic runner which was impossible because of unrecoverable panics in another go routine. 

Added unit tests and they pass.

```
$ make test
?       go.uber.org/zap/internal        [no test files]
?       go.uber.org/zap/internal/bufferpool     [no test files]
ok      go.uber.org/zap (cached)
?       go.uber.org/zap/internal/readme [no test files]
ok      go.uber.org/zap/buffer  (cached)
ok      go.uber.org/zap/internal/color  (cached)
ok      go.uber.org/zap/internal/exit   (cached)
ok      go.uber.org/zap/internal/pool   (cached)
ok      go.uber.org/zap/internal/stacktrace     (cached)
ok      go.uber.org/zap/internal/ztest  (cached)
ok      go.uber.org/zap/zapcore (cached)
ok      go.uber.org/zap/zapgrpc (cached)
ok      go.uber.org/zap/zapio   (cached)
ok      go.uber.org/zap/zaptest (cached)
ok      go.uber.org/zap/zaptest/observer        (cached)
ok      go.uber.org/zap/exp/zapfield    (cached)
ok      go.uber.org/zap/exp/zapslog     (cached)
ok      go.uber.org/zap/benchmarks      (cached) [no tests to run]
ok      go.uber.org/zap/zapgrpc/internal/test   (cached)
```

Closes #1415 