### PR TITLE
fix: correct typos in comments and test strings

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -99,7 +99,7 @@ func (b *Buffer) String() string {
 	return string(b.bs)
 }
 
-// Reset resets the underlying byte slice. Subsequent writes re-use the slice's
+// Reset resets the underlying byte slice. Subsequent writes reuse the slice's
 // backing array.
 func (b *Buffer) Reset() {
 	b.bs = b.bs[:0]

--- a/error.go
+++ b/error.go
@@ -76,7 +76,7 @@ type errArrayElem struct {
 }
 
 func (e *errArrayElem) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	// Re-use the error field's logic, which supports non-standard error types.
+	// Reuse the error field's logic, which supports non-standard error types.
 	Error(e.error).AddTo(enc)
 	return nil
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1044,7 +1044,7 @@ func TestNopLogger(t *testing.T) {
 
 func TestMust(t *testing.T) {
 	t.Run("must without an error does not panic", func(t *testing.T) {
-		assert.NotPanics(t, func() { Must(NewNop(), nil) }, "must paniced with no error")
+		assert.NotPanics(t, func() { Must(NewNop(), nil) }, "must panicked with no error")
 	})
 
 	t.Run("must with an error panics", func(t *testing.T) {

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -241,7 +241,7 @@ func (ce *CheckedEntry) reset() {
 }
 
 // Write writes the entry to the stored Cores, returns any errors, and returns
-// the CheckedEntry reference to a pool for immediate re-use. Finally, it
+// the CheckedEntry reference to a pool for immediate reuse. Finally, it
 // executes any required CheckWriteAction.
 func (ce *CheckedEntry) Write(fields ...Field) {
 	if ce == nil {
@@ -250,13 +250,13 @@ func (ce *CheckedEntry) Write(fields ...Field) {
 
 	if ce.dirty {
 		if ce.ErrorOutput != nil {
-			// Make a best effort to detect unsafe re-use of this CheckedEntry.
+			// Make a best effort to detect unsafe reuse of this CheckedEntry.
 			// If the entry is dirty, log an internal error; because the
 			// CheckedEntry is being used after it was returned to the pool,
 			// the message may be an amalgamation from multiple call sites.
 			_, _ = fmt.Fprintf(
 				ce.ErrorOutput,
-				"%v Unsafe CheckedEntry re-use near Entry %+v.\n",
+				"%v Unsafe CheckedEntry reuse near Entry %+v.\n",
 				ce.Time,
 				ce.Entry,
 			)

--- a/zapcore/entry_ext_test.go
+++ b/zapcore/entry_ext_test.go
@@ -50,6 +50,6 @@ func TestCheckedEntryIllegalReuse(t *testing.T) {
 
 	// The second write should fail.
 	ce.Write(zap.String("foo", "bar"), zap.Int("x", 1))
-	assert.Contains(t, errOut.String(), "Unsafe CheckedEntry re-use near Entry",
+	assert.Contains(t, errOut.String(), "Unsafe CheckedEntry reuse near Entry",
 		"Expected error logged on second write.")
 }

--- a/zapcore/error.go
+++ b/zapcore/error.go
@@ -85,7 +85,7 @@ type errorGroup interface {
 }
 
 // Note that errArray and errArrayElem are very similar to the version
-// implemented in the top-level error.go file. We can't re-use this because
+// implemented in the top-level error.go file. We can't reuse this because
 // that would require exporting errArray as part of the zapcore API.
 
 // Encodes a list of errors using the standard error encoding logic.
@@ -111,7 +111,7 @@ var _errArrayElemPool = pool.New(func() *errArrayElem {
 	return &errArrayElem{}
 })
 
-// Encodes any error into a {"error": ...} re-using the same errors logic.
+// Encodes any error into a {"error": ...} reusing the same errors logic.
 //
 // May be passed in place of an array to build a single-element array.
 type errArrayElem struct{ err error }

--- a/zapcore/lazy_with.go
+++ b/zapcore/lazy_with.go
@@ -52,7 +52,7 @@ func (d *lazyWithCore) With(fields []Field) Core {
 
 func (d *lazyWithCore) Check(e Entry, ce *CheckedEntry) *CheckedEntry {
 	// This is safe because `lazyWithCore` doesn't change the level.
-	// So we can delagate the level check, any not `initOnce`
+	// So we can delegate the level check, any not `initOnce`
 	// just for the check.
 	if !d.originalCore.Enabled(e.Level) {
 		return ce


### PR DESCRIPTION
Found a few typos via codespell. All fixes are in comments or test strings (no logic changes).

- `delagate` -> `delegate` in `zapcore/lazy_with.go`
- `paniced` -> `panicked` in `logger_test.go`
- `re-use` -> `reuse` in comments across `buffer/buffer.go`, `error.go`, `zapcore/entry.go`, `zapcore/entry_ext_test.go`, `zapcore/error.go`

The `entry_ext_test.go` test string was also updated to match the corrected format string in `entry.go`.