### PR TITLE
BUGFIX: Suppress "failed to get caller" diagnostic for std-log bridges

### DIFF
--- a/global.go
+++ b/global.go
@@ -76,7 +76,10 @@ func ReplaceGlobals(logger *Logger) func() {
 // InfoLevel. To redirect the standard library's package-global logging
 // functions, use RedirectStdLog instead.
 func NewStdLog(l *Logger) *log.Logger {
-	logger := l.WithOptions(AddCallerSkip(_stdLogDefaultDepth + _loggerWriterDepth))
+	logger := l.WithOptions(
+		AddCallerSkip(_stdLogDefaultDepth+_loggerWriterDepth),
+		suppressCallerFailure(),
+	)
 	f := logger.Info
 	return log.New(&loggerWriter{f}, "" /* prefix */, 0 /* flags */)
 }
@@ -84,7 +87,10 @@ func NewStdLog(l *Logger) *log.Logger {
 // NewStdLogAt returns *log.Logger which writes to supplied zap logger at
 // required level.
 func NewStdLogAt(l *Logger, level zapcore.Level) (*log.Logger, error) {
-	logger := l.WithOptions(AddCallerSkip(_stdLogDefaultDepth + _loggerWriterDepth))
+	logger := l.WithOptions(
+		AddCallerSkip(_stdLogDefaultDepth+_loggerWriterDepth),
+		suppressCallerFailure(),
+	)
 	logFunc, err := levelToFunc(logger, level)
 	if err != nil {
 		return nil, err
@@ -125,7 +131,10 @@ func redirectStdLogAt(l *Logger, level zapcore.Level) (func(), error) {
 	prefix := log.Prefix()
 	log.SetFlags(0)
 	log.SetPrefix("")
-	logger := l.WithOptions(AddCallerSkip(_stdLogDefaultDepth + _loggerWriterDepth))
+	logger := l.WithOptions(
+		AddCallerSkip(_stdLogDefaultDepth+_loggerWriterDepth),
+		suppressCallerFailure(),
+	)
 	logFunc, err := levelToFunc(logger, level)
 	if err != nil {
 		return nil, err

--- a/global_test.go
+++ b/global_test.go
@@ -217,6 +217,37 @@ func TestRedirectStdLogAtCaller(t *testing.T) {
 	}
 }
 
+func TestRedirectStdLogNoCallerFailure(t *testing.T) {
+	// The std-log bridge bakes in a fixed AddCallerSkip that only matches
+	// messages routed through log.Print -> log.Output -> loggerWriter.Write. A
+	// direct write to the returned writer (e.g. via log.Writer()) arrives on a
+	// shallower stack from which no caller can be resolved. That is expected for
+	// an io.Writer bridge and must not spam the error output with a "failed to
+	// get caller" diagnostic.
+	errBuf := &ztest.Buffer{}
+	withLogger(t, DebugLevel, []Option{AddCaller(), ErrorOutput(errBuf)}, func(l *Logger, logs *observer.ObservedLogs) {
+		defer RedirectStdLog(l)()
+
+		// Write directly to the std logger's writer from a freshly spawned
+		// goroutine. The bare goroutine keeps the stack shallow enough that the
+		// fixed caller skip overshoots the available frames, which is exactly
+		// the condition that used to emit the diagnostic.
+		done := make(chan struct{})
+		writer := log.Writer()
+		go func() {
+			_, _ = writer.Write([]byte("direct writer message\n"))
+			close(done)
+		}()
+		<-done
+
+		assert.NotContains(t, errBuf.String(), "failed to get caller",
+			"std-log redirect must not emit the caller-resolution diagnostic")
+		entries := logs.All()
+		require.Len(t, entries, 1, "Message should still be logged.")
+		assert.Equal(t, "direct writer message", entries[0].Message)
+	})
+}
+
 func TestRedirectStdLogAtPanics(t *testing.T) {
 	initialFlags := log.Flags()
 	initialPrefix := log.Prefix()

--- a/logger.go
+++ b/logger.go
@@ -54,6 +54,16 @@ type Logger struct {
 	callerSkip int
 
 	clock zapcore.Clock
+
+	// suppressCallerFailure silences the "failed to get caller" diagnostic
+	// that check emits when caller resolution fails. It is set on the loggers
+	// backing the standard-library bridges (NewStdLog, NewStdLogAt,
+	// RedirectStdLog): their fixed caller skip only matches messages routed
+	// through log.Output, so a direct write to the returned writer (e.g. via
+	// log.Writer()) arrives on a shallower stack from which no caller can be
+	// resolved. That is expected for an io.Writer bridge and must not spam the
+	// error output.
+	suppressCallerFailure bool
 }
 
 // New constructs a new Logger from the provided zapcore.Core and Options. If
@@ -380,7 +390,7 @@ func (log *Logger) check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 	defer stack.Free()
 
 	if stack.Count() == 0 {
-		if log.addCaller {
+		if log.addCaller && !log.suppressCallerFailure {
 			_, _ = fmt.Fprintf(
 				log.errorOutput,
 				"%v Logger.check error: failed to get caller\n",

--- a/options.go
+++ b/options.go
@@ -111,6 +111,16 @@ func AddCallerSkip(skip int) Option {
 	})
 }
 
+// suppressCallerFailure silences the "failed to get caller" diagnostic emitted
+// when caller resolution fails. It is intended for the standard-library bridges
+// (see NewStdLog, NewStdLogAt, RedirectStdLog), whose fixed caller skip cannot
+// resolve a caller for messages written directly to the returned io.Writer.
+func suppressCallerFailure() Option {
+	return optionFunc(func(log *Logger) {
+		log.suppressCallerFailure = true
+	})
+}
+
 // AddStacktrace configures the Logger to record a stack trace for all messages at
 // or above a given level.
 func AddStacktrace(lvl zapcore.LevelEnabler) Option {


### PR DESCRIPTION
The standard-library bridges (NewStdLog, NewStdLogAt, RedirectStdLog) bake in a fixed AddCallerSkip that only resolves a caller for messages routed through log.Output -> loggerWriter.Write. A direct write to the returned io.Writer (e.g. via log.Writer()) arrives on a shallower stack where no caller can be resolved, causing check to spam the error output with "failed to get caller".

Add an internal suppressCallerFailure option and set it on the loggers backing these bridges so the expected caller-resolution failure stays silent.