### PR TITLE
Prevent zap.Object from panicing on nils

### DIFF
--- a/benchmarks/zap_test.go
+++ b/benchmarks/zap_test.go
@@ -134,6 +134,7 @@ func fakeFields() []zap.Field {
 		zap.Times("times", _tenTimes),
 		zap.Object("user1", _oneUser),
 		zap.Object("user2", _oneUser),
+		zap.Object("user3", nil),
 		zap.Array("users", _tenUsers),
 		zap.Error(errExample),
 	}

--- a/field.go
+++ b/field.go
@@ -398,6 +398,9 @@ func Durationp(key string, val *time.Duration) Field {
 // struct-like user-defined types to the logging context. The struct's
 // MarshalLogObject method is called lazily.
 func Object(key string, val zapcore.ObjectMarshaler) Field {
+	if val == nil {
+		return nilField(key)
+	}
 	return Field{Key: key, Type: zapcore.ObjectMarshalerType, Interface: val}
 }
 

--- a/field_test.go
+++ b/field_test.go
@@ -253,6 +253,7 @@ func TestFieldConstructors(t *testing.T) {
 		{"Any:PtrUintptr", Any("k", &uintptrVal), Uintptr("k", uintptrVal)},
 		{"Any:ErrorNil", Any("k", nilErr), nilField("k")},
 		{"Namespace", Namespace("k"), Field{Key: "k", Type: zapcore.NamespaceType}},
+		{"Object:Nil", Object("k", nil), nilField("k")},
 	}
 
 	for _, tt := range tests {

--- a/zapcore/field_test.go
+++ b/zapcore/field_test.go
@@ -158,6 +158,7 @@ func TestFields(t *testing.T) {
 		{t: Uint8Type, i: 42, want: uint8(42)},
 		{t: UintptrType, i: 42, want: uintptr(42)},
 		{t: ReflectType, iface: users(2), want: users(2)},
+		{t: ReflectType, iface: nil, want: nil},
 		{t: NamespaceType, want: map[string]interface{}{}},
 		{t: StringerType, iface: users(2), want: "2 users"},
 		{t: StringerType, iface: &obj{}, want: "obj"},
@@ -328,6 +329,16 @@ func TestEquals(t *testing.T) {
 		{
 			a:    zap.Object("k", zap.DictObject(zap.String("a", "b"))),
 			b:    zap.Object("k", zap.DictObject(zap.String("a", "d"))),
+			want: false,
+		},
+		{
+			a:    zap.Object("k", nil),
+			b:    zap.Object("k", nil),
+			want: true,
+		},
+		{
+			a:    zap.Object("k", users(10)),
+			b:    zap.Object("k", nil),
 			want: false,
 		},
 	}


### PR DESCRIPTION
It is possible to call zap.Object with nil or nil interface This will cause panic in zap bringing down the app using it

The standard way of handling this is via nilField - compare all the constructors on pointers. As interfaces are similar to pointers - lets handle this case the same way

Add tests in zapcore for equality on zap.Object(nil) Show ReflectType does not panic on nils
Add test that zap.Object(nil) works

Update benchmarks and use such a field to show performance and allocation are not affected excessively

Refs #1500