### PR TITLE
Include package dir in trimmed caller for major-version modules

### DIFF
--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -119,9 +119,17 @@ func (ec EntryCaller) TrimmedPath() string {
 		return ec.FullPath()
 	}
 	// Find the penultimate separator.
+	end := idx
 	idx = strings.LastIndexByte(ec.File[:idx], '/')
 	if idx == -1 {
 		return ec.FullPath()
+	}
+	// A directory like "v2@v2.0.3" is a module's major-version suffix in the
+	// module cache, not the package name; keep one more directory.
+	if isVersionDir(ec.File[idx+1 : end]) {
+		if i := strings.LastIndexByte(ec.File[:idx], '/'); i != -1 {
+			idx = i
+		}
 	}
 	buf := bufferpool.Get()
 	// Keep everything after the penultimate separator.
@@ -131,6 +139,26 @@ func (ec EntryCaller) TrimmedPath() string {
 	caller := buf.String()
 	buf.Free()
 	return caller
+}
+
+// isVersionDir reports whether dir is a module directory with a major-version
+// suffix in the module cache, of the form "v<digits>@v<digits>.".
+func isVersionDir(dir string) bool {
+	if len(dir) < 2 || dir[0] != 'v' {
+		return false
+	}
+	i := 1
+	for i < len(dir) && dir[i] >= '0' && dir[i] <= '9' {
+		i++
+	}
+	if i == 1 || !strings.HasPrefix(dir[i:], "@v") {
+		return false
+	}
+	j := i + 2
+	for j < len(dir) && dir[j] >= '0' && dir[j] <= '9' {
+		j++
+	}
+	return j > i+2 && j < len(dir) && dir[j] == '.'
 }
 
 // An Entry represents a complete log message. The entry's structured context

--- a/zapcore/entry_test.go
+++ b/zapcore/entry_test.go
@@ -94,6 +94,31 @@ func TestEntryCaller(t *testing.T) {
 			full:   "to/foo.go:42",
 			short:  "to/foo.go:42",
 		},
+		{
+			caller: NewEntryCaller(100, "/go/pkg/mod/github.com/me/go-pkg/v2@v2.0.3/foo.go", 42, true),
+			full:   "/go/pkg/mod/github.com/me/go-pkg/v2@v2.0.3/foo.go:42",
+			short:  "go-pkg/v2@v2.0.3/foo.go:42",
+		},
+		{
+			caller: NewEntryCaller(100, "/go/pkg/mod/github.com/me/go-pkg/v10@v10.1.2/foo.go", 42, true),
+			full:   "/go/pkg/mod/github.com/me/go-pkg/v10@v10.1.2/foo.go:42",
+			short:  "go-pkg/v10@v10.1.2/foo.go:42",
+		},
+		{
+			caller: NewEntryCaller(100, "v2@v2.0.3/foo.go", 42, true),
+			full:   "v2@v2.0.3/foo.go:42",
+			short:  "v2@v2.0.3/foo.go:42",
+		},
+		{
+			caller: NewEntryCaller(100, "/path/to/v2plus/foo.go", 42, true),
+			full:   "/path/to/v2plus/foo.go:42",
+			short:  "v2plus/foo.go:42",
+		},
+		{
+			caller: NewEntryCaller(100, "/vendor/pkg/v2/foo.go", 42, true),
+			full:   "/vendor/pkg/v2/foo.go:42",
+			short:  "v2/foo.go:42",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
For a module with a major-version suffix, the file path in the module cache has the form `.../go-pkg/v2@v2.0.3/file.go`, so TrimmedPath kept only the version directory and reported callers like `"v2@v2.0.3/file.go:9"`, dropping the package name.

When the penultimate path element looks like a major-version suffix (v<digits>@v<digits>.), keep one more directory, producing `"go-pkg/v2@v2.0.3/file.go:9"`.

Fixes #1209