### PR TITLE
codecov: Use non-environment option

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,8 +44,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         verbose: true
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     name: Lint


### PR DESCRIPTION
codecov jobs have been failing recently.

The error we're seeing with verbose true is
```
debug - 2024-06-12 19:18:58,188 -- Starting create commit process --- {"commit_sha": "60547051d2c7a282f81ee9c7cb4c2547c0640e40", "parent_sha": null, "pr": "1435", "branch": "dependabot/github_actions/golangci/golangci-lint-action-6", "slug": "uber-go/zap", "token": null, "service": "github", "enterprise_url": null}
Error: Codecov token not found. Please provide Codecov token with -t flag.
Warning: Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1
```

ref: https://github.com/uber-go/zap/actions/runs/9488445442/job/26147390272#step:6:58

From the docs there are multiple valid ways to specify the coverage upload token https://github.com/codecov/codecov-action

Since we're using the environment variable approach and we're still getting an error that the token is not provided, let's try the with token option.