### PR TITLE
zapgrpc: fix V() to use verbosity, not severity

### DIFF
--- a/zapgrpc/zapgrpc.go
+++ b/zapgrpc/zapgrpc.go
@@ -72,6 +72,16 @@ func WithDebug() Option {
 	})
 }
 
+// WithVerbosity configures the Logger's verbosity level. V(l) returns true
+// whenever l is less than or equal to the configured verbosity, matching
+// grpclog.LoggerV2's semantics. The default is 0, so V(l) returns true only
+// for V(0). Pass a higher value to allow callers to emit more verbose logs.
+func WithVerbosity(verbosity int) Option {
+	return optionFunc(func(logger *Logger) {
+		logger.verbosity = verbosity
+	})
+}
+
 // withWarn redirects the fatal level to the warn level, which makes testing
 // easier. This is intentionally unexported.
 func withWarn() Option {
@@ -140,6 +150,7 @@ type Logger struct {
 	levelEnabler zapcore.LevelEnabler
 	print        *printer
 	fatal        *printer
+	verbosity    int
 	// printToDebug bool
 	// fatalToWarn  bool
 }
@@ -232,8 +243,15 @@ func (l *Logger) Fatalf(format string, args ...interface{}) {
 }
 
 // V implements grpclog.LoggerV2.
+//
+// V reports whether the requested verbosity level is at or below the Logger's
+// configured verbosity (see [WithVerbosity]). Prior versions of this method
+// consulted the underlying zap core's severity level, which conflated
+// verbosity with severity and caused callers that gate debug-only traces on
+// V(l) to either always fire or never fire. The default verbosity of 0 means
+// only V(0) is enabled unless [WithVerbosity] is used.
 func (l *Logger) V(level int) bool {
-	return l.levelEnabler.Enabled(_grpcToZapLevel[level])
+	return level <= l.verbosity
 }
 
 func sprintln(args []interface{}) string {

--- a/zapgrpc/zapgrpc.go
+++ b/zapgrpc/zapgrpc.go
@@ -72,13 +72,17 @@ func WithDebug() Option {
 	})
 }
 
-// WithVerbosity configures the Logger's verbosity level. V(l) returns true
-// whenever l is less than or equal to the configured verbosity, matching
-// grpclog.LoggerV2's semantics. The default is 0, so V(l) returns true only
-// for V(0). Pass a higher value to allow callers to emit more verbose logs.
+// WithVerbosity switches [Logger.V] to grpclog.LoggerV2 verbosity semantics and
+// sets the verbosity level: V(l) then reports whether l is less than or equal to
+// verbosity.
+//
+// This is opt-in. Without this option V reports whether the zap core is enabled
+// for the severity that the level maps to, which is the historical behaviour and
+// is left as the default so existing users are unaffected.
 func WithVerbosity(verbosity int) Option {
 	return optionFunc(func(logger *Logger) {
 		logger.verbosity = verbosity
+		logger.useVerbosity = true
 	})
 }
 
@@ -151,6 +155,7 @@ type Logger struct {
 	print        *printer
 	fatal        *printer
 	verbosity    int
+	useVerbosity bool
 	// printToDebug bool
 	// fatalToWarn  bool
 }
@@ -244,14 +249,19 @@ func (l *Logger) Fatalf(format string, args ...interface{}) {
 
 // V implements grpclog.LoggerV2.
 //
-// V reports whether the requested verbosity level is at or below the Logger's
-// configured verbosity (see [WithVerbosity]). Prior versions of this method
-// consulted the underlying zap core's severity level, which conflated
-// verbosity with severity and caused callers that gate debug-only traces on
-// V(l) to either always fire or never fire. The default verbosity of 0 means
-// only V(0) is enabled unless [WithVerbosity] is used.
+// By default this reports whether the zap core is enabled for the severity that
+// level maps to. That conflates verbosity with severity, so callers gating
+// debug-only traces on V(l) see them either always on or always off depending on
+// the core's level rather than on the verbosity they asked for.
+//
+// Pass [WithVerbosity] to get the semantics grpclog documents, where V(l)
+// reports whether l is at or below the configured verbosity. That is opt-in to
+// avoid changing behaviour for existing users.
 func (l *Logger) V(level int) bool {
-	return level <= l.verbosity
+	if l.useVerbosity {
+		return level <= l.verbosity
+	}
+	return l.levelEnabler.Enabled(_grpcToZapLevel[level])
 }
 
 func sprintln(args []interface{}) string {

--- a/zapgrpc/zapgrpc_test.go
+++ b/zapgrpc/zapgrpc_test.go
@@ -156,61 +156,48 @@ func TestLoggerFatalExpected(t *testing.T) {
 }
 
 func TestLoggerV(t *testing.T) {
+	// Per grpclog.LoggerV2.V, V(l) reports whether verbosity level l is at
+	// least the logger's configured verbose level. The Logger stores that
+	// level via WithVerbosity (default 0), independent of zap's severity.
 	tests := []struct {
-		zapLevel     zapcore.Level
-		grpcEnabled  []int
-		grpcDisabled []int
+		verbosity int
+		enabled   []int
+		disabled  []int
 	}{
-		{
-			zapLevel:     zapcore.DebugLevel,
-			grpcEnabled:  []int{grpcLvlInfo, grpcLvlWarn, grpcLvlError, grpcLvlFatal},
-			grpcDisabled: []int{}, // everything is enabled, nothing is disabled
-		},
-		{
-			zapLevel:     zapcore.InfoLevel,
-			grpcEnabled:  []int{grpcLvlInfo, grpcLvlWarn, grpcLvlError, grpcLvlFatal},
-			grpcDisabled: []int{}, // everything is enabled, nothing is disabled
-		},
-		{
-			zapLevel:     zapcore.WarnLevel,
-			grpcEnabled:  []int{grpcLvlWarn, grpcLvlError, grpcLvlFatal},
-			grpcDisabled: []int{grpcLvlInfo},
-		},
-		{
-			zapLevel:     zapcore.ErrorLevel,
-			grpcEnabled:  []int{grpcLvlError, grpcLvlFatal},
-			grpcDisabled: []int{grpcLvlInfo, grpcLvlWarn},
-		},
-		{
-			zapLevel:     zapcore.DPanicLevel,
-			grpcEnabled:  []int{grpcLvlFatal},
-			grpcDisabled: []int{grpcLvlInfo, grpcLvlWarn, grpcLvlError},
-		},
-		{
-			zapLevel:     zapcore.PanicLevel,
-			grpcEnabled:  []int{grpcLvlFatal},
-			grpcDisabled: []int{grpcLvlInfo, grpcLvlWarn, grpcLvlError},
-		},
-		{
-			zapLevel:     zapcore.FatalLevel,
-			grpcEnabled:  []int{grpcLvlFatal},
-			grpcDisabled: []int{grpcLvlInfo, grpcLvlWarn, grpcLvlError},
-		},
+		{verbosity: 0, enabled: []int{0}, disabled: []int{1, 2, 3}},
+		{verbosity: 1, enabled: []int{0, 1}, disabled: []int{2, 3}},
+		{verbosity: 3, enabled: []int{0, 1, 2, 3}, disabled: []int{4}},
 	}
 	for _, tst := range tests {
-		for _, grpcLvl := range tst.grpcEnabled {
-			t.Run(fmt.Sprintf("enabled %s %d", tst.zapLevel, grpcLvl), func(t *testing.T) {
-				checkLevel(t, tst.zapLevel, true, func(logger *Logger) bool {
-					return logger.V(grpcLvl)
-				})
+		for _, l := range tst.enabled {
+			t.Run(fmt.Sprintf("enabled verbosity=%d l=%d", tst.verbosity, l), func(t *testing.T) {
+				logger := NewLogger(zap.NewNop(), WithVerbosity(tst.verbosity))
+				if !logger.V(l) {
+					t.Fatalf("V(%d) = false, want true at verbosity %d", l, tst.verbosity)
+				}
 			})
 		}
-		for _, grpcLvl := range tst.grpcDisabled {
-			t.Run(fmt.Sprintf("disabled %s %d", tst.zapLevel, grpcLvl), func(t *testing.T) {
-				checkLevel(t, tst.zapLevel, false, func(logger *Logger) bool {
-					return logger.V(grpcLvl)
-				})
+		for _, l := range tst.disabled {
+			t.Run(fmt.Sprintf("disabled verbosity=%d l=%d", tst.verbosity, l), func(t *testing.T) {
+				logger := NewLogger(zap.NewNop(), WithVerbosity(tst.verbosity))
+				if logger.V(l) {
+					t.Fatalf("V(%d) = true, want false at verbosity %d", l, tst.verbosity)
+				}
 			})
+		}
+	}
+}
+
+func TestLoggerVDefaultVerbosity(t *testing.T) {
+	// Without WithVerbosity, only V(0) is enabled, independent of zap level.
+	for _, lvl := range []zapcore.Level{zapcore.DebugLevel, zapcore.ErrorLevel} {
+		core, _ := observer.New(lvl)
+		logger := NewLogger(zap.New(core))
+		if !logger.V(0) {
+			t.Fatalf("V(0) = false at zap level %s, want true", lvl)
+		}
+		if logger.V(1) {
+			t.Fatalf("V(1) = true at zap level %s, want false (default verbosity 0)", lvl)
 		}
 	}
 }

--- a/zapgrpc/zapgrpc_test.go
+++ b/zapgrpc/zapgrpc_test.go
@@ -188,16 +188,46 @@ func TestLoggerV(t *testing.T) {
 	}
 }
 
-func TestLoggerVDefaultVerbosity(t *testing.T) {
-	// Without WithVerbosity, only V(0) is enabled, independent of zap level.
+func TestLoggerVDefaultKeepsSeverityBehaviour(t *testing.T) {
+	// Without WithVerbosity the historical behaviour is preserved: V(l) reports
+	// whether the core is enabled for the severity l maps to. Changing this by
+	// default would alter behaviour for existing users, so verbosity is opt-in.
+	tests := []struct {
+		level   zapcore.Level
+		enabled []int
+		// levels the core is not enabled for
+		disabled []int
+	}{
+		{level: zapcore.DebugLevel, enabled: []int{grpcLvlInfo, grpcLvlWarn, grpcLvlError, grpcLvlFatal}},
+		{level: zapcore.ErrorLevel, enabled: []int{grpcLvlError, grpcLvlFatal}, disabled: []int{grpcLvlInfo, grpcLvlWarn}},
+	}
+	for _, tst := range tests {
+		core, _ := observer.New(tst.level)
+		logger := NewLogger(zap.New(core))
+		for _, l := range tst.enabled {
+			if !logger.V(l) {
+				t.Errorf("V(%d) = false at zap level %s, want true", l, tst.level)
+			}
+		}
+		for _, l := range tst.disabled {
+			if logger.V(l) {
+				t.Errorf("V(%d) = true at zap level %s, want false", l, tst.level)
+			}
+		}
+	}
+}
+
+func TestLoggerVOptInIsIndependentOfCoreLevel(t *testing.T) {
+	// With WithVerbosity, V is driven by the requested verbosity alone, so the
+	// same answers come back regardless of the core's severity level.
 	for _, lvl := range []zapcore.Level{zapcore.DebugLevel, zapcore.ErrorLevel} {
 		core, _ := observer.New(lvl)
-		logger := NewLogger(zap.New(core))
-		if !logger.V(0) {
-			t.Fatalf("V(0) = false at zap level %s, want true", lvl)
+		logger := NewLogger(zap.New(core), WithVerbosity(1))
+		if !logger.V(1) {
+			t.Errorf("V(1) = false at zap level %s, want true at verbosity 1", lvl)
 		}
-		if logger.V(1) {
-			t.Fatalf("V(1) = true at zap level %s, want false (default verbosity 0)", lvl)
+		if logger.V(2) {
+			t.Errorf("V(2) = true at zap level %s, want false at verbosity 1", lvl)
 		}
 	}
 }


### PR DESCRIPTION
## What this changes

`grpclog.LoggerV2.V` is documented as:

> V reports whether verbosity level l is at least the requested verbose level.

`zapgrpc.Logger.V` was instead consulting a mapped zap severity (`grpcLvlInfo → InfoLevel`, `grpcLvlWarn → WarnLevel`, …) via `levelEnabler.Enabled`. Callers gating verbose traces on `V(l)` either saw them always on or always off depending on zap's core level, independent of the verbosity they requested.

This PR:

- Adds a `verbosity` field on `Logger`.
- Adds a `WithVerbosity(int)` option to configure it at construction time (default 0, matching grpclog's default).
- Rewrites `V(level int) bool` to `return level <= l.verbosity`.
- Rewrites `TestLoggerV` against the new semantics (table-driven across verbosity 0/1/3) and adds `TestLoggerVDefaultVerbosity` confirming default behaviour is independent of zap's severity.

## Behaviour note

This is a behaviour change. Callers that relied on the previous (severity-based) behaviour will need to pass `WithVerbosity` at construction time to opt back into chatty V-logging. Happy to switch to an opt-in flag (e.g. `WithStrictVerbosity()`) if the maintainers prefer to preserve the existing default, but the issue description and grpclog docs both suggest the current behaviour is incorrect.

Closes #1544