### PR TITLE
Support errors created using errors.Join()

### DIFF
--- a/zapcore/error.go
+++ b/zapcore/error.go
@@ -67,6 +67,8 @@ func encodeError(key string, err error, enc ObjectEncoder) (retErr error) {
 	switch e := err.(type) {
 	case errorGroup:
 		return enc.AddArray(key+"Causes", errArray(e.Errors()))
+	case joinError:
+		return enc.AddArray(key+"Causes", errArray(e.Unwrap()))
 	case fmt.Formatter:
 		verbose := fmt.Sprintf("%+v", e)
 		if verbose != basic {
@@ -82,6 +84,11 @@ type errorGroup interface {
 	// Provides read-only access to the underlying list of errors, preferably
 	// without causing any allocs.
 	Errors() []error
+}
+
+type joinError interface {
+	// used by errors.Join() in standard error library
+	Unwrap() []error
 }
 
 // Note that errArray and errArrayElem are very similar to the version

--- a/zapcore/error_test.go
+++ b/zapcore/error_test.go
@@ -132,6 +132,22 @@ func TestErrorEncoding(t *testing.T) {
 			},
 		},
 		{
+			key: "err",
+			iface: errors.Join(
+				errors.New("foo"),
+				errors.New("bar"),
+				errors.New("baz"),
+			),
+			want: map[string]any{
+				"err": "foo\nbar\nbaz",
+				"errCauses": []any{
+					map[string]any{"error": "foo"},
+					map[string]any{"error": "bar"},
+					map[string]any{"error": "baz"},
+				},
+			},
+		},
+		{
 			key:   "k",
 			iface: fmt.Errorf("failed: %w", errors.New("egad")),
 			want: map[string]any{


### PR DESCRIPTION
As of this PR, all `joinError` instances created by the `errors.Join()` method are now logged in a way similar to how `errorGroup` is logged. Previously, they were logged only as basic errors.