### PR TITLE
Implement leveledEnabler for zapcore.nopCore

### DIFF
--- a/zapcore/core.go
+++ b/zapcore/core.go
@@ -46,6 +46,11 @@ type Core interface {
 
 type nopCore struct{}
 
+var (
+	_ Core           = nopCore{}
+	_ leveledEnabler = nopCore{}
+)
+
 // NewNopCore returns a no-op Core.
 func NewNopCore() Core                                        { return nopCore{} }
 func (nopCore) Enabled(Level) bool                            { return false }
@@ -53,6 +58,7 @@ func (n nopCore) With([]Field) Core                           { return n }
 func (nopCore) Check(_ Entry, ce *CheckedEntry) *CheckedEntry { return ce }
 func (nopCore) Write(Entry, []Field) error                    { return nil }
 func (nopCore) Sync() error                                   { return nil }
+func (nopCore) Level() Level                                  { return InvalidLevel }
 
 // NewCore creates a Core that writes logs to a WriteSyncer.
 func NewCore(enc Encoder, ws WriteSyncer, enab LevelEnabler) Core {


### PR DESCRIPTION
When `zapcore.LevelOf` is called with a `zapcore.nopCore{}`, it does one type assertion to determine that it doesn't implement `leveledEnabler`, then it calls `Enabled` 6 times on it before returning `InvalidLevel`. By implementing `leveledEnabler` and making it return `InvalidLevel`, we can greatly decrease the cost of calling `zapcore.LevelOf` on nop cores.