### PR TITLE
feat(zapslog): add WithLevelMapper for custom slog level mapping

### DIFF
--- a/exp/zapslog/handler.go
+++ b/exp/zapslog/handler.go
@@ -39,6 +39,7 @@ type Handler struct {
 	addCaller  bool
 	addStackAt slog.Level
 	callerSkip int
+	mapLevel   LevelMapper
 
 	// List of unapplied groups.
 	//
@@ -54,6 +55,7 @@ func NewHandler(core zapcore.Core, opts ...HandlerOption) *Handler {
 	h := &Handler{
 		core:       core,
 		addStackAt: slog.LevelError,
+		mapLevel:   DefaultLevelMapper,
 	}
 	for _, v := range opts {
 		v.apply(h)
@@ -113,10 +115,25 @@ func convertAttrToField(attr slog.Attr) zapcore.Field {
 	}
 }
 
-// convertSlogLevel maps slog Levels to zap Levels.
-// Note that there is some room between slog levels while zap levels are continuous, so we can't 1:1 map them.
-// See also https://go.googlesource.com/proposal/+/master/design/56345-structured-logging.md?pli=1#levels
-func convertSlogLevel(l slog.Level) zapcore.Level {
+// A LevelMapper maps a [slog.Level] to a [zapcore.Level].
+//
+// slog levels are sparse -- callers may define their own levels anywhere in
+// the gaps between the standard ones -- while zap levels are contiguous, so a
+// mapper cannot be a 1:1 correspondence. See the [structured logging proposal]
+// for details on slog's level scheme.
+//
+// Use [WithLevelMapper] to install a custom mapper on a [Handler].
+//
+// [structured logging proposal]: https://go.googlesource.com/proposal/+/master/design/56345-structured-logging.md?pli=1#levels
+type LevelMapper func(slog.Level) zapcore.Level
+
+// DefaultLevelMapper is the [LevelMapper] used by a Handler
+// that was not given a [WithLevelMapper] option.
+// It maps each standard slog level to the zap level of the same name,
+// rounding levels in between down to the next lowest standard slog level.
+//
+// Custom mappers can call it to handle the levels they don't care about.
+func DefaultLevelMapper(l slog.Level) zapcore.Level {
 	switch {
 	case l >= slog.LevelError:
 		return zapcore.ErrorLevel
@@ -131,13 +148,13 @@ func convertSlogLevel(l slog.Level) zapcore.Level {
 
 // Enabled reports whether the handler handles records at the given level.
 func (h *Handler) Enabled(_ context.Context, level slog.Level) bool {
-	return h.core.Enabled(convertSlogLevel(level))
+	return h.core.Enabled(h.mapLevel(level))
 }
 
 // Handle handles the Record.
 func (h *Handler) Handle(_ context.Context, record slog.Record) error {
 	ent := zapcore.Entry{
-		Level:      convertSlogLevel(record.Level),
+		Level:      h.mapLevel(record.Level),
 		Time:       record.Time,
 		Message:    record.Message,
 		LoggerName: h.name,

--- a/exp/zapslog/handler_test.go
+++ b/exp/zapslog/handler_test.go
@@ -24,6 +24,7 @@ package zapslog
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"log/slog"
 	"sync"
@@ -416,4 +417,107 @@ func TestSlogtest(t *testing.T) {
 		},
 	)
 	require.NoError(t, err, "Unexpected error from slogtest.TestHandler")
+}
+
+func TestLevelMapper(t *testing.T) {
+	t.Parallel()
+
+	// A level in the gap between slog's Info and Warn,
+	// which DefaultLevelMapper would round down to Info.
+	const levelNotice = slog.LevelInfo + 2
+
+	mapper := func(l slog.Level) zapcore.Level {
+		if l == levelNotice {
+			return zapcore.WarnLevel
+		}
+		return DefaultLevelMapper(l)
+	}
+
+	t.Run("custom level", func(t *testing.T) {
+		t.Parallel()
+
+		fac, logs := observer.New(zapcore.DebugLevel)
+		sl := slog.New(NewHandler(fac, WithLevelMapper(mapper)))
+		sl.Log(context.Background(), levelNotice, "msg")
+
+		require.Len(t, logs.AllUntimed(), 1, "Expected exactly one entry to be logged")
+		assert.Equal(t, zapcore.WarnLevel, logs.AllUntimed()[0].Level,
+			"Custom mapper should have been used")
+	})
+
+	t.Run("delegates to default", func(t *testing.T) {
+		t.Parallel()
+
+		fac, logs := observer.New(zapcore.DebugLevel)
+		sl := slog.New(NewHandler(fac, WithLevelMapper(mapper)))
+		sl.Error("msg")
+
+		require.Len(t, logs.AllUntimed(), 1, "Expected exactly one entry to be logged")
+		assert.Equal(t, zapcore.ErrorLevel, logs.AllUntimed()[0].Level,
+			"Levels the mapper doesn't handle should use the default mapping")
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		t.Parallel()
+
+		// The core drops anything below Warn, so the mapping decides
+		// whether levelNotice survives.
+		fac, logs := observer.New(zapcore.WarnLevel)
+		h := NewHandler(fac, WithLevelMapper(mapper))
+		assert.True(t, h.Enabled(context.Background(), levelNotice),
+			"Enabled should consult the custom mapper")
+
+		slog.New(h).Log(context.Background(), levelNotice, "msg")
+		assert.Len(t, logs.AllUntimed(), 1, "Expected the entry to survive the core's level")
+
+		// Without the mapper, the same level maps to Info and is dropped.
+		fac, logs = observer.New(zapcore.WarnLevel)
+		h = NewHandler(fac)
+		assert.False(t, h.Enabled(context.Background(), levelNotice),
+			"Default mapping should round the level down to Info")
+
+		slog.New(h).Log(context.Background(), levelNotice, "msg")
+		assert.Empty(t, logs.AllUntimed(), "Expected the entry to be dropped")
+	})
+
+	t.Run("nil restores default", func(t *testing.T) {
+		t.Parallel()
+
+		fac, logs := observer.New(zapcore.DebugLevel)
+		sl := slog.New(NewHandler(fac, WithLevelMapper(mapper), WithLevelMapper(nil)))
+		sl.Log(context.Background(), levelNotice, "msg")
+
+		require.Len(t, logs.AllUntimed(), 1, "Expected exactly one entry to be logged")
+		assert.Equal(t, zapcore.InfoLevel, logs.AllUntimed()[0].Level,
+			"A nil mapper should restore the default mapping")
+	})
+}
+
+func TestDefaultLevelMapper(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		give slog.Level
+		want zapcore.Level
+	}{
+		{"debug", slog.LevelDebug, zapcore.DebugLevel},
+		{"below debug", slog.LevelDebug - 1, zapcore.DebugLevel},
+		{"between debug and info", slog.LevelDebug + 1, zapcore.DebugLevel},
+		{"info", slog.LevelInfo, zapcore.InfoLevel},
+		{"between info and warn", slog.LevelInfo + 1, zapcore.InfoLevel},
+		{"warn", slog.LevelWarn, zapcore.WarnLevel},
+		{"between warn and error", slog.LevelWarn + 1, zapcore.WarnLevel},
+		{"error", slog.LevelError, zapcore.ErrorLevel},
+		{"above error", slog.LevelError + 1, zapcore.ErrorLevel},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, DefaultLevelMapper(tt.give))
+		})
+	}
 }

--- a/exp/zapslog/options.go
+++ b/exp/zapslog/options.go
@@ -70,3 +70,27 @@ func AddStacktraceAt(lvl slog.Level) HandlerOption {
 		log.addStackAt = lvl
 	})
 }
+
+// WithLevelMapper configures how the Handler maps [slog.Level] values
+// to [zapcore.Level] values.
+//
+// This is useful for applications that define custom slog levels
+// in the gaps between the standard ones,
+// or that want to reach zap levels which slog has no equivalent for.
+//
+//	zapslog.WithLevelMapper(func(l slog.Level) zapcore.Level {
+//		if l == LevelTrace {
+//			return zapcore.DebugLevel
+//		}
+//		return zapslog.DefaultLevelMapper(l)
+//	})
+//
+// A nil mapper restores the default mapping.
+func WithLevelMapper(m LevelMapper) HandlerOption {
+	return handlerOptionFunc(func(handler *Handler) {
+		if m == nil {
+			m = DefaultLevelMapper
+		}
+		handler.mapLevel = m
+	})
+}


### PR DESCRIPTION
slog levels are sparse, so applications can define their own levels in the gaps between the standard ones. The handler previously hardcoded the slog-to-zap level mapping, rounding any such level down to the next lowest standard level with no way to override it.

Add a LevelMapper func type and a WithLevelMapper option. The existing mapping is exported as DefaultLevelMapper so custom mappers can delegate for the levels they don't handle. A nil mapper restores the default.

Fixes #1412