### PR TITLE
add error handling for `logger.Sync()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ packages and includes both structured and `printf`-style APIs.
 
 ```go
 logger, _ := zap.NewProduction()
-defer logger.Sync() // flushes buffer, if any
+defer func(logger *zap.Logger) {
+  err := logger.Sync()
+  if err != nil {
+    log.Fatal(err)
+  }
+}(logger) // flushes buffer, if any
 sugar := logger.Sugar()
 sugar.Infow("failed to fetch URL",
   // Structured context as loosely typed key-value pairs.
@@ -42,7 +47,12 @@ structured logging.
 
 ```go
 logger, _ := zap.NewProduction()
-defer logger.Sync()
+defer func(logger *zap.Logger) {
+  err := logger.Sync()
+  if err != nil {
+    log.Fatal(err)
+  }
+}(logger)
 logger.Info("failed to fetch URL",
   // Structured context as strongly typed Field values.
   zap.String("url", url),


### PR DESCRIPTION
By using current approach `defer logger.Sync()` we don't handle possible error returned by `func (log *Logger) Sync() error`. My suggestion is to wrap it with anonymous function.