### PR TITLE
Removed manually installation govulncheck in Makefile

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,6 +66,12 @@ jobs:
         # Hack: Use the official action to download, but not run.
         # make lint below will handle actually running the linter.
         args: --help
+        
+    - uses: golang/govulncheck-action@v1
+      name: Install govulncheck
+      with:
+         go-version-input: 1.23.x
+         go-package: all
 
     - run: make lint
       name: Lint

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,6 @@ tidy-lint:
 license-lint:
 	./checklicense.sh
 
-$(GOVULNCHECK):
-	cd tools && go install golang.org/x/vuln/cmd/govulncheck
-
 .PHONY: test
 test:
 	@$(foreach dir,$(MODULE_DIRS),(cd $(dir) && go test -race ./...) &&) true

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 export GOBIN ?= $(PROJECT_ROOT)/bin
 export PATH := $(GOBIN):$(PATH)
 
-GOVULNCHECK = $(GOBIN)/govulncheck
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 
 # Directories containing independent Go modules.
@@ -72,5 +71,5 @@ updatereadme:
 	cat .readme.tmpl | go run internal/readme/readme.go > README.md
 
 .PHONY: vulncheck
-vulncheck: $(GOVULNCHECK)
-	$(GOVULNCHECK) ./...
+vulncheck:
+	govulncheck ./...


### PR DESCRIPTION
Hello, i have changed workflow (more specifically action) to use official `govulncheck`  and replaced this solution in `Makefile` to simplify that.

Motivation:
Better and more convenience way to maintain runners.

```sh
$ make all
[lint] golangci-lint: .
[lint] golangci-lint: ./exp
[lint] golangci-lint: ./benchmarks
[lint] golangci-lint: ./zapgrpc/internal/test
[lint] tidy: .
[lint] tidy: ./exp
[lint] tidy: ./benchmarks
[lint] tidy: ./zapgrpc/internal/test
./checklicense.sh
?   	go.uber.org/zap/internal	[no test files]
?   	go.uber.org/zap/internal/bufferpool	[no test files]
ok  	go.uber.org/zap	(cached)
ok  	go.uber.org/zap/buffer	(cached)
ok  	go.uber.org/zap/internal/color	(cached)
?   	go.uber.org/zap/internal/readme	[no test files]
ok  	go.uber.org/zap/internal/exit	(cached)
ok  	go.uber.org/zap/internal/pool	(cached)
ok  	go.uber.org/zap/internal/stacktrace	(cached)
ok  	go.uber.org/zap/internal/ztest	(cached)
ok  	go.uber.org/zap/zapcore	(cached)
ok  	go.uber.org/zap/zapgrpc	(cached)
ok  	go.uber.org/zap/zapio	(cached)
ok  	go.uber.org/zap/zaptest	(cached)
ok  	go.uber.org/zap/zaptest/observer	(cached)
ok  	go.uber.org/zap/exp/zapfield	(cached)
ok  	go.uber.org/zap/exp/zapslog	(cached)
ok  	go.uber.org/zap/benchmarks	(cached) [no tests to run]
ok  	go.uber.org/zap/zapgrpc/internal/test	(cached)
```
```sh
$ make vulncheck
govulncheck ./...
No vulnerabilities found.
```