### PR TITLE
docs: clarify zapcore Entry documentation

### DIFF
--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -133,13 +133,12 @@ func (ec EntryCaller) TrimmedPath() string {
 	return caller
 }
 
-// An Entry represents a complete log message. The entry's structured context
-// is already serialized, but the log level, time, message, and call site
-// information are available for inspection and modification. Any fields left
-// empty will be omitted when encoding.
+// An Entry represents the fixed metadata for a single log event. It includes
+// the log level, time, logger name, message, caller, and stack trace.
 //
-// Entries are pooled, so any functions that accept them MUST be careful not to
-// retain references to them.
+// Structured context is supplied separately as fields to Core.Write and encoded
+// by the configured Encoder. Optional Entry fields left empty are omitted when
+// encoding.
 type Entry struct {
 	Level      Level
 	Time       time.Time


### PR DESCRIPTION
## Summary
- Clarifies the `zapcore.Entry` doc comment to describe it as fixed metadata for a log event.
- Removes the outdated note that entries are pooled.
- Notes that structured context is supplied separately as fields to `Core.Write` and encoded by the configured encoder.

## Why
Issue #1037 points out that the previous comment described `Entry` as a complete log message and warned about pooling, both of which are outdated or misleading.

## Changes
- Updated the `Entry` comment in `zapcore/entry.go`.
- No behavior changes.

## Testing
- `git diff --check`
- `git diff --cached --check`

Not run:
- `go test ./zapcore` because Go is not installed in this environment.

## Known Issues
None.

Closes #1037