### PR TITLE
[codex] Escape custom time layout output in JSON

### DIFF
--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -23,6 +23,7 @@ package zapcore
 import (
 	"encoding/base64"
 	"math"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -296,10 +297,14 @@ func (enc *jsonEncoder) AppendString(val string) {
 	enc.buf.AppendByte('"')
 }
 
-func (enc *jsonEncoder) AppendTimeLayout(time time.Time, layout string) {
+func (enc *jsonEncoder) AppendTimeLayout(t time.Time, layout string) {
 	enc.addElementSeparator()
 	enc.buf.AppendByte('"')
-	enc.buf.AppendTime(time, layout)
+	if layoutNeedsEscaping(layout, t) {
+		enc.safeAddString(t.Format(layout))
+	} else {
+		enc.buf.AppendTime(t, layout)
+	}
 	enc.buf.AppendByte('"')
 }
 
@@ -502,6 +507,36 @@ func (enc *jsonEncoder) safeAddByteString(s []byte) {
 		enc.buf,
 		s,
 	)
+}
+
+func layoutNeedsEscaping(layout string, t time.Time) bool {
+	if !isJSONStringSafe(layout) {
+		return true
+	}
+	if strings.Contains(layout, "MST") {
+		zone, _ := t.Zone()
+		return !isJSONStringSafe(zone)
+	}
+	return false
+}
+
+func isJSONStringSafe(s string) bool {
+	for i := 0; i < len(s); {
+		if s[i] < utf8.RuneSelf {
+			if s[i] < 0x20 || s[i] == '\\' || s[i] == '"' {
+				return false
+			}
+			i++
+			continue
+		}
+
+		_, size := utf8.DecodeRuneInString(s[i:])
+		if size == 1 {
+			return false
+		}
+		i += size
+	}
+	return true
 }
 
 // safeAppendStringLike is a generic implementation of safeAddString and safeAddByteString.

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -328,6 +328,14 @@ func TestJSONEncoderTimeFormats(t *testing.T) {
 			},
 			expected: `"k":"2000-01-02T03:04:05.000000006Z","a":["2000-01-02T03:04:05.000000006Z"]`,
 		},
+		{
+			desc: "time.Time layout with JSON escapes",
+			cfg: EncoderConfig{
+				EncodeDuration: NanosDurationEncoder,
+				EncodeTime:     TimeEncoderOfLayout("2006\"01\n02"),
+			},
+			expected: `"k":"2000\"01\n02","a":["2000\"01\n02"]`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -335,6 +343,28 @@ func TestJSONEncoderTimeFormats(t *testing.T) {
 			assertOutput(t, tt.cfg, tt.expected, f)
 		})
 	}
+}
+
+func TestJSONEncoderTimeLayoutEscapesZoneName(t *testing.T) {
+	date := time.Date(
+		2000, time.January, 2, 3, 4, 5, 6,
+		time.FixedZone("bad\nzone\"", 0),
+	)
+
+	f := func(e Encoder) {
+		e.AddTime("k", date)
+		err := e.AddArray("a", ArrayMarshalerFunc(func(enc ArrayEncoder) error {
+			enc.AppendTime(date)
+			return nil
+		}))
+		assert.NoError(t, err)
+	}
+
+	cfg := EncoderConfig{
+		EncodeDuration: NanosDurationEncoder,
+		EncodeTime:     TimeEncoderOfLayout("2006 MST"),
+	}
+	assertOutput(t, cfg, `"k":"2000 bad\nzone\"","a":["2000 bad\nzone\""]`, f)
 }
 
 func TestJSONEncoderArrays(t *testing.T) {


### PR DESCRIPTION
## Summary
- Escape TimeEncoderOfLayout output when the layout or zone name could break JSON strings.

## Validation
- targeted zapcore tests, zapcore tests, full go test ./..., and BenchmarkZapJSON passed in Docker.

## Notes
- Opened as a draft PR for maintainer review.
