### PR TITLE
Update zaptest.Logger to use t.Helper()

### DIFF
--- a/zaptest/logger.go
+++ b/zaptest/logger.go
@@ -137,6 +137,7 @@ func (w TestingWriter) WithMarkFailed(v bool) TestingWriter {
 
 // Write writes bytes from p to the underlying testing.TB.
 func (w TestingWriter) Write(p []byte) (n int, err error) {
+	w.t.Helper()
 	n = len(p)
 
 	// Strip trailing newline because t.Log always adds one.

--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -146,6 +146,10 @@ type testLogSpy struct {
 	Messages []string
 }
 
+func (t *testLogSpy) Helper() {
+	t.TB.Helper()
+}
+
 func newTestLogSpy(t testing.TB) *testLogSpy {
 	return &testLogSpy{TB: t}
 }

--- a/zaptest/testingt.go
+++ b/zaptest/testingt.go
@@ -40,6 +40,10 @@ type TestingT interface {
 
 	// Marks the test as failed and stops execution of that test.
 	FailNow()
+
+	// Helper marks the calling function as a test helper function.
+	// When printing file and line information, that function will be skipped.
+	Helper()
 }
 
 // Note: We currently only rely on Logf. We are including Errorf and FailNow


### PR DESCRIPTION
This provided more meaningful logging location information.