### PR TITLE
Improve code quality by removing a potential nil panic

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -343,6 +343,13 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 	ce := log.core.Check(ent, nil)
 	willWrite := ce != nil
 
+	// Only do further annotation if we're going to write this message; checked
+	// entries that exist only for terminal behavior don't benefit from
+	// annotation.
+	if !willWrite {
+		return ce
+	}
+
 	// Set up any required terminal behavior.
 	switch ent.Level {
 	case zapcore.PanicLevel:
@@ -353,13 +360,6 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 		if log.development {
 			ce = ce.After(ent, terminalHookOverride(zapcore.WriteThenPanic, log.onPanic))
 		}
-	}
-
-	// Only do further annotation if we're going to write this message; checked
-	// entries that exist only for terminal behavior don't benefit from
-	// annotation.
-	if !willWrite {
-		return ce
 	}
 
 	// Thread the error output through to the CheckedEntry.


### PR DESCRIPTION
Dear developers,

In the [`Logger.check`](https://github.com/uber-go/zap/blob/6d482535bdd97f4d97b2f9573ac308f1cf9b574e/logger.go#L322) function, the result of `log.core.Check(ent, nil)` is assigned to `ce` and later used in a [switch block](https://github.com/uber-go/zap/blob/6d482535bdd97f4d97b2f9573ac308f1cf9b574e/logger.go#L347) that may call methods on `ce` (e.g., `ce.After(...)`) without ensuring it is non-nil. This can lead to a nil pointer dereference panic if the implementation of `Check` returns nil.

Although the current code checks whether `ce != nil` holds at line 361 [(Link)](https://github.com/uber-go/zap/blob/6d482535bdd97f4d97b2f9573ac308f1cf9b574e/logger.go#L361C2-L361C17), the check occurs too late. I think the original purpose of introducing the `!willWrite` check should be to avoid the nil pointer dereference panic, but it was mistakenly placed in the wrong location in the program.

We have provided a patch for your reference. With this patch, the code would be more reliable than the original one. We hope our effort helps improve your code quality.


