### PR TITLE
zapcore: fix DurationEncoder.UnmarshalText doc comment

### DIFF
--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -254,8 +254,9 @@ func StringDurationEncoder(d time.Duration, enc PrimitiveArrayEncoder) {
 }
 
 // UnmarshalText unmarshals text to a DurationEncoder. "string" is unmarshaled
-// to StringDurationEncoder, and anything else is unmarshaled to
-// NanosDurationEncoder.
+// to StringDurationEncoder, "nanos" is unmarshaled to NanosDurationEncoder,
+// "ms" is unmarshaled to MillisDurationEncoder, and anything else is
+// unmarshaled to SecondsDurationEncoder.
 func (e *DurationEncoder) UnmarshalText(text []byte) error {
 	switch string(text) {
 	case "string":


### PR DESCRIPTION
The doc comment on `DurationEncoder.UnmarshalText` says anything other than `"string"` unmarshals to `NanosDurationEncoder`, but the switch defaults to `SecondsDurationEncoder` and also handles `"nanos"` and `"ms"` explicitly.

`TestDurationEncoders` already pins the actual behavior: `""` and `"something-random"` serialize to `1.0000005` (seconds), not `int64(1000000500)` (nanos).

Updated the comment to list all four cases, matching the existing `TimeEncoder.UnmarshalText` doc in the same file. Comment-only change, no behavior change.