### PR TITLE
fix(zapcore): fall back to default Encode* implementations when nil

### DIFF
--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -90,6 +90,20 @@ func newJSONEncoder(cfg EncoderConfig, spaced bool) *jsonEncoder {
 		cfg.NewReflectedEncoder = defaultReflectedEncoder
 	}
 
+	// If no encoder is provided, fall back to the default implementation.
+	if cfg.EncodeLevel == nil {
+		cfg.EncodeLevel = LowercaseLevelEncoder
+	}
+	if cfg.EncodeTime == nil {
+		cfg.EncodeTime = EpochTimeEncoder
+	}
+	if cfg.EncodeDuration == nil {
+		cfg.EncodeDuration = SecondsDurationEncoder
+	}
+	if cfg.EncodeCaller == nil {
+		cfg.EncodeCaller = ShortCallerEncoder
+	}
+
 	return &jsonEncoder{
 		EncoderConfig: &cfg,
 		buf:           bufferpool.Get(),

--- a/zapcore/json_encoder_test.go
+++ b/zapcore/json_encoder_test.go
@@ -188,12 +188,12 @@ func TestJSONEmptyConfig(t *testing.T) {
 		{
 			name:     "time",
 			field:    zap.Time("foo", time.Unix(1591287718, 0)), // 2020-06-04 09:21:58 -0700 PDT
-			expected: `{"foo": 1591287718000000000}`,
+			expected: `{"foo": 1591287718}`,
 		},
 		{
 			name:     "duration",
 			field:    zap.Duration("bar", time.Microsecond),
-			expected: `{"bar": 1000}`,
+			expected: `{"bar": 0.000001}`,
 		},
 	}
 


### PR DESCRIPTION
## Summary

When `EncoderConfig` sets `LevelKey`, `TimeKey`, or `CallerKey` but leaves the matching `Encode*` function nil, the encoder now applies the same defaults used elsewhere (`LowercaseLevelEncoder`, `EpochTimeEncoder`, `SecondsDurationEncoder`, `ShortCallerEncoder`).

Previously, a nil `EncodeLevel` would silently skip the level field, and a nil `EncodeCaller` could cause a panic. This change makes the behavior consistent with the existing `EncodeName` fallback and the documented defaults in `EncoderConfig`.

## Changes

- **zapcore/json_encoder.go**: Add fallback defaults for `EncodeLevel`, `EncodeTime`, `EncodeDuration`, and `EncodeCaller` in `newJSONEncoder()` when they are nil. This is consistent with the existing `LineEnding` and `NewReflectedEncoder` fallbacks already in `newJSONEncoder()`.
- **zapcore/json_encoder_test.go**: Update `TestJSONEmptyConfig` expectations to match the new default encoder output.

## Test plan

- [x] `go test ./...` — all 14 packages pass

Fixes #537