### PR TITLE
Use colored log levels in development config

### DIFF
--- a/config.go
+++ b/config.go
@@ -176,7 +176,7 @@ func NewProductionConfig() Config {
 // intended to print human-readable output.
 // It will print log messages with the following information:
 //
-//   - The log level (e.g. "INFO", "ERROR").
+//   - The log level (e.g. "INFO", "ERROR"), colored for better readability.
 //   - The time in ISO8601 format (e.g. "2017-01-01T12:00:00Z").
 //   - The message passed to the log statement.
 //   - If available, a short path to the file and line number
@@ -208,7 +208,7 @@ func NewDevelopmentEncoderConfig() zapcore.EncoderConfig {
 		MessageKey:     "M",
 		StacktraceKey:  "S",
 		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeLevel:    zapcore.CapitalLevelEncoder,
+		EncodeLevel:    zapcore.CapitalColorLevelEncoder,
 		EncodeTime:     zapcore.ISO8601TimeEncoder,
 		EncodeDuration: zapcore.StringDurationEncoder,
 		EncodeCaller:   zapcore.ShortCallerEncoder,
@@ -218,6 +218,7 @@ func NewDevelopmentEncoderConfig() zapcore.EncoderConfig {
 // NewDevelopmentConfig builds a reasonable default development logging
 // configuration.
 // Logging is enabled at DebugLevel and above, and uses a console encoder.
+// Log levels are colored for better readability in a terminal.
 // Logs are written to standard error.
 // Stacktraces are included on logs of WarnLevel and above.
 // DPanicLevel logs will panic.

--- a/config_test.go
+++ b/config_test.go
@@ -49,9 +49,9 @@ func TestConfig(t *testing.T) {
 			desc:    "development",
 			cfg:     NewDevelopmentConfig(),
 			expectN: 3 + 200, // 3 initial logs, all 200 subsequent logs
-			expectRe: "DEBUG\t[a-z0-9_-]+/config_test.go:" + `\d+` + "\tdebug\t" + `{"k": "v", "z": "zz"}` + "\n" +
-				"INFO\t[a-z0-9_-]+/config_test.go:" + `\d+` + "\tinfo\t" + `{"k": "v", "z": "zz"}` + "\n" +
-				"WARN\t[a-z0-9_-]+/config_test.go:" + `\d+` + "\twarn\t" + `{"k": "v", "z": "zz"}` + "\n" +
+			expectRe: "\x1b\\[35mDEBUG\x1b\\[0m\t[a-z0-9_-]+/config_test.go:" + `\d+` + "\tdebug\t" + `{"k": "v", "z": "zz"}` + "\n" +
+				"\x1b\\[34mINFO\x1b\\[0m\t[a-z0-9_-]+/config_test.go:" + `\d+` + "\tinfo\t" + `{"k": "v", "z": "zz"}` + "\n" +
+				"\x1b\\[33mWARN\x1b\\[0m\t[a-z0-9_-]+/config_test.go:" + `\d+` + "\twarn\t" + `{"k": "v", "z": "zz"}` + "\n" +
 				`go.uber.org/zap.TestConfig.\w+`,
 		},
 	}

--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -50,11 +50,11 @@ func TestTestLogger(t *testing.T) {
 	}, "log.Panic should panic")
 
 	ts.AssertMessages(
-		"INFO	received work order",
-		"DEBUG	starting work",
-		"WARN	work may fail",
-		`ERROR	work failed	{"error": "great sadness"}`,
-		"PANIC	failed to do work",
+		"\x1b[34mINFO\x1b[0m	received work order",
+		"\x1b[35mDEBUG\x1b[0m	starting work",
+		"\x1b[33mWARN\x1b[0m	work may fail",
+		"\x1b[31mERROR\x1b[0m	work failed\t{\"error\": \"great sadness\"}",
+		"\x1b[31mPANIC\x1b[0m	failed to do work",
 	)
 }
 
@@ -74,9 +74,9 @@ func TestTestLoggerSupportsLevels(t *testing.T) {
 	}, "log.Panic should panic")
 
 	ts.AssertMessages(
-		"WARN	work may fail",
-		`ERROR	work failed	{"error": "great sadness"}`,
-		"PANIC	failed to do work",
+		"\x1b[33mWARN\x1b[0m	work may fail",
+		"\x1b[31mERROR\x1b[0m	work failed\t{\"error\": \"great sadness\"}",
+		"\x1b[31mPANIC\x1b[0m	failed to do work",
 	)
 }
 
@@ -96,11 +96,11 @@ func TestTestLoggerSupportsWrappedZapOptions(t *testing.T) {
 	}, "log.Panic should panic")
 
 	ts.AssertMessages(
-		`INFO	zaptest/logger_test.go:89	received work order	{"k1": "v1"}`,
-		`DEBUG	zaptest/logger_test.go:90	starting work	{"k1": "v1"}`,
-		`WARN	zaptest/logger_test.go:91	work may fail	{"k1": "v1"}`,
-		`ERROR	zaptest/logger_test.go:92	work failed	{"k1": "v1", "error": "great sadness"}`,
-		`PANIC	zaptest/logger_test.go:95	failed to do work	{"k1": "v1"}`,
+		"\x1b[34mINFO\x1b[0m\tzaptest/logger_test.go:89\treceived work order\t{\"k1\": \"v1\"}",
+		"\x1b[35mDEBUG\x1b[0m\tzaptest/logger_test.go:90\tstarting work\t{\"k1\": \"v1\"}",
+		"\x1b[33mWARN\x1b[0m\tzaptest/logger_test.go:91\twork may fail\t{\"k1\": \"v1\"}",
+		"\x1b[31mERROR\x1b[0m\tzaptest/logger_test.go:92\twork failed\t{\"k1\": \"v1\", \"error\": \"great sadness\"}",
+		"\x1b[31mPANIC\x1b[0m\tzaptest/logger_test.go:95\tfailed to do work\t{\"k1\": \"v1\"}",
 	)
 }
 


### PR DESCRIPTION
## Summary
- Changes `NewDevelopmentEncoderConfig` to use `CapitalColorLevelEncoder` instead of `CapitalLevelEncoder`, enabling ANSI-colored log level output in the development configuration
- Log levels are now visually distinct in terminal output: Debug (magenta), Info (blue), Warn (yellow), Error/DPanic/Panic/Fatal (red)
- Updates tests in `config_test.go` and `zaptest/logger_test.go` to expect colored level strings

Fixes #489

## Details

The development configuration is designed for human-readable console output. By using the already-existing `CapitalColorLevelEncoder` (which was available but not used by default), log lines become much easier to scan visually. Users who prefer uncolored output can still override this by setting `EncodeLevel` to `CapitalLevelEncoder` on the encoder config.

The color codes used per level:
- **DEBUG**: Magenta (`\x1b[35m`)
- **INFO**: Blue (`\x1b[34m`)
- **WARN**: Yellow (`\x1b[33m`)
- **ERROR/DPANIC/PANIC/FATAL**: Red (`\x1b[31m`)

## Test plan
- [x] Updated regex expectations in `TestConfig` for development config output
- [x] Updated string expectations in `zaptest/logger_test.go` for `TestTestLogger`, `TestTestLoggerSupportsLevels`, and `TestTestLoggerSupportsWrappedZapOptions`
- [x] All tests pass: `go test ./... -count=1`