### PR TITLE
Add an option to disable errorVerbose

### DIFF
--- a/config.go
+++ b/config.go
@@ -91,6 +91,8 @@ type Config struct {
 	ErrorOutputPaths []string `json:"errorOutputPaths" yaml:"errorOutputPaths"`
 	// InitialFields is a collection of fields to add to the root logger.
 	InitialFields map[string]interface{} `json:"initialFields" yaml:"initialFields"`
+	// DisableVerbose stops printing error verbose in the error log.
+	DisableVerbose bool `json:"disableVerbose" yaml:"disableVerbose"`
 }
 
 // NewProductionEncoderConfig returns an opinionated EncoderConfig for
@@ -166,6 +168,7 @@ func NewProductionConfig() Config {
 		EncoderConfig:    NewProductionEncoderConfig(),
 		OutputPaths:      []string{"stderr"},
 		ErrorOutputPaths: []string{"stderr"},
+		DisableVerbose:   true,
 	}
 }
 
@@ -232,6 +235,7 @@ func NewDevelopmentConfig() Config {
 		EncoderConfig:    NewDevelopmentEncoderConfig(),
 		OutputPaths:      []string{"stderr"},
 		ErrorOutputPaths: []string{"stderr"},
+		DisableVerbose:   true,
 	}
 }
 
@@ -276,8 +280,13 @@ func (cfg Config) buildOptions(errSink zapcore.WriteSyncer) []Option {
 	if cfg.Development {
 		stackLevel = WarnLevel
 	}
+
 	if !cfg.DisableStacktrace {
 		opts = append(opts, AddStacktrace(stackLevel))
+	}
+
+	if cfg.DisableVerbose {
+		opts = append(opts, DisableVerbose())
 	}
 
 	if scfg := cfg.Sampling; scfg != nil {

--- a/logger.go
+++ b/logger.go
@@ -54,6 +54,8 @@ type Logger struct {
 	callerSkip int
 
 	clock zapcore.Clock
+
+	DisableVerbose bool
 }
 
 // New constructs a new Logger from the provided zapcore.Core and Options. If
@@ -260,6 +262,9 @@ func (log *Logger) Warn(msg string, fields ...Field) {
 // at the log site, as well as any fields accumulated on the logger.
 func (log *Logger) Error(msg string, fields ...Field) {
 	if ce := log.check(ErrorLevel, msg); ce != nil {
+		for i := range fields {
+			fields[i].DisableVerbose = log.DisableVerbose
+		}
 		ce.Write(fields...)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -184,3 +184,17 @@ func WithClock(clock zapcore.Clock) Option {
 		log.clock = clock
 	})
 }
+
+// WithDisableVerbose configures the Logger to turn off the error verbose or not,
+// depending on the value of disableVerbose. This is a generalized form of DisableVerbose.
+func WithDisableVerbose(disableVerbose bool) Option {
+	return optionFunc(func(log *Logger) {
+		log.DisableVerbose = disableVerbose
+	})
+}
+
+// DisableVerbose configures the Logger to turn off the error verbose.
+// See also WithDisableVerbose.
+func DisableVerbose() Option {
+	return WithDisableVerbose(true)
+}

--- a/zapcore/error.go
+++ b/zapcore/error.go
@@ -44,7 +44,7 @@ import (
 //	    ...
 //	  ],
 //	}
-func encodeError(key string, err error, enc ObjectEncoder) (retErr error) {
+func encodeError(key string, err error, enc ObjectEncoder, opts ...bool) (retErr error) {
 	// Try to capture panics (from nil references or otherwise) when calling
 	// the Error() method
 	defer func() {
@@ -68,8 +68,12 @@ func encodeError(key string, err error, enc ObjectEncoder) (retErr error) {
 	case errorGroup:
 		return enc.AddArray(key+"Causes", errArray(e.Errors()))
 	case fmt.Formatter:
+		disableVerbose := false
+		if len(opts) > 0 {
+			disableVerbose = opts[0]
+		}
 		verbose := fmt.Sprintf("%+v", e)
-		if verbose != basic {
+		if !disableVerbose && verbose != basic {
 			// This is a rich error type, like those produced by
 			// github.com/pkg/errors.
 			enc.AddString(key+"Verbose", verbose)

--- a/zapcore/error_test.go
+++ b/zapcore/error_test.go
@@ -79,20 +79,31 @@ func (e customMultierr) Errors() []error {
 
 func TestErrorEncoding(t *testing.T) {
 	tests := []struct {
-		key   string
-		iface any
-		want  map[string]any
+		key            string
+		iface          any
+		disableVerbose bool
+		want           map[string]any
 	}{
 		{
-			key:   "k",
-			iface: errTooManyUsers(2),
+			key:            "k",
+			iface:          errTooManyUsers(2),
+			disableVerbose: true,
 			want: map[string]any{
 				"k": "2 too many users",
 			},
 		},
 		{
-			key:   "k",
-			iface: errTooFewUsers(2),
+			key:            "k",
+			iface:          errTooFewUsers(2),
+			disableVerbose: true,
+			want: map[string]any{
+				"k": "2 too few users",
+			},
+		},
+		{
+			key:            "k",
+			iface:          errTooFewUsers(2),
+			disableVerbose: false,
 			want: map[string]any{
 				"k":        "2 too few users",
 				"kVerbose": "verbose: 2 too few users",
@@ -105,6 +116,7 @@ func TestErrorEncoding(t *testing.T) {
 				errors.New("bar"),
 				errors.New("baz"),
 			),
+			disableVerbose: true,
 			want: map[string]any{
 				"err": "foo; bar; baz",
 				"errCauses": []any{
@@ -115,8 +127,9 @@ func TestErrorEncoding(t *testing.T) {
 			},
 		},
 		{
-			key:   "e",
-			iface: customMultierr{},
+			key:            "e",
+			iface:          customMultierr{},
+			disableVerbose: true,
 			want: map[string]any{
 				"e": "great sadness",
 				"eCauses": []any{
@@ -132,8 +145,9 @@ func TestErrorEncoding(t *testing.T) {
 			},
 		},
 		{
-			key:   "k",
-			iface: fmt.Errorf("failed: %w", errors.New("egad")),
+			key:            "k",
+			iface:          fmt.Errorf("failed: %w", errors.New("egad")),
+			disableVerbose: true,
 			want: map[string]any{
 				"k": "failed: egad",
 			},
@@ -147,6 +161,7 @@ func TestErrorEncoding(t *testing.T) {
 				errors.New("baz"),
 				fmt.Errorf("world: %w", errors.New("qux")),
 			),
+			disableVerbose: true,
 			want: map[string]any{
 				"error": "hello: foo; bar; baz; world: qux",
 				"errorCauses": []any{
@@ -162,7 +177,7 @@ func TestErrorEncoding(t *testing.T) {
 
 	for _, tt := range tests {
 		enc := NewMapObjectEncoder()
-		f := Field{Key: tt.key, Type: ErrorType, Interface: tt.iface}
+		f := Field{Key: tt.key, Type: ErrorType, Interface: tt.iface, DisableVerbose: tt.disableVerbose}
 		f.AddTo(enc)
 		assert.Equal(t, tt.want, enc.Fields, "Unexpected output from field %+v.", f)
 	}

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -102,11 +102,12 @@ const (
 // context. Most fields are lazily marshaled, so it's inexpensive to add fields
 // to disabled debug-level log statements.
 type Field struct {
-	Key       string
-	Type      FieldType
-	Integer   int64
-	String    string
-	Interface interface{}
+	Key            string
+	Type           FieldType
+	Integer        int64
+	String         string
+	Interface      interface{}
+	DisableVerbose bool
 }
 
 // AddTo exports a field through the ObjectEncoder interface. It's primarily
@@ -173,7 +174,7 @@ func (f Field) AddTo(enc ObjectEncoder) {
 	case StringerType:
 		err = encodeStringer(f.Key, f.Interface, enc)
 	case ErrorType:
-		err = encodeError(f.Key, f.Interface.(error), enc)
+		err = encodeError(f.Key, f.Interface.(error), enc, f.DisableVerbose)
 	case SkipType:
 		break
 	default:


### PR DESCRIPTION
This PR adds `disableVerbose` option to `Logger` type.

This option allows users to disable the output of error verbose when they use pkg/errors, which enables simpler logging and provides clearer understanding of the current situation in their applications, especially in their production environments.

Closes #650 #1168