### PR TITLE
fix(zaptest): remove irrelevant caller info from TestingWriter

### DIFF
--- a/zaptest/logger.go
+++ b/zaptest/logger.go
@@ -21,8 +21,6 @@
 package zaptest
 
 import (
-	"bytes"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -139,11 +137,10 @@ func (w TestingWriter) WithMarkFailed(v bool) TestingWriter {
 func (w TestingWriter) Write(p []byte) (n int, err error) {
 	n = len(p)
 
-	// Strip trailing newline because t.Log always adds one.
-	p = bytes.TrimRight(p, "\n")
-
-	// Note: t.Log is safe for concurrent use.
-	w.t.Logf("%s", p)
+	_, err = w.t.Output().Write(p)
+	if err != nil {
+		return 0, err
+	}
 	if w.markFailed {
 		w.t.Fail()
 	}

--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -21,6 +21,7 @@
 package zaptest
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -96,11 +97,11 @@ func TestTestLoggerSupportsWrappedZapOptions(t *testing.T) {
 	}, "log.Panic should panic")
 
 	ts.AssertMessages(
-		`INFO	zaptest/logger_test.go:89	received work order	{"k1": "v1"}`,
-		`DEBUG	zaptest/logger_test.go:90	starting work	{"k1": "v1"}`,
-		`WARN	zaptest/logger_test.go:91	work may fail	{"k1": "v1"}`,
-		`ERROR	zaptest/logger_test.go:92	work failed	{"k1": "v1", "error": "great sadness"}`,
-		`PANIC	zaptest/logger_test.go:95	failed to do work	{"k1": "v1"}`,
+		`INFO	zaptest/logger_test.go:90	received work order	{"k1": "v1"}`,
+		`DEBUG	zaptest/logger_test.go:91	starting work	{"k1": "v1"}`,
+		`WARN	zaptest/logger_test.go:92	work may fail	{"k1": "v1"}`,
+		`ERROR	zaptest/logger_test.go:93	work failed	{"k1": "v1", "error": "great sadness"}`,
+		`PANIC	zaptest/logger_test.go:96	failed to do work	{"k1": "v1"}`,
 	)
 }
 
@@ -174,6 +175,17 @@ func (t *testLogSpy) Logf(format string, args ...interface{}) {
 	m = m[strings.IndexByte(m, '\t')+1:]
 	t.Messages = append(t.Messages, m)
 	t.TB.Log(m)
+}
+
+func (t *testLogSpy) Output() io.Writer {
+	return t
+}
+
+func (t *testLogSpy) Write(p []byte) (n int, err error) {
+	m := string(p[bytes.IndexByte(p, '\t')+1:])
+	m = strings.TrimSuffix(m, "\n")
+	t.Messages = append(t.Messages, m)
+	return t.TB.Output().Write(p)
 }
 
 func (t *testLogSpy) AssertMessages(msgs ...string) {

--- a/zaptest/testingt.go
+++ b/zaptest/testingt.go
@@ -20,6 +20,8 @@
 
 package zaptest
 
+import "io"
+
 // TestingT is a subset of the API provided by all *testing.T and *testing.B
 // objects.
 type TestingT interface {
@@ -40,6 +42,9 @@ type TestingT interface {
 
 	// Marks the test as failed and stops execution of that test.
 	FailNow()
+
+	// Output returns a Writer that writes to the test output stream.
+	Output() io.Writer
 }
 
 // Note: We currently only rely on Logf. We are including Errorf and FailNow


### PR DESCRIPTION
Remove irrelevant caller info from `zaptest.TestingWriter` logs by using testing.TB output stream directly.

Fixes: https://github.com/uber-go/zap/issues/1493. Probably related to https://github.com/uber-go/zap/pull/1512.

**Example**

```go
package zaptest

import (
	"testing"

	"go.uber.org/zap/zaptest"
)

func TestLogger(t *testing.T) {
	logger := zaptest.NewLogger(t)
	logger.Info("Hello, World!")
}
```

Before:
```
❯ go test -v ./...
=== RUN   TestLogger
    logger.go:146: 2026-02-11T19:03:39.937+0300	INFO	Hello, World!
--- PASS: TestLogger (0.00s)
PASS
```

After:
```
❯ go test -v ./...
=== RUN   TestLogger
    2026-02-11T19:02:04.048+0300	INFO	Hello, World!
--- PASS: TestLogger (0.00s)
PASS
```