### PR TITLE
zapcore: add warning as Level

### DIFF
--- a/zapcore/level.go
+++ b/zapcore/level.go
@@ -183,7 +183,7 @@ func (l *Level) unmarshalText(text []byte) bool {
 		*l = DebugLevel
 	case "info", "INFO", "": // make the zero value useful
 		*l = InfoLevel
-	case "warn", "WARN":
+	case "warn", "warning", "WARN":
 		*l = WarnLevel
 	case "error", "ERROR":
 		*l = ErrorLevel

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -84,7 +84,6 @@ func TestLevelText(t *testing.T) {
 		err := unmarshaled.UnmarshalText(input)
 		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, string(input))
 		assert.Equal(t, WarnLevel, unmarshaled, `Text %q unmarshaled to an unexpected level.`, string(input))
-
 	})
 }
 

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -57,13 +57,14 @@ func TestLevelText(t *testing.T) {
 		{"info", InfoLevel},
 		{"", InfoLevel}, // make the zero value useful
 		{"warn", WarnLevel},
+		{"warning", WarnLevel}, // compatibility handling for packages that emit "warning" instead of "warn"
 		{"error", ErrorLevel},
 		{"dpanic", DPanicLevel},
 		{"panic", PanicLevel},
 		{"fatal", FatalLevel},
 	}
 	for _, tt := range tests {
-		if tt.text != "" {
+		if tt.text != "" && tt.text != "warning" {
 			lvl := tt.level
 			marshaled, err := lvl.MarshalText()
 			assert.NoError(t, err, "Unexpected error marshaling level %v to text.", &lvl)

--- a/zapcore/level_test.go
+++ b/zapcore/level_test.go
@@ -57,14 +57,13 @@ func TestLevelText(t *testing.T) {
 		{"info", InfoLevel},
 		{"", InfoLevel}, // make the zero value useful
 		{"warn", WarnLevel},
-		{"warning", WarnLevel}, // compatibility handling for packages that emit "warning" instead of "warn"
 		{"error", ErrorLevel},
 		{"dpanic", DPanicLevel},
 		{"panic", PanicLevel},
 		{"fatal", FatalLevel},
 	}
 	for _, tt := range tests {
-		if tt.text != "" && tt.text != "warning" {
+		if tt.text != "" {
 			lvl := tt.level
 			marshaled, err := lvl.MarshalText()
 			assert.NoError(t, err, "Unexpected error marshaling level %v to text.", &lvl)
@@ -76,6 +75,17 @@ func TestLevelText(t *testing.T) {
 		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, tt.text)
 		assert.Equal(t, tt.level, unmarshaled, `Text %q unmarshaled to an unexpected level.`, tt.text)
 	}
+
+	// Some logging libraries are using "warning" instead of "warn" as level indicator. Handle this case
+	// for cross compatability.
+	t.Run("unmarshal warning compatability", func(t *testing.T) {
+		var unmarshaled Level
+		input := []byte("warning")
+		err := unmarshaled.UnmarshalText(input)
+		assert.NoError(t, err, `Unexpected error unmarshaling text %q to level.`, string(input))
+		assert.Equal(t, WarnLevel, unmarshaled, `Text %q unmarshaled to an unexpected level.`, string(input))
+
+	})
 }
 
 func TestParseLevel(t *testing.T) {


### PR DESCRIPTION
Some packages set their value for WarnLevel to "warning". For easier integration add "warning" as accepted WarnLevel.

Example for a package that is using "warning":
https://github.com/sirupsen/logrus/blob/dd1b4c2e81afc5c255f216a722b012ed26be57df/logrus.go#L68