### PR TITLE
Bump setup-go from 4 to 5

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
         cache-dependency-path: '**/go.sum'
@@ -52,7 +52,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       name: Check out repository
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       name: Set up Go
       with:
         go-version: 1.22.x


### PR DESCRIPTION
This PR manually bumps setup-go to version 5 since the [dependabot PR](https://github.com/uber-go/zap/pull/1393) for it seems to be having issues w/ codecov token.

CI runs on newer PRs somehow do not have this issue.