### PR TITLE
memory leak fix

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -142,5 +142,7 @@ func (b *Buffer) TrimNewline() {
 //
 // Callers must not retain references to the Buffer after calling Free.
 func (b *Buffer) Free() {
-	b.pool.put(b)
+	if len(b.bs) <= _size {
+		b.pool.put(b)
+	}
 }

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -142,7 +142,7 @@ func (b *Buffer) TrimNewline() {
 //
 // Callers must not retain references to the Buffer after calling Free.
 func (b *Buffer) Free() {
-	if len(b.bs) <= _size {
+	if len(b.bs) <= 4*_size {
 		b.pool.put(b)
 	}
 }


### PR DESCRIPTION
If buffer size is too large, do not put it back to sync.Pool, or finally all buffer in sync.Pool become large,then cause memory leak.