### PR TITLE
zapcore/field, field: handle nil Stringer interface without emitting PANIC error

### DIFF
--- a/field.go
+++ b/field.go
@@ -338,7 +338,12 @@ func Namespace(key string) Field {
 
 // Stringer constructs a field with the given key and the output of the value's
 // String method. The Stringer's String method is called lazily.
+//
+// If the passed value is nil, the field is a no-op.
 func Stringer(key string, val fmt.Stringer) Field {
+	if val == nil {
+		return nilField(key)
+	}
 	return Field{Key: key, Type: zapcore.StringerType, Interface: val}
 }
 

--- a/field_test.go
+++ b/field_test.go
@@ -21,6 +21,7 @@
 package zap
 
 import (
+	"fmt"
 	"math"
 	"net"
 	"regexp"
@@ -124,12 +125,14 @@ func TestFieldConstructors(t *testing.T) {
 		{"Reflect", Field{Key: "k", Type: zapcore.ReflectType, Interface: ints}, Reflect("k", ints)},
 		{"Reflect", Field{Key: "k", Type: zapcore.ReflectType}, Reflect("k", nil)},
 		{"Stringer", Field{Key: "k", Type: zapcore.StringerType, Interface: addr}, Stringer("k", addr)},
+		{"Stringer:Nil", nilField("k"), Stringer("k", nil)},
 		{"Object", Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: name}, Object("k", name)},
 		{"Inline", Field{Type: zapcore.InlineMarshalerType, Interface: name}, Inline(name)},
 		{"Any:ObjectMarshaler", Any("k", name), Object("k", name)},
 		{"Any:ArrayMarshaler", Any("k", bools([]bool{true})), Array("k", bools([]bool{true}))},
 		{"Any:Dict", Any("k", []Field{String("k", "v")}), Dict("k", String("k", "v"))},
 		{"Any:Stringer", Any("k", addr), Stringer("k", addr)},
+		{"Any:Stringer:Nil", Any("k", (fmt.Stringer)(nil)), Stringer("k", nil)},
 		{"Any:Bool", Any("k", true), Bool("k", true)},
 		{"Any:Bools", Any("k", []bool{true}), Bools("k", []bool{true})},
 		{"Any:Byte", Any("k", byte(1)), Uint8("k", 1)},

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -224,6 +224,14 @@ func encodeStringer(key string, stringer interface{}, enc ObjectEncoder) (retErr
 				return
 			}
 
+			// If the interface itself is nil (Kind == Invalid), treat as nil.
+			// This can happen if a caller bypasses the zap.Stringer nil-guard
+			// and constructs a Field{Type: StringerType, Interface: nil} directly.
+			if v := reflect.ValueOf(stringer); !v.IsValid() {
+				enc.AddString(key, "<nil>")
+				return
+			}
+
 			retErr = fmt.Errorf("PANIC=%v", err)
 		}
 	}()

--- a/zapcore/field_test.go
+++ b/zapcore/field_test.go
@@ -166,6 +166,7 @@ func TestFields(t *testing.T) {
 		{t: SkipType, want: interface{}(nil)},
 		{t: StringerType, iface: (*url.URL)(nil), want: "<nil>"},
 		{t: StringerType, iface: (*users)(nil), want: "<nil>"},
+		{t: StringerType, iface: nil, want: "<nil>"},
 		{t: ErrorType, iface: (*errObj)(nil), want: "<nil>"},
 	}
 


### PR DESCRIPTION
## Summary

`zap.Stringer("key", nil)` silently logged a confusing internal error
instead of treating the nil value as a no-op (or emitting `"<nil>"`).

### Root cause

`Stringer` stored the nil `fmt.Stringer` interface directly in the
`Field.Interface` slot. When `Field.AddTo` later called `encodeStringer`,
the line:

```go
enc.AddString(key, stringer.(fmt.Stringer).String())
```

panicked because the type assertion on a nil interface panics. The
`recover` block then checked:

```go
if v := reflect.ValueOf(stringer); v.Kind() == reflect.Ptr && v.IsNil()
```

A nil *interface* has `reflect.Kind == reflect.Invalid` (not
`reflect.Ptr`), so the guard was skipped and the code fell through to:

```go
retErr = fmt.Errorf("PANIC=%v", err)
```

This emitted a key `"kError": "PANIC=interface conversion: interface is
nil, not fmt.Stringer"` in the structured log output — confusing and
undocumented behaviour.

### Fix (two layers)

1. **`field.go` — `zap.Stringer`**: return `nilField(key)` when `val`
   is nil, consistent with `zap.Object` and every pointer-typed field
   constructor (`Boolp`, `Stringp`, etc.).

2. **`zapcore/field.go` — `encodeStringer`**: add a defensive `!v.IsValid()`
   branch in the recover so that a `Field{Type: StringerType, Interface:
   nil}` constructed directly (e.g. by library users or future code paths)
   emits `"<nil>"` rather than a PANIC string.

### Test plan

- [ ] `TestFieldConstructors` — new cases `Stringer:Nil` and
  `Any:Stringer:Nil` confirm `zap.Stringer("k", nil)` equals
  `nilField("k")` and is reusable across goroutines.
- [ ] `TestFields` in `zapcore/field_test.go` — new case
  `{t: StringerType, iface: nil, want: "<nil>"}` exercises the
  defensive path in `encodeStringer`.
- [ ] Existing `TestFieldAddingError` cases for `StringerType` continue
  to pass unchanged (nil pointer, panic with string/error/<nil>).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)