### PR TITLE
fix(test): correct assertion message

### DIFF
--- a/writer_test.go
+++ b/writer_test.go
@@ -171,7 +171,7 @@ func TestOpenFails(t *testing.T) {
 
 	for _, tt := range tests {
 		_, cleanup, err := Open(tt.paths...)
-		require.Nil(t, cleanup, "Cleanup function should never be nil")
+		require.Nil(t, cleanup, "Cleanup function should be nil")
 		assert.Error(t, err, "Open with invalid URL should fail.")
 	}
 }


### PR DESCRIPTION
The current message is misleading. It states the opposite of what the assertion is checking for.