### PR TITLE
fix: make stdout/stderr Sync a no-op

### DIFF
--- a/sink.go
+++ b/sink.go
@@ -55,6 +55,15 @@ type nopCloserSink struct{ zapcore.WriteSyncer }
 
 func (nopCloserSink) Close() error { return nil }
 
+// stdioSink wraps os.Stdout / os.Stderr. Sync is a no-op because calling Sync
+// on a terminal or pipe returns EINVAL ("inappropriate ioctl for device") on
+// many platforms, which is not an actionable application error.
+// See https://github.com/uber-go/zap/issues/880.
+type stdioSink struct{ *os.File }
+
+func (stdioSink) Sync() error  { return nil }
+func (stdioSink) Close() error { return nil }
+
 type sinkRegistry struct {
 	mu        sync.Mutex
 	factories map[string]func(*url.URL) (Sink, error)          // keyed by scheme
@@ -151,9 +160,9 @@ func (sr *sinkRegistry) newFileSinkFromURL(u *url.URL) (Sink, error) {
 func (sr *sinkRegistry) newFileSinkFromPath(path string) (Sink, error) {
 	switch path {
 	case "stdout":
-		return nopCloserSink{os.Stdout}, nil
+		return stdioSink{os.Stdout}, nil
 	case "stderr":
-		return nopCloserSink{os.Stderr}, nil
+		return stdioSink{os.Stderr}, nil
 	}
 	return sr.openFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o666)
 }

--- a/sink_test.go
+++ b/sink_test.go
@@ -105,3 +105,14 @@ func TestRegisterSinkErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestStdioSinkSyncIsNoop(t *testing.T) {
+	r := newSinkRegistry()
+	for _, path := range []string{"stdout", "stderr"} {
+		sink, err := r.newFileSinkFromPath(path)
+		require.NoError(t, err, path)
+		// Must not return EINVAL / "inappropriate ioctl for device".
+		assert.NoError(t, sink.Sync(), path)
+		assert.NoError(t, sink.Close(), path)
+	}
+}


### PR DESCRIPTION
## Summary

`logger.Sync()` on the default production/development configs often returns:

```
sync /dev/stderr: inappropriate ioctl for device
```

because `os.Stderr.Sync()` / `os.Stdout.Sync()` yield `EINVAL` when the fd is a terminal or pipe. Apps that `defer logger.Sync()` then log a spurious error.

This change uses a dedicated `stdioSink` for the `"stdout"` / `"stderr"` paths so `Sync` is a no-op while writes still go through `*os.File`.

Fixes #880

## Test plan

- [x] `go test ./...`
- [x] `TestStdioSinkSyncIsNoop` asserts Sync/Close succeed for stdout and stderr sinks