### PR TITLE
exp: Release v0.3.0

### DIFF
--- a/exp/CHANGELOG.md
+++ b/exp/CHANGELOG.md
@@ -3,6 +3,28 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 - 22 Oct 2024
+
+Breaking changes:
+* [#1339][]: zapslog: Drop `HandlerOptions` in favor of `HandlerOption`,
+  which uses the functional options pattern.
+* [#1339][]: zapslog: Rename `AddSource` option to `WithCaller`.
+
+Enhancements:
+* [#1339][]: zapslog: Record stack traces for error logs or higher.
+  The new `AddStackAt` option changes this level.
+
+Bug fixes:
+* [#1344][], [#1408][]: zapslog: Comply fully with `slog.Handler` contract.
+  This includes ignoring empty `Attr`s, inlining `Group`s with empty names,
+  and omitting groups with no attributes.
+
+[#1344]: https://github.com/uber-go/zap/pull/1344
+[#1339]: https://github.com/uber-go/zap/pull/1339
+[#1408]: https://github.com/uber-go/zap/pull/1408
+
+Thanks to @zekth and @arukiidou for their contributions to this release.
+
 ## 0.2.0 - 9 Sep 2023
 
 Breaking changes:


### PR DESCRIPTION
Updates the CHANGELOG of exp to prepare for a new release
based on changes made to this directory since the last release.

I think I got all user-facing changes, but feel free to tweak.

Once this PR lands, maintainers should run:

```bash
git pull
git checkout master
git tag exp/v0.3.0
git push origin exp/v0.3.0
```
