### PR TITLE
fix: handle nil marshalers in Array, Inline, Objects and Stringers

### DIFF
--- a/array.go
+++ b/array.go
@@ -30,7 +30,11 @@ import (
 // Array constructs a field with the given key and ArrayMarshaler. It provides
 // a flexible, but still type-safe and efficient, way to add array-like types
 // to the logging context. The struct's MarshalLogArray method is called lazily.
+// A nil ArrayMarshaler is logged as nil, as Object does with a nil ObjectMarshaler.
 func Array(key string, val zapcore.ArrayMarshaler) Field {
+	if val == nil {
+		return nilField(key)
+	}
 	return Field{Key: key, Type: zapcore.ArrayMarshalerType, Interface: val}
 }
 
@@ -135,6 +139,12 @@ type objects[T zapcore.ObjectMarshaler] []T
 
 func (os objects[T]) MarshalLogArray(arr zapcore.ArrayEncoder) error {
 	for _, o := range os {
+		if any(o) == nil {
+			if err := arr.AppendReflected(nil); err != nil {
+				return err
+			}
+			continue
+		}
 		if err := arr.AppendObject(o); err != nil {
 			return err
 		}
@@ -221,6 +231,12 @@ type stringers[T fmt.Stringer] []T
 
 func (os stringers[T]) MarshalLogArray(arr zapcore.ArrayEncoder) error {
 	for _, o := range os {
+		if any(o) == nil {
+			if err := arr.AppendReflected(nil); err != nil {
+				return err
+			}
+			continue
+		}
 		arr.AppendString(o.String())
 	}
 	return nil

--- a/array_test.go
+++ b/array_test.go
@@ -268,6 +268,24 @@ func TestObjectsAndObjectValues_marshalError(t *testing.T) {
 	}
 }
 
+// errReflectedArrayEncoder fails AppendReflected, the call a nil element
+// makes; every other method is never reached.
+type errReflectedArrayEncoder struct {
+	zapcore.ArrayEncoder
+}
+
+func (errReflectedArrayEncoder) AppendReflected(any) error {
+	return errors.New("append reflected failed")
+}
+
+func TestObjectsAndStringers_nilElementEncoderError(t *testing.T) {
+	t.Parallel()
+
+	enc := errReflectedArrayEncoder{}
+	assert.Error(t, objects[zapcore.ObjectMarshaler]{nil}.MarshalLogArray(enc))
+	assert.Error(t, stringers[fmt.Stringer]{nil}.MarshalLogArray(enc))
+}
+
 type stringerObject struct {
 	value string
 }

--- a/array_test.go
+++ b/array_test.go
@@ -118,6 +118,17 @@ func TestObjectsAndObjectValues(t *testing.T) {
 		want []any
 	}{
 		{
+			desc: "Objects/nil element",
+			give: Objects("", []zapcore.ObjectMarshaler{
+				&fakeObject{value: "foo"},
+				nil,
+			}),
+			want: []any{
+				map[string]any{"value": "foo"},
+				nil,
+			},
+		},
+		{
 			desc: "Objects/nil slice",
 			give: Objects[*emptyObject]("", nil),
 			want: []any{},
@@ -273,6 +284,17 @@ func TestStringers(t *testing.T) {
 		give Field
 		want []any
 	}{
+		{
+			desc: "Stringers with nil element",
+			give: Stringers("", []fmt.Stringer{
+				stringerObject{value: "foo"},
+				nil,
+			}),
+			want: []any{
+				"foo",
+				nil,
+			},
+		},
 		{
 			desc: "Stringers",
 			give: Stringers("", []stringerObject{

--- a/field.go
+++ b/field.go
@@ -406,8 +406,11 @@ func Object(key string, val zapcore.ObjectMarshaler) Field {
 
 // Inline constructs a Field that is similar to Object, but it
 // will add the elements of the provided ObjectMarshaler to the
-// current namespace.
+// current namespace. A nil ObjectMarshaler adds nothing.
 func Inline(val zapcore.ObjectMarshaler) Field {
+	if val == nil {
+		return Skip()
+	}
 	return zapcore.Field{
 		Type:      zapcore.InlineMarshalerType,
 		Interface: val,

--- a/field_test.go
+++ b/field_test.go
@@ -254,6 +254,8 @@ func TestFieldConstructors(t *testing.T) {
 		{"Any:ErrorNil", Any("k", nilErr), nilField("k")},
 		{"Namespace", Namespace("k"), Field{Key: "k", Type: zapcore.NamespaceType}},
 		{"Object:Nil", Object("k", nil), nilField("k")},
+		{"Array:Nil", Array("k", nil), nilField("k")},
+		{"Inline:Nil", Inline(nil), Skip()},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`zap.Object("k", nil)` logs `null`, but the neighbouring constructors panicked on the same input: `zap.Array("k", nil)` and `zap.Inline(nil)` fail the type assertion in `Field.AddTo`, and a nil element in the slice given to `zap.Objects` or `zap.Stringers` is dereferenced inside `MarshalLogArray`. A logging call took the process down.

This mirrors the `Object` handling: `Array` with a nil marshaler is a nil field, `Inline` with one is `Skip()`, and a nil element in `Objects` or `Stringers` is appended as nil. Nothing changes for non-nil inputs, and typed nil pointers still reach the user's own method as before.

Tests added for each case; on master they fail with a nil pointer dereference. `make test` (go test -race, all modules) passes.
