### PR TITLE
feat: add CheckedEntry.Free to return entries to the pool without writing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+Enhancements:
+* [#1572][]: Add `CheckedEntry.Free` method to return a checked entry to the pool without writing it.
+
+[#1572]: https://github.com/uber-go/zap/pull/1572
+
 ## 1.28.0 (27 Apr 2026)
 Enhancements:
 * [#1534][]: Add `zapcore.CheckPreWriteHook` and `CheckedEntry.Before` method for transforming entries before they are written to any Cores.

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -292,6 +292,31 @@ func (ce *CheckedEntry) Write(fields ...Field) {
 	putCheckedEntry(ce)
 }
 
+// Free returns the CheckedEntry to the internal pool without writing it.
+//
+// Free is intended for Core implementations that obtain a CheckedEntry by
+// probing a wrapped Core — calling its Check method with a nil CheckedEntry —
+// and then decide not to log the entry. Returning the unused CheckedEntry to
+// the pool with Free keeps the pool effective; dropping it on the floor
+// instead forces a fresh allocation on the next logged entry.
+//
+// Like Write, Free returns the CheckedEntry to the pool, so the reference MUST
+// NOT be used after Free returns. Calling Free on a nil CheckedEntry is a
+// no-op.
+func (ce *CheckedEntry) Free() {
+	if ce == nil {
+		return
+	}
+	if ce.dirty {
+		// Best-effort detection of misuse, mirroring Write: this CheckedEntry
+		// has already been written or freed, so returning it to the pool again
+		// could hand the same reference to two callers.
+		return
+	}
+	ce.dirty = true
+	putCheckedEntry(ce)
+}
+
 // AddCore adds a Core that has agreed to log this CheckedEntry. It's intended to be
 // used by Core.Check implementations, and is safe to call on nil CheckedEntry
 // references.

--- a/zapcore/entry_test.go
+++ b/zapcore/entry_test.go
@@ -23,6 +23,7 @@ package zapcore
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"go.uber.org/zap/internal/exit"
 
@@ -211,10 +212,69 @@ func TestCheckedEntryBefore(t *testing.T) {
 	})
 }
 
-// recordingCore captures the last entry and fields written to it.
+func TestCheckedEntryFree(t *testing.T) {
+	t.Run("nil is safe", func(t *testing.T) {
+		var ce *CheckedEntry
+		assert.NotPanics(t, func() { ce.Free() }, "Unexpected panic freeing a nil CheckedEntry.")
+	})
+
+	t.Run("marks the entry dirty", func(t *testing.T) {
+		var ce *CheckedEntry
+		ce = ce.AddCore(Entry{Message: "hello"}, &recordingCore{})
+		ce.Free()
+		assert.True(t, ce.dirty, "Expected Free to mark the CheckedEntry dirty.")
+	})
+
+	t.Run("write after free does not reach cores", func(t *testing.T) {
+		core := &recordingCore{}
+		var ce *CheckedEntry
+		ce = ce.AddCore(Entry{Message: "hello"}, core)
+		ce.Free()
+
+		// The dirty bit set by Free flags the misuse, so Write must be a no-op
+		// rather than writing a stale entry and returning it to the pool twice.
+		ce.Write(Field{Key: "k", Type: StringType, String: "v"})
+		assert.Equal(t, Entry{}, core.entry, "Expected no Write to reach the core after Free.")
+		assert.Zero(t, core.writes, "Expected no Write to reach the core after Free.")
+	})
+
+	t.Run("double free is safe", func(t *testing.T) {
+		var ce *CheckedEntry
+		ce = ce.AddCore(Entry{Message: "hello"}, &recordingCore{})
+		assert.NotPanics(t, func() {
+			ce.Free()
+			ce.Free()
+		}, "Unexpected panic on double Free.")
+	})
+
+	t.Run("probe pattern preserves sampling", func(t *testing.T) {
+		// A core that probes and frees must consult the wrapped sampler exactly
+		// once per entry, neither bypassing it nor counting an entry twice.
+		rec := &recordingCore{}
+		sampler := NewSamplerWithOptions(rec, time.Minute, 2, 3)
+		core := &probeThenFreeCore{Core: sampler}
+
+		now := time.Now()
+		const n = 5
+		for i := 0; i < n; i++ {
+			ent := Entry{Level: InfoLevel, Message: "repeat", Time: now}
+			if ce := core.Check(ent, nil); ce != nil {
+				ce.Write()
+			}
+		}
+
+		// first=2 (n=1,2) plus every 3rd thereafter (n=5) => 3 entries logged.
+		assert.Equal(t, 3, rec.writes, "Sampler should log the first 2 and every 3rd after.")
+		assert.Equal(t, 3, core.written, "Filtering core should Write exactly the sampled entries.")
+	})
+}
+
+// recordingCore captures the last entry and fields written to it, along with a
+// count of the number of writes.
 type recordingCore struct {
 	entry  Entry
 	fields []Field
+	writes int
 }
 
 func (c *recordingCore) Enabled(Level) bool                              { return true }
@@ -224,5 +284,31 @@ func (c *recordingCore) Sync() error                                     { retur
 func (c *recordingCore) Write(ent Entry, fields []Field) error {
 	c.entry = ent
 	c.fields = fields
+	c.writes++
 	return nil
+}
+
+// probeThenFreeCore demonstrates the pattern that CheckedEntry.Free enables: it
+// consults the wrapped Core by probing its Check with a nil CheckedEntry,
+// returns the probe to the pool with Free, and then adds itself so that its own
+// Write runs. Probing this way lets the wrapped chain (e.g. a sampler) make its
+// decision exactly once without being bypassed.
+type probeThenFreeCore struct {
+	Core
+	written int
+}
+
+func (c *probeThenFreeCore) Check(ent Entry, ce *CheckedEntry) *CheckedEntry {
+	probe := c.Core.Check(ent, nil)
+	if probe == nil {
+		// The wrapped chain declined the entry.
+		return ce
+	}
+	probe.Free()
+	return ce.AddCore(ent, c)
+}
+
+func (c *probeThenFreeCore) Write(ent Entry, fields []Field) error {
+	c.written++
+	return c.Core.Write(ent, fields)
 }


### PR DESCRIPTION
**What**
Adds (*CheckedEntry).Free(), which returns a CheckedEntry to zap's internal pool without writing it.

**Why**
A Core that wants to filter on field values (e.g. drop zap.Error(err) logs for known-benign errors) must override Check so that it-not the core it wraps-gets added to the CheckedEntry, since fields only arrive in Write. To decide whether the downstream chain (crucially, the sampler) actually wants the entry, such a core can probe it:

```go
func (c *core) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
    probe := c.Core.Check(ent, nil) // consults the inner chain, incl. the sampler
    if probe == nil {
        return ce // inner chain declined
    }
    probe.Free() // <- previously impossible
    return ce.AddCore(ent, c)
}
```

- Before this change there was no way to hand that probe back to the pool: putCheckedEntry is unexported and only reachable via Write. Dropping the probe on the floor collapses the sync.Pool hit rate, allocating a fresh CheckedEntry plus its 4-element []Core backing array on every logged line.

- Reuses the existing dirty best-effort misuse detection, so double-free / use-after-Free is guarded the same way double-Write already is.