### PR TITLE
zaptest: add ability to filter observer logs by logger name

### DIFF
--- a/zaptest/observer/observer.go
+++ b/zaptest/observer/observer.go
@@ -91,7 +91,7 @@ func (o *ObservedLogs) FilterMessage(msg string) *ObservedLogs {
 	})
 }
 
-// FilterLoggerName filters entries to those that have the specified logger name.
+// FilterLoggerName filters entries to those logged through logger with the specified logger name.
 func (o *ObservedLogs) FilterLoggerName(name string) *ObservedLogs {
 	return o.Filter(func(e LoggedEntry) bool {
 		return e.LoggerName == name

--- a/zaptest/observer/observer.go
+++ b/zaptest/observer/observer.go
@@ -91,6 +91,13 @@ func (o *ObservedLogs) FilterMessage(msg string) *ObservedLogs {
 	})
 }
 
+// FilterLoggerName filters entries to those that have the specified logger name.
+func (o *ObservedLogs) FilterLoggerName(name string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.LoggerName == name
+	})
+}
+
 // FilterMessageSnippet filters entries to those that have a message containing the specified snippet.
 func (o *ObservedLogs) FilterMessageSnippet(snippet string) *ObservedLogs {
 	return o.Filter(func(e LoggedEntry) bool {

--- a/zaptest/observer/observer_test.go
+++ b/zaptest/observer/observer_test.go
@@ -171,6 +171,10 @@ func TestFilters(t *testing.T) {
 			Entry:   zapcore.Entry{Level: zap.ErrorLevel, Message: "warp core breach"},
 			Context: []zapcore.Field{zap.Int("b", 42)},
 		},
+		{
+			Entry:   zapcore.Entry{Level: zap.ErrorLevel, Message: "msg", LoggerName: "my.logger"},
+			Context: []zapcore.Field{zap.Int("b", 42)},
+		},
 	}
 
 	logger, sink := New(zap.InfoLevel)
@@ -250,6 +254,11 @@ func TestFilters(t *testing.T) {
 			msg:      "filter level",
 			filtered: sink.FilterLevelExact(zap.WarnLevel),
 			want:     logs[9:10],
+		},
+		{
+			msg:      "filter logger name",
+			filtered: sink.FilterLoggerName("my.logger"),
+			want:     logs[11:12],
 		},
 	}
 


### PR DESCRIPTION
This is useful for assertions on logs in a particular named path, currently this is only possible through calls to Filter but it is more verbose.

Added a FilterLoggerName function that plays nicely with the other filters:

	zapLogs.FilterLoggerName("my.logger").FilterMessage("hello")