### PR TITLE
chore: bump zapgrpc/internal/test deps

### DIFF
--- a/zapgrpc/internal/test/go.mod
+++ b/zapgrpc/internal/test/go.mod
@@ -1,11 +1,11 @@
 module go.uber.org/zap/zapgrpc/internal/test
 
-go 1.18
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.12.1
-	go.uber.org/zap v1.16.0
-	google.golang.org/grpc v1.56.3
+	go.uber.org/zap v1.28.0
+	google.golang.org/grpc v1.83.2
 )
 
 require (

--- a/zapgrpc/internal/test/go.sum
+++ b/zapgrpc/internal/test/go.sum
@@ -1,9 +1,10 @@
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
-google.golang.org/grpc v1.56.3 h1:8I4C0Yq1EjstUzUJzpcRVbuYA2mODtEmpWiQoN/b2nc=
-google.golang.org/grpc v1.56.3/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=


### PR DESCRIPTION
Fixes:
```
remote: GitHub found 2 vulnerabilities on uber-go/zap's default branch (1 critical, 1 high). To find out more, visit:
remote:      https://github.com/uber-go/zap/security/dependabot
```