### PR TITLE
chore(lint): migrate to golangci-lint v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,7 +59,7 @@ jobs:
         go-version: 1.26.x
         cache: false  # managed by golangci-lint
 
-    - uses: golangci/golangci-lint-action@v6
+    - uses: golangci/golangci-lint-action@v9
       name: Install golangci-lint
       with:
         version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,77 +1,82 @@
-output:
-  # Make output more digestible with quickfix in vim/emacs/etc.
-  sort-results: true
-  print-issued-lines: false
+version: "2"
 
 linters:
   # We'll track the golangci-lint default linters manually
   # instead of letting them change without our control.
-  disable-all: true
+  default: none
   enable:
     # golangci-lint defaults:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
 
     # Our own extras:
-    - gofumpt
     - nolintlint # lints nolint directives
     - revive
+  settings:
+    govet:
+      # These govet checks are disabled by default, but they're useful.
+      enable:
+        - nilness
+        - reflectvaluecompare
+        - sortslice
+        - unusedwrite
+    errcheck:
+      exclude-functions:
+        # These methods can not fail.
+        # They operate on an in-memory buffer.
+        - (*go.uber.org/zap/buffer.Buffer).Write
+        - (*go.uber.org/zap/buffer.Buffer).WriteByte
+        - (*go.uber.org/zap/buffer.Buffer).WriteString
 
-linters-settings:
-  govet:
-    # These govet checks are disabled by default, but they're useful.
-    enable:
-      - nilness
-      - reflectvaluecompare
-      - sortslice
-      - unusedwrite
+        - (*go.uber.org/zap/zapio.Writer).Close
+        - (*go.uber.org/zap/zapio.Writer).Sync
+        - (*go.uber.org/zap/zapio.Writer).Write
+        # Write to zapio.Writer cannot fail,
+        # so io.WriteString on it cannot fail.
+        - io.WriteString(*go.uber.org/zap/zapio.Writer)
 
-  errcheck:
-    exclude-functions:
-      # These methods can not fail.
-      # They operate on an in-memory buffer.
-      - (*go.uber.org/zap/buffer.Buffer).Write
-      - (*go.uber.org/zap/buffer.Buffer).WriteByte
-      - (*go.uber.org/zap/buffer.Buffer).WriteString
+        # Writing a plain string to a fmt.State cannot fail.
+        - io.WriteString(fmt.State)
+  exclusions:
+    generated: lax
+    rules:
+      # Unused parameters are common and acceptable in test and callback
+      # signatures, so only enforce the check outside of test files.
+      - linters: [revive]
+        text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
+        path: _test\.go$
 
-      - (*go.uber.org/zap/zapio.Writer).Close
-      - (*go.uber.org/zap/zapio.Writer).Sync
-      - (*go.uber.org/zap/zapio.Writer).Write
-      # Write to zapio.Writer cannot fail,
-      # so io.WriteString on it cannot fail.
-      - io.WriteString(*go.uber.org/zap/zapio.Writer)
+      # staticcheck already has smarter checks for empty blocks.
+      # revive's empty-block linter has false positives.
+      # For example, as of writing this, the following is not allowed.
+      #   for foo() { }
+      - linters: [revive]
+        text: 'empty-block: this block is empty, you can remove it'
 
-      # Writing a plain string to a fmt.State cannot fail.
-      - io.WriteString(fmt.State)
+      # Ignore logger.Sync() errcheck failures in example_test.go
+      # since those are intended to be uncomplicated examples.
+      - linters: [errcheck]
+        path: example_test.go
+        text: 'Error return value of `logger.Sync` is not checked'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 issues:
   # Print all issues reported by all linters.
   max-issues-per-linter: 0
   max-same-issues: 0
 
-  # Don't ignore some of the issues that golangci-lint considers okay.
-  # This includes documenting all exported entities.
-  exclude-use-default: false
-
-  exclude-rules:
-    # Don't warn on unused parameters.
-    # Parameter names are useful; replacing them with '_' is undesirable.
-    - linters: [revive]
-      text: 'unused-parameter: parameter \S+ seems to be unused, consider removing or renaming it as _'
-
-    # staticcheck already has smarter checks for empty blocks.
-    # revive's empty-block linter has false positives.
-    # For example, as of writing this, the following is not allowed.
-    #   for foo() { }
-    - linters: [revive]
-      text: 'empty-block: this block is empty, you can remove it'
-
-    # Ignore logger.Sync() errcheck failures in example_test.go
-    # since those are intended to be uncomplicated examples.
-    - linters: [errcheck]
-      path: example_test.go
-      text: 'Error return value of `logger.Sync` is not checked'
+formatters:
+  enable:
+    - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/exp/zapslog/handler.go
+++ b/exp/zapslog/handler.go
@@ -130,12 +130,12 @@ func convertSlogLevel(l slog.Level) zapcore.Level {
 }
 
 // Enabled reports whether the handler handles records at the given level.
-func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
+func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
 	return h.core.Enabled(convertSlogLevel(level))
 }
 
 // Handle handles the Record.
-func (h *Handler) Handle(ctx context.Context, record slog.Record) error {
+func (h *Handler) Handle(_ context.Context, record slog.Record) error {
 	ent := zapcore.Entry{
 		Level:      convertSlogLevel(record.Level),
 		Time:       record.Time,

--- a/zapcore/entry_test.go
+++ b/zapcore/entry_test.go
@@ -156,7 +156,7 @@ func TestCheckedEntryBefore(t *testing.T) {
 			return ent, fields
 		})
 		assert.NotNil(t, ce)
-		assert.Equal(t, "hello", ce.Entry.Message)
+		assert.Equal(t, "hello", ce.Message)
 	})
 
 	t.Run("modifies entry and fields", func(t *testing.T) {

--- a/zapcore/error.go
+++ b/zapcore/error.go
@@ -52,7 +52,7 @@ func encodeError(key string, err error, enc ObjectEncoder) (retErr error) {
 			// If it's a nil pointer, just say "<nil>". The likeliest causes are a
 			// error that fails to guard against nil or a nil pointer for a
 			// value receiver, and in either case, "<nil>" is a nice result.
-			if v := reflect.ValueOf(err); v.Kind() == reflect.Ptr && v.IsNil() {
+			if v := reflect.ValueOf(err); v.Kind() == reflect.Pointer && v.IsNil() {
 				enc.AddString(key, "<nil>")
 				return
 			}

--- a/zapcore/field.go
+++ b/zapcore/field.go
@@ -219,7 +219,7 @@ func encodeStringer(key string, stringer interface{}, enc ObjectEncoder) (retErr
 			// If it's a nil pointer, just say "<nil>". The likeliest causes are a
 			// Stringer that fails to guard against nil or a nil pointer for a
 			// value receiver, and in either case, "<nil>" is a nice result.
-			if v := reflect.ValueOf(stringer); v.Kind() == reflect.Ptr && v.IsNil() {
+			if v := reflect.ValueOf(stringer); v.Kind() == reflect.Pointer && v.IsNil() {
 				enc.AddString(key, "<nil>")
 				return
 			}

--- a/zapcore/field_test.go
+++ b/zapcore/field_test.go
@@ -69,11 +69,12 @@ func (o *obj) String() string {
 		return "nil obj"
 	}
 
-	if o.kind == 1 {
+	switch o.kind {
+	case 1:
 		panic("panic with string")
-	} else if o.kind == 2 {
+	case 2:
 		panic(errors.New("panic with error"))
-	} else if o.kind == 3 {
+	case 3:
 		// panic with an arbitrary object that causes a panic itself
 		// when being converted to a string
 		panic((*url.URL)(nil))

--- a/zapcore/lazy_with.go
+++ b/zapcore/lazy_with.go
@@ -40,7 +40,7 @@ func NewLazyWith(core Core, fields []Field) Core {
 }
 
 func (d *lazyWithCore) initOnce() {
-	d.Once.Do(func() {
+	d.Do(func() {
 		d.core = d.originalCore.With(d.fields)
 	})
 }

--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -173,7 +173,7 @@ func (t *testLogSpy) Logf(format string, args ...interface{}) {
 	m := fmt.Sprintf(format, args...)
 	m = m[strings.IndexByte(m, '\t')+1:]
 	t.Messages = append(t.Messages, m)
-	t.TB.Log(m)
+	t.Log(m)
 }
 
 func (t *testLogSpy) AssertMessages(msgs ...string) {

--- a/zaptest/testingt_test.go
+++ b/zaptest/testingt_test.go
@@ -26,4 +26,4 @@ import "testing"
 // interface. We could do this in testingt.go but that would put a dependency
 // on the "testing" package from zaptest.
 
-var _ TestingT = (testing.TB)(nil)
+var _ TestingT = testing.TB(nil)


### PR DESCRIPTION
golangci-lint v1 (installed by golangci-lint-action@v6) is built with Go 1.24 and its type checker cannot parse the Go 1.26 standard library (files gated behind //go:build go1.26), so lint fails once CI runs on Go 1.26 (#1535).

- Bump golangci/golangci-lint-action v6 -> v9 and run lint on Go 1.26.
- Migrate .golangci.yml to the v2 schema (via `golangci-lint migrate`): gosimple folds into staticcheck, gofumpt moves to the formatters section, and linters-settings / issues.exclude-rules move under linters.settings / linters.exclusions.
- Fix the few nits v2's newer analyzers report:
  - reflect.Ptr -> reflect.Pointer (deprecated; govet inline)
  - drop redundant embedded-field selectors (staticcheck QF1008)
  - use a tagged switch in a test helper (staticcheck QF1003)
- Scope the revive unused-parameter exclusion to _test.go so it is enforced on non-test code; rename two interface-required but unused context.Context parameters in exp/zapslog to _.

make lint and go test ./... pass on Go 1.26.