### PR TITLE
zapcore: fix CheckWriteHook godoc example signature

### DIFF
--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -155,7 +155,7 @@ type Entry struct {
 // Register one on a CheckedEntry with the After method.
 //
 //	if ce := logger.Check(...); ce != nil {
-//	  ce = ce.After(hook)
+//	  ce = ce.After(ent, hook)
 //	  ce.Write(...)
 //	}
 //


### PR DESCRIPTION

**Repo:** uber-go/zap (⭐ 22000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Fixes the example in the `CheckWriteHook` doc comment in `zapcore/entry.go`. The example showed `ce = ce.After(hook)` but the actual `(*CheckedEntry).After` method signature requires an `Entry` argument first: `After(ent Entry, hook CheckWriteHook)`. The example now matches the real API.

## Why
Godoc examples are the first thing users see when integrating with a public API. Showing a call that won't compile is misleading and erodes trust in the documentation. All other call sites in the package (including tests at `zapcore/entry_test.go:114-137`) use the two-argument form.

## Testing
Pure documentation change inside a comment block, no behavior affected. Verified the corrected example matches the actual `After` signature at `zapcore/entry.go:331` and the usage pattern in `entry_test.go`.

## Risk
Low — comment-only change.
