### PR TITLE
Replace go.uber.org/multierr with errors.Join, update to go1.20

### DIFF
--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/rs/zerolog v1.30.0
 	github.com/sirupsen/logrus v1.9.3
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.23.0
 	gopkg.in/inconshreveable/log15.v2 v2.16.0
 )

--- a/benchmarks/go.sum
+++ b/benchmarks/go.sum
@@ -71,8 +71,6 @@ github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPf
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
-go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/benchmarks/zap_test.go
+++ b/benchmarks/zap_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"time"
 
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/internal/ztest"
 	"go.uber.org/zap/zapcore"
@@ -83,11 +82,13 @@ func getMessage(iter int) string {
 type users []*user
 
 func (uu users) MarshalLogArray(arr zapcore.ArrayEncoder) error {
-	var err error
+	var errs []error
 	for i := range uu {
-		err = multierr.Append(err, arr.AppendObject(uu[i]))
+		if err := arr.AppendObject(uu[i]); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return err
+	return errors.Join(errs...)
 }
 
 type user struct {

--- a/exp/go.mod
+++ b/exp/go.mod
@@ -1,15 +1,12 @@
 module go.uber.org/zap/exp
 
-go 1.19
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.12.1
 	go.uber.org/zap v1.26.0
 )
 
-require (
-	go.uber.org/multierr v1.10.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.5 // indirect
-)
+require go.yaml.in/yaml/v3 v3.0.5 // indirect
 
 replace go.uber.org/zap => ../

--- a/exp/go.sum
+++ b/exp/go.sum
@@ -1,7 +1,5 @@
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
-go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module go.uber.org/zap
 
-go 1.19
+go 1.20
 
 require (
 	github.com/stretchr/testify v1.12.1
 	go.uber.org/goleak v1.3.0
-	go.uber.org/multierr v1.10.0
 	go.yaml.in/yaml/v3 v3.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,5 @@ github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWD
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
-go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=

--- a/sugar.go
+++ b/sugar.go
@@ -473,5 +473,8 @@ func (ps invalidPairs) MarshalLogArray(enc zapcore.ArrayEncoder) error {
 			errs = append(errs, err)
 		}
 	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
 	return errors.Join(errs...)
 }

--- a/sugar.go
+++ b/sugar.go
@@ -21,11 +21,10 @@
 package zap
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap/zapcore"
-
-	"go.uber.org/multierr"
 )
 
 const (
@@ -468,9 +467,11 @@ func (p invalidPair) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 type invalidPairs []invalidPair
 
 func (ps invalidPairs) MarshalLogArray(enc zapcore.ArrayEncoder) error {
-	var err error
+	var errs []error
 	for i := range ps {
-		err = multierr.Append(err, enc.AppendObject(ps[i]))
+		if err := enc.AppendObject(ps[i]); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return err
+	return errors.Join(errs...)
 }

--- a/writer.go
+++ b/writer.go
@@ -21,12 +21,11 @@
 package zap
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
 	"go.uber.org/zap/zapcore"
-
-	"go.uber.org/multierr"
 )
 
 // Open is a high-level wrapper that takes a variadic number of URLs, opens or
@@ -66,19 +65,19 @@ func open(paths []string) ([]zapcore.WriteSyncer, func(), error) {
 		}
 	}
 
-	var openErr error
+	var errs []error
 	for _, path := range paths {
 		sink, err := _sinkRegistry.newSink(path)
 		if err != nil {
-			openErr = multierr.Append(openErr, fmt.Errorf("open sink %q: %w", path, err))
+			errs = append(errs, fmt.Errorf("open sink %q: %w", path, err))
 			continue
 		}
 		writers = append(writers, sink)
 		closers = append(closers, sink)
 	}
-	if openErr != nil {
+	if err := errors.Join(errs...); err != nil {
 		closeAll()
-		return nil, nil, openErr
+		return nil, nil, err
 	}
 
 	return writers, closeAll, nil

--- a/writer_test.go
+++ b/writer_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -129,7 +128,10 @@ func TestOpenPathsNotFound(t *testing.T) {
 				return
 			}
 
-			errs := multierr.Errors(err)
+			var joined interface{ Unwrap() []error }
+			require.ErrorAs(t, err, &joined)
+
+			errs := joined.Unwrap()
 			require.Len(t, errs, len(tt.wantNotFoundPaths))
 			for i, err := range errs {
 				assert.ErrorIs(t, err, fs.ErrNotExist)

--- a/zapcore/buffered_write_syncer.go
+++ b/zapcore/buffered_write_syncer.go
@@ -22,10 +22,9 @@ package zapcore
 
 import (
 	"bufio"
+	"errors"
 	"sync"
 	"time"
-
-	"go.uber.org/multierr"
 )
 
 const (
@@ -164,7 +163,7 @@ func (s *BufferedWriteSyncer) Sync() error {
 		err = s.writer.Flush()
 	}
 
-	return multierr.Append(err, s.WS.Sync())
+	return errors.Join(err, s.WS.Sync())
 }
 
 // flushLoop flushes the buffer at the configured interval until Stop is

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -21,12 +21,12 @@
 package zapcore
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
 	"time"
 
-	"go.uber.org/multierr"
 	"go.uber.org/zap/internal/bufferpool"
 	"go.uber.org/zap/internal/exit"
 	"go.uber.org/zap/internal/pool"
@@ -271,11 +271,13 @@ func (ce *CheckedEntry) Write(fields ...Field) {
 		ent, fields = ce.before[i](ent, fields)
 	}
 
-	var err error
+	var errs []error
 	for i := range ce.cores {
-		err = multierr.Append(err, ce.cores[i].Write(ent, fields))
+		if err := ce.cores[i].Write(ent, fields); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	if err != nil && ce.ErrorOutput != nil {
+	if err := errors.Join(errs...); err != nil && ce.ErrorOutput != nil {
 		_, _ = fmt.Fprintf(
 			ce.ErrorOutput,
 			"%v write error: %v\n",

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -271,20 +271,24 @@ func (ce *CheckedEntry) Write(fields ...Field) {
 		ent, fields = ce.before[i](ent, fields)
 	}
 
+	errorOutput := ce.ErrorOutput
+
 	var errs []error
 	for i := range ce.cores {
-		if err := ce.cores[i].Write(ent, fields); err != nil {
+		if err := ce.cores[i].Write(ent, fields); err != nil && errorOutput != nil {
 			errs = append(errs, err)
 		}
 	}
-	if err := errors.Join(errs...); err != nil && ce.ErrorOutput != nil {
-		_, _ = fmt.Fprintf(
-			ce.ErrorOutput,
-			"%v write error: %v\n",
-			ce.Time,
-			err,
-		)
-		_ = ce.ErrorOutput.Sync() // ignore error
+	if errorOutput != nil {
+		if err := errors.Join(errs...); err != nil {
+			_, _ = fmt.Fprintf(
+				errorOutput,
+				"%v write error: %v\n",
+				ce.Time,
+				err,
+			)
+			_ = errorOutput.Sync() // ignore error
+		}
 	}
 
 	hook := ce.after

--- a/zapcore/error.go
+++ b/zapcore/error.go
@@ -65,6 +65,8 @@ func encodeError(key string, err error, enc ObjectEncoder) (retErr error) {
 	enc.AddString(key, basic)
 
 	switch e := err.(type) {
+	case multiError:
+		return enc.AddArray(key+"Causes", errArray(e.Unwrap()))
 	case errorGroup:
 		return enc.AddArray(key+"Causes", errArray(e.Errors()))
 	case fmt.Formatter:
@@ -78,9 +80,17 @@ func encodeError(key string, err error, enc ObjectEncoder) (retErr error) {
 	return nil
 }
 
+// multiError is implemented by errors created with errors.Join and other
+// errors that follow the standard Go multi-error convention.
+type multiError interface {
+	Unwrap() []error
+}
+
+// errorGroup is implemented by errors created by go.uber.org/multierr and
+// other errors that expose their component errors as a group.
 type errorGroup interface {
-	// Provides read-only access to the underlying list of errors, preferably
-	// without causing any allocs.
+	// Errors returns the errors that comprise the group. The returned slice
+	// must not be modified.
 	Errors() []error
 }
 

--- a/zapcore/error_test.go
+++ b/zapcore/error_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"go.uber.org/multierr"
 	//revive:disable:dot-imports
 	. "go.uber.org/zap/zapcore"
 )
@@ -60,6 +59,8 @@ func (e errTooFewUsers) Format(s fmt.State, verb rune) {
 	}
 }
 
+// customMultierr exercises support for the Errors method implemented by
+// errors from go.uber.org/multierr.
 type customMultierr struct{}
 
 func (e customMultierr) Error() string {
@@ -70,11 +71,16 @@ func (e customMultierr) Errors() []error {
 	return []error{
 		errors.New("foo"),
 		nil,
-		multierr.Append(
-			errors.New("bar"),
-			errors.New("baz"),
-		),
+		nestedCustomMultierr{},
 	}
+}
+
+type nestedCustomMultierr struct{}
+
+func (nestedCustomMultierr) Error() string { return "bar; baz" }
+
+func (nestedCustomMultierr) Errors() []error {
+	return []error{errors.New("bar"), errors.New("baz")}
 }
 
 func TestErrorEncoding(t *testing.T) {
@@ -100,13 +106,13 @@ func TestErrorEncoding(t *testing.T) {
 		},
 		{
 			key: "err",
-			iface: multierr.Combine(
+			iface: errors.Join(
 				errors.New("foo"),
 				errors.New("bar"),
 				errors.New("baz"),
 			),
 			want: map[string]any{
-				"err": "foo; bar; baz",
+				"err": "foo\nbar\nbaz",
 				"errCauses": []any{
 					map[string]any{"error": "foo"},
 					map[string]any{"error": "bar"},
@@ -140,18 +146,18 @@ func TestErrorEncoding(t *testing.T) {
 		},
 		{
 			key: "error",
-			iface: multierr.Combine(
+			iface: errors.Join(
 				fmt.Errorf("hello: %w",
-					multierr.Combine(errors.New("foo"), errors.New("bar")),
+					errors.Join(errors.New("foo"), errors.New("bar")),
 				),
 				errors.New("baz"),
 				fmt.Errorf("world: %w", errors.New("qux")),
 			),
 			want: map[string]any{
-				"error": "hello: foo; bar; baz; world: qux",
+				"error": "hello: foo\nbar\nbaz\nworld: qux",
 				"errorCauses": []any{
 					map[string]any{
-						"error": "hello: foo; bar",
+						"error": "hello: foo\nbar",
 					},
 					map[string]any{"error": "baz"},
 					map[string]any{"error": "world: qux"},
@@ -185,7 +191,7 @@ func TestErrArrayBrokenEncoder(t *testing.T) {
 	f := Field{
 		Key:  "foo",
 		Type: ErrorType,
-		Interface: multierr.Combine(
+		Interface: errors.Join(
 			errors.New("foo"),
 			errors.New("bar"),
 		),

--- a/zapcore/hook.go
+++ b/zapcore/hook.go
@@ -20,7 +20,7 @@
 
 package zapcore
 
-import "go.uber.org/multierr"
+import "errors"
 
 type hooked struct {
 	Core
@@ -69,9 +69,11 @@ func (h *hooked) With(fields []Field) Core {
 func (h *hooked) Write(ent Entry, _ []Field) error {
 	// Since our downstream had a chance to register itself directly with the
 	// CheckedMessage, we don't need to call it here.
-	var err error
+	var errs []error
 	for i := range h.funcs {
-		err = multierr.Append(err, h.funcs[i](ent))
+		if err := h.funcs[i](ent); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return err
+	return errors.Join(errs...)
 }

--- a/zapcore/hook.go
+++ b/zapcore/hook.go
@@ -75,5 +75,8 @@ func (h *hooked) Write(ent Entry, _ []Field) error {
 			errs = append(errs, err)
 		}
 	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
 	return errors.Join(errs...)
 }

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/multierr"
 )
 
 var _defaultEncoderConfig = EncoderConfig{
@@ -550,12 +549,14 @@ func (t turducken) MarshalLogObject(enc ObjectEncoder) error {
 type turduckens int
 
 func (t turduckens) MarshalLogArray(enc ArrayEncoder) error {
-	var err error
+	var errs []error
 	tur := turducken{}
 	for i := 0; i < int(t); i++ {
-		err = multierr.Append(err, enc.AppendObject(tur))
+		if err := enc.AppendObject(tur); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return err
+	return errors.Join(errs...)
 }
 
 type loggable struct{ bool }

--- a/zapcore/tee.go
+++ b/zapcore/tee.go
@@ -20,7 +20,7 @@
 
 package zapcore
 
-import "go.uber.org/multierr"
+import "errors"
 
 type multiCore []Core
 
@@ -80,17 +80,21 @@ func (mc multiCore) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
 }
 
 func (mc multiCore) Write(ent Entry, fields []Field) error {
-	var err error
+	var errs []error
 	for i := range mc {
-		err = multierr.Append(err, mc[i].Write(ent, fields))
+		if err := mc[i].Write(ent, fields); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return err
+	return errors.Join(errs...)
 }
 
 func (mc multiCore) Sync() error {
-	var err error
+	var errs []error
 	for i := range mc {
-		err = multierr.Append(err, mc[i].Sync())
+		if err := mc[i].Sync(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return err
+	return errors.Join(errs...)
 }

--- a/zapcore/tee_test.go
+++ b/zapcore/tee_test.go
@@ -188,5 +188,5 @@ func TestTeeSync(t *testing.T) {
 		DebugLevel,
 	)
 	tee = NewTee(tee, noSync)
-	assert.Equal(t, err, tee.Sync(), "Expected an error when part of tee can't Sync.")
+	assert.ErrorIs(t, tee.Sync(), err, "Expected an error when part of tee can't Sync.")
 }

--- a/zapcore/write_syncer.go
+++ b/zapcore/write_syncer.go
@@ -21,10 +21,9 @@
 package zapcore
 
 import (
+	"errors"
 	"io"
 	"sync"
-
-	"go.uber.org/multierr"
 )
 
 // A WriteSyncer is an io.Writer that can also flush any buffered data. Note
@@ -99,24 +98,28 @@ func NewMultiWriteSyncer(ws ...WriteSyncer) WriteSyncer {
 // the smallest number is returned even though Write() is called on
 // all of them.
 func (ws multiWriteSyncer) Write(p []byte) (int, error) {
-	var writeErr error
+	var errs []error
 	nWritten := 0
 	for _, w := range ws {
 		n, err := w.Write(p)
-		writeErr = multierr.Append(writeErr, err)
+		if err != nil {
+			errs = append(errs, err)
+		}
 		if nWritten == 0 && n != 0 {
 			nWritten = n
 		} else if n < nWritten {
 			nWritten = n
 		}
 	}
-	return nWritten, writeErr
+	return nWritten, errors.Join(errs...)
 }
 
 func (ws multiWriteSyncer) Sync() error {
-	var err error
+	var errs []error
 	for _, w := range ws {
-		err = multierr.Append(err, w.Sync())
+		if err := w.Sync(); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return err
+	return errors.Join(errs...)
 }

--- a/zapcore/write_syncer.go
+++ b/zapcore/write_syncer.go
@@ -121,5 +121,8 @@ func (ws multiWriteSyncer) Sync() error {
 			errs = append(errs, err)
 		}
 	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
 	return errors.Join(errs...)
 }

--- a/zapgrpc/internal/test/go.mod
+++ b/zapgrpc/internal/test/go.mod
@@ -8,9 +8,6 @@ require (
 	google.golang.org/grpc v1.56.3
 )
 
-require (
-	go.uber.org/multierr v1.10.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.5 // indirect
-)
+require go.yaml.in/yaml/v3 v3.0.5 // indirect
 
 replace go.uber.org/zap => ../../..

--- a/zapgrpc/internal/test/go.sum
+++ b/zapgrpc/internal/test/go.sum
@@ -1,8 +1,6 @@
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
-go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
 google.golang.org/grpc v1.56.3 h1:8I4C0Yq1EjstUzUJzpcRVbuYA2mODtEmpWiQoN/b2nc=


### PR DESCRIPTION
Use Go stdlib multi-errors instead of go.uber.org/multierr, and update error encoding to handle both stlib Unwrap() []error interface as well as the Errors() []error interface implemented by go.uber.org/multierr.

Update tests to account for errors.Join formatting and to use errors.Is when checking wrapped errors.

Native multi-errors (errors.Join) were introduced in Go 1.20, so the module's minimum Go version was raised to 1.20.