### PR TITLE
zapcore: recover panics from ObjectMarshaler and ArrayMarshaler (#1504)

### DIFF
--- a/zapcore/field_test.go
+++ b/zapcore/field_test.go
@@ -94,6 +94,20 @@ func (eobj *errObj) Error() string {
 	return eobj.errMsg
 }
 
+// panickyObject panics inside MarshalLogObject.
+type panickyObject struct{}
+
+func (p panickyObject) MarshalLogObject(enc ObjectEncoder) error {
+	panic("panic in MarshalLogObject")
+}
+
+// panickyArray panics inside MarshalLogArray.
+type panickyArray struct{}
+
+func (p panickyArray) MarshalLogArray(enc ArrayEncoder) error {
+	panic("panic in MarshalLogArray")
+}
+
 func TestUnknownFieldType(t *testing.T) {
 	unknown := Field{Key: "k", String: "foo"}
 	assert.Equal(t, UnknownType, unknown.Type, "Expected zero value of FieldType to be UnknownType.")
@@ -118,6 +132,9 @@ func TestFieldAddingError(t *testing.T) {
 		{t: StringerType, iface: &obj{2}, want: empty, err: "PANIC=panic with error"},
 		{t: StringerType, iface: &obj{3}, want: empty, err: "PANIC=<nil>"},
 		{t: ErrorType, iface: &errObj{kind: 1}, want: empty, err: "PANIC=panic in Error() method"},
+		{t: ObjectMarshalerType, iface: panickyObject{}, want: map[string]interface{}{}, err: "PANIC=panic in MarshalLogObject"},
+		{t: ArrayMarshalerType, iface: panickyArray{}, want: nil, err: "PANIC=panic in MarshalLogArray"},
+		{t: InlineMarshalerType, iface: panickyObject{}, want: nil, err: "PANIC=panic in MarshalLogObject"},
 	}
 	for _, tt := range tests {
 		f := Field{Key: "k", Interface: tt.iface, Type: tt.t}


### PR DESCRIPTION
Fixes #1504

## Problem

Panics in user-provided `MarshalLogObject` and `MarshalLogArray` implementations crash the entire application. This is inconsistent with the existing panic recovery for `Stringer` (`encodeStringer`) and `Error` types, which gracefully convert panics to `PANIC=<msg>` error entries.

## Fix

Added three panic-recovering wrapper functions (`encodeObject`, `encodeArray`, `encodeInlinedObject`) that mirror the existing `encodeStringer` pattern. These wrap the calls to `enc.AddObject`, `enc.AddArray`, and `obj.MarshalLogObject` respectively, converting any panic to a `PANIC=<msg>` error that gets logged as a `<key>Error` field.

Affected field types:
- `ObjectMarshalerType`
- `ArrayMarshalerType`  
- `InlineMarshalerType`

## Test

Added `panickyObject` and `panickyArray` test types plus 3 new test cases to `TestFieldAddingError` that verify:
- A panicking `ObjectMarshaler` does not crash, produces `PANIC=panic in MarshalLogObject`
- A panicking `ArrayMarshaler` does not crash, produces `PANIC=panic in MarshalLogArray`
- A panicking inlined `ObjectMarshaler` does not crash, produces `PANIC=panic in MarshalLogObject`

Full test suite passes on macOS ARM (Apple Silicon).