### PR TITLE
fix: set content type for AtomicLevel HTTP responses

### DIFF
--- a/http_handler.go
+++ b/http_handler.go
@@ -70,12 +70,15 @@ import (
 //	curl -X PUT localhost:8080/log/level -H "Content-Type: application/json" -d '{"level":"debug"}'
 func (lvl AtomicLevel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := lvl.serveHTTP(w, r); err != nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = fmt.Fprintf(w, "internal error: %v", err)
 	}
 }
 
 func (lvl AtomicLevel) serveHTTP(w http.ResponseWriter, r *http.Request) error {
+	w.Header().Set("Content-Type", "application/json")
+
 	type errorResponse struct {
 		Error string `json:"error"`
 	}

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -174,6 +174,7 @@ func TestAtomicLevelServeHTTP(t *testing.T) {
 			}()
 
 			require.Equal(t, tt.expectedCode, res.StatusCode, "Unexpected status code.")
+			assert.Equal(t, "application/json", res.Header.Get("Content-Type"), "Unexpected content type.")
 			if tt.expectedCode != http.StatusOK {
 				// Don't need to test exact error message, but one should be present.
 				var pld struct {
@@ -207,6 +208,7 @@ func TestAtomicLevelServeHTTPBrokenWriter(t *testing.T) {
 	}, request)
 
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code, "Unexpected status code.")
+	assert.Equal(t, "text/plain; charset=utf-8", recorder.Header().Get("Content-Type"), "Unexpected content type.")
 }
 
 type brokenHTTPResponseWriter struct {


### PR DESCRIPTION
`AtomicLevel.ServeHTTP` returns JSON responses, but does not explicitly set`Content-Type`. As a result, `net/http` detects these responses as`text/plain; charset=utf-8`.

This change:

- sets `Content-Type: application/json` for normal and business error responses;
- sets `Content-Type: text/plain; charset=utf-8` for the fallback internal error;
- adds tests covering both response types.

Response bodies and status codes are unchanged.

Thank you for your time. Any feedback is welcome. 