### PR TITLE
ci: Fix lint issues, makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ golangci-lint:
 	@$(foreach mod,$(MODULE_DIRS), \
 		(cd $(mod) && \
 		echo "[lint] golangci-lint: $(mod)" && \
-		golangci-lint run --path-prefix $(mod)) &&) true
+		golangci-lint run --path-prefix $(mod) ./...) &&) true
 
 .PHONY: tidy
 tidy:

--- a/http_handler.go
+++ b/http_handler.go
@@ -71,7 +71,7 @@ import (
 func (lvl AtomicLevel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := lvl.serveHTTP(w, r); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "internal error: %v", err)
+		_, _ = fmt.Fprintf(w, "internal error: %v", err)
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -381,7 +381,11 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 
 	if stack.Count() == 0 {
 		if log.addCaller {
-			fmt.Fprintf(log.errorOutput, "%v Logger.check error: failed to get caller\n", ent.Time.UTC())
+			_, _ = fmt.Fprintf(
+				log.errorOutput,
+				"%v Logger.check error: failed to get caller\n",
+				ent.Time.UTC(),
+			)
 			_ = log.errorOutput.Sync()
 		}
 		return ce

--- a/options.go
+++ b/options.go
@@ -125,7 +125,11 @@ func IncreaseLevel(lvl zapcore.LevelEnabler) Option {
 	return optionFunc(func(log *Logger) {
 		core, err := zapcore.NewIncreaseLevelCore(log.core, lvl)
 		if err != nil {
-			fmt.Fprintf(log.errorOutput, "failed to IncreaseLevel: %v\n", err)
+			_, _ = fmt.Fprintf(
+				log.errorOutput,
+				"failed to IncreaseLevel: %v\n",
+				err,
+			)
 		} else {
 			log.core = core
 		}

--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -105,7 +105,7 @@ func (c consoleEncoder) EncodeEntry(ent Entry, fields []Field) (*buffer.Buffer, 
 		if i > 0 {
 			line.AppendString(c.ConsoleSeparator)
 		}
-		fmt.Fprint(line, arr.elems[i])
+		_, _ = fmt.Fprint(line, arr.elems[i])
 	}
 	putSliceEncoder(arr)
 

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -241,7 +241,12 @@ func (ce *CheckedEntry) Write(fields ...Field) {
 			// If the entry is dirty, log an internal error; because the
 			// CheckedEntry is being used after it was returned to the pool,
 			// the message may be an amalgamation from multiple call sites.
-			fmt.Fprintf(ce.ErrorOutput, "%v Unsafe CheckedEntry re-use near Entry %+v.\n", ce.Time, ce.Entry)
+			_, _ = fmt.Fprintf(
+				ce.ErrorOutput,
+				"%v Unsafe CheckedEntry re-use near Entry %+v.\n",
+				ce.Time,
+				ce.Entry,
+			)
 			_ = ce.ErrorOutput.Sync() // ignore error
 		}
 		return
@@ -253,7 +258,12 @@ func (ce *CheckedEntry) Write(fields ...Field) {
 		err = multierr.Append(err, ce.cores[i].Write(ce.Entry, fields))
 	}
 	if err != nil && ce.ErrorOutput != nil {
-		fmt.Fprintf(ce.ErrorOutput, "%v write error: %v\n", ce.Time, err)
+		_, _ = fmt.Fprintf(
+			ce.ErrorOutput,
+			"%v write error: %v\n",
+			ce.Time,
+			err,
+		)
 		_ = ce.ErrorOutput.Sync() // ignore error
 	}
 


### PR DESCRIPTION
Noticed that there were a handful of lint issues, all `errcheck` things. This PR:
- Adds underscores to clarify error discarding
- Updates the `make golangci-lint` target to use `./...`, as e.g. there are no `exp/*.go` files